### PR TITLE
Fix NPE on import statements

### DIFF
--- a/src/ro/redeul/google/go/lang/psi/resolve/references/ImportReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/ImportReference.java
@@ -31,6 +31,9 @@ public class ImportReference extends GoPsiReference<GoImportDeclaration, ImportR
     @Override
     public TextRange getRangeInElement() {
         GoLiteralString importPath = getElement().getImportPath();
+        if (importPath == null) {
+            return TextRange.EMPTY_RANGE;
+        }
 
         return new TextRange(
             importPath.getStartOffsetInParent(),


### PR DESCRIPTION
Hi,

This fixes the case when the package literal string cannot be resolved/found in import statement due to invalid syntax.

E.g:

import abc // yes, the syntax is invalid because there are no "" around package and this result in an NPE

This commit is also fixing Issue #91 - Can't Add Import to New Package
