### PR TITLE
Windows compatibility fixes

### DIFF
--- a/src/ro/redeul/google/go/runner/GoAppEngineRunningState.java
+++ b/src/ro/redeul/google/go/runner/GoAppEngineRunningState.java
@@ -45,7 +45,12 @@ public class GoAppEngineRunningState extends CommandLineState {
         if (scriptArguments != null && scriptArguments.trim().length() > 0) {
             commandLine.addParameter(scriptArguments);
         }
-        commandLine.setExePath(sdkDirectory + "/dev_appserver.py");
+        if (workDir.contains("\\")) { // we are on Windows...
+            commandLine.setExePath("python.exe");
+            commandLine.addParameter(sdkDirectory + "/dev_appserver.py");
+        } else {
+            commandLine.setExePath(sdkDirectory + "/dev_appserver.py");
+        }
         commandLine.addParameter(".");
         commandLine.setWorkDirectory(workDir);
 

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -63,7 +63,7 @@ public class GoSdkUtil {
         Pattern.compile("^api_versions: \\[([^\\]]+)\\]$", Pattern.MULTILINE);
 
     private static Pattern RE_OS_MATCHER =
-        Pattern.compile("^(?:set )?GOOS=\"(darwin|freebsd|linux|windows)\"$",
+        Pattern.compile("^(?:set )?GOOS=\"?(darwin|freebsd|linux|windows)\"?$",
                         Pattern.MULTILINE);
 
     private static Pattern RE_ARCH_MATCHER =
@@ -94,7 +94,11 @@ public class GoSdkUtil {
 
         String goCommand = path + "/bin/go";
         if ( ! checkFileExists(goCommand) ) {
-            goCommand = "/usr/bin/go";
+            // Perhaps we're on Windows?
+            goCommand = path + "/bin/go.exe";
+            if ( ! checkFileExists(goCommand) ) {
+                goCommand = "/usr/bin/go";
+            }
         }
 
         GoSdkData data = findHostOsAndArch(path, goCommand, new GoSdkData());
@@ -247,8 +251,8 @@ public class GoSdkUtil {
 
         try {
             String fileContent =
-                VfsUtil.loadText(VfsUtil.findFileByURL(new URL(
-                    VfsUtil.pathToUrl(format("%s/VERSION", path)))));
+                VfsUtil.loadText(VfsUtil.findFileByIoFile(
+                        new File(format("%s/VERSION", path)), true));
 
             Matcher matcher = RE_APP_ENGINE_VERSION_MATCHER.matcher(
                 fileContent);


### PR DESCRIPTION
GoAppEngineRunningState.java:

It is trying to start dev_appserver.py Python script
through CreateProcess() Windows API call, which will not work. We must set
ExePath to python.exe, and set the script file name as the 1st argument.

GoSdkUtil.java:

RE_OS_MATCHER was defined incorrectly and never worked - the
program thus thought that it is always on Linux. Question marks were needed at
the start and end of RegEx expression.

Around line 97, goCommand was set to path + "/bin/go" and then a file exist
check was done. Well, on Windows, you must check for   + "/bin/go.exe" instead...

At line 249 we were getting an exception because of using VfsUtil.findFileByURL(),
and the whole URL construction and conversion back to path is screwed up for
file objects on Windows - for a path like D:/somedir/someother, the URL makes
D the "host" - which is wrong, and sets path to "/somedir/someother", then good
luck finding it on the file system! Fixed by using VfsUtil.findFileByIoFile()
instead.
