### PR TITLE
Allow compability with newer builds of IntelliJ 10. 

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -120,7 +120,7 @@
         ]]>
     </change-notes>
 
-    <idea-version since-build="99.000" until-build="100.000"/>
+    <idea-version since-build="99.000" />
 
     <category>Custom Languages</category>
 


### PR DESCRIPTION
Removed until-build attribute to allow recent builds, and future ones, to allow the plugin to run.
