### PR TITLE
Make it work with latest IDEA JDK

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -288,7 +288,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IU-123.100" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IU-129.354" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ResourceManagerContainer">

--- a/test/ro/redeul/google/go/GoTestCase.java
+++ b/test/ro/redeul/google/go/GoTestCase.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.SdkModificator;
-import com.intellij.openapi.projectRoots.impl.JavaSdkImpl;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.util.text.StringUtil;
@@ -120,17 +119,6 @@ public abstract class GoTestCase<FixtureType extends IdeaProjectTestFixture> ext
     protected DefaultLightProjectDescriptor getProjectDescriptor() {
 
         return new DefaultLightProjectDescriptor() {
-
-            Sdk sdk;
-
-            @Override
-            public Sdk getSdk() {
-                if ( sdk == null ) {
-                    sdk = JavaSdkImpl.getMockJdk17("java 1.5");
-                }
-
-                return sdk;
-            }
 
             @Override            
             public void configureModule(Module module, ModifiableRootModel model, ContentEntry contentEntry) {


### PR DESCRIPTION
The latest IDEA JDK has removed the "JavaSdkImpl.getMockJdk17" meothd,
and added the same method in "IdeaTestUtil".
