### PR TITLE
Fix contributor link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ on GitHub: <http://github.com/mtoader/google-go-lang-idea-plugin/issues>
 ## Contributing
 
 If you want to contribute to this effort you should read the following page:
-[how to contribute](contributing.md).
+[how to contribute](https://github.com/mtoader/google-go-lang-idea-plugin/blob/master/contributing.md).


### PR DESCRIPTION
Hey @mtoader, I happened to notice that the "how to contribute" link was broken on README.md, which makes for a great excuse to send a pull and say thanks for running this project.

I really enjoyed your talk in the Jetbrains plugin developers webinar a few weeks ago, and I used your source as inspiration for both my new formatter and for my own contributors section.

So yeah: thanks!
