### PR TITLE
Fixed all current formatter tests

### DIFF
--- a/src/ro/redeul/google/go/formatter/GoFormattingModelBuilder.java
+++ b/src/ro/redeul/google/go/formatter/GoFormattingModelBuilder.java
@@ -34,6 +34,13 @@ public class GoFormattingModelBuilder implements FormattingModelBuilder {
         CommonCodeStyleSettings goSettings =
             settings.getCommonSettings(GoLanguage.INSTANCE);
 
+        // Here we deny what user believes about space (or tab)
+        // For more detail see: http://golang.org/doc/effective_go.html#formatting
+        if (goSettings.getIndentOptions() != null) {
+            goSettings.getIndentOptions().USE_TAB_CHARACTER = true;
+            goSettings.getIndentOptions().SMART_TABS = false;
+        }
+
         Block block = GoBlockGenerator.generateBlock(fileElement, goSettings);
 
         return FormattingModelProvider

--- a/src/ro/redeul/google/go/formatter/blocks/GoBinaryExpressionBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoBinaryExpressionBlock.java
@@ -7,6 +7,7 @@ import com.intellij.formatting.Wrap;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import org.jetbrains.annotations.Nullable;
 import ro.redeul.google.go.lang.psi.expressions.binary.GoBinaryExpression;
@@ -25,11 +26,28 @@ class GoBinaryExpressionBlock extends GoBlock {
         super(node, alignment, Indent.getNormalIndent(), wrap, settings);
 
         GoBinaryExpression psi = node.getPsi(GoBinaryExpression.class);
-        if (psi != null && (EMPTY_SPACE_TOKENS.contains(psi.getOperator()) || psi.getOperator() == oMUL)) {
-            spacing = EMPTY_SPACING_KEEP_LINE_BREAKS;
-        } else {
-            spacing = BASIC_SPACING_KEEP_LINE_BREAKS;
+        if (psi != null) {
+            IElementType psiOperator = psi.getOperator();
+
+            if (EMPTY_SPACE_TOKENS.contains(psiOperator)) {
+                spacing = EMPTY_SPACING_KEEP_LINE_BREAKS;
+                return;
+            }
+            IElementType parentElementType = node.getTreeParent().getElementType();
+            if (EXPRESSION_SETS.contains(parentElementType)
+                    && inTheSameLine(psi.getLeftOperand().getNode(), psi.getRightOperand().getNode())
+            && (
+                    psiOperator == oMUL ||
+                    psiOperator == oQUOTIENT ||
+                    psiOperator == oPLUS ||
+                    psiOperator == oMINUS
+            )) {
+                spacing = EMPTY_SPACING_KEEP_LINE_BREAKS;
+                return;
+            }
         }
+
+        spacing = BASIC_SPACING_KEEP_LINE_BREAKS;
     }
 
     @Override

--- a/src/ro/redeul/google/go/formatter/blocks/GoBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoBlock.java
@@ -254,6 +254,11 @@ class GoBlock implements Block, GoElementTypes {
 
             return BASIC_SPACING;
         }
+
+        if (COMMENTS.contains(child1Type) && child2Type == FUNCTION_DECLARATION) {
+            return BASIC_SPACING;
+        }
+
         return null;
     }
 

--- a/src/ro/redeul/google/go/formatter/blocks/GoCallOrConvExpressionBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoCallOrConvExpressionBlock.java
@@ -22,7 +22,7 @@ class GoCallOrConvExpressionBlock extends GoBlock {
     @Override
     protected Indent getChildIndent(@Nullable PsiElement child) {
         if (child instanceof GoExpressionList || child instanceof GoLiteralIdentifier) {
-            return CONTINUATION_WITHOUT_FIRST;
+            return NORMAL_INDENT_TO_CHILDREN;
         }
         return super.getChildIndent(child);
     }

--- a/testdata/formatter/functionCall.go
+++ b/testdata/formatter/functionCall.go
@@ -22,7 +22,7 @@ fmt.Println(1,
 fmt.Println(
 1,
 2,
-(1+     // space before comment should be removed
+(1+     // all space but one before comment should be removed
 2*-  3),
 3,
 )
@@ -70,7 +70,7 @@ func main() {
 	fmt.Println(
 		1,
 		2,
-		(1 + // space before comment should be removed
+		(1 + // all space but one before comment should be removed
 			2*-3),
 		3,
 	)

--- a/testdata/formatter/interfaceType.go
+++ b/testdata/formatter/interfaceType.go
@@ -3,7 +3,7 @@ package main
 type T interface {
 Method1() T
 Method2()
-/*def*/Method3();
+/*def*/Method3()
 }
 -----
 package main

--- a/testdata/formatter/topLevel.go
+++ b/testdata/formatter/topLevel.go
@@ -43,6 +43,11 @@ return 3
 // doc
 package main
 
+import (
+	"fmt"
+	"io"
+)
+
 const CA = 5
 const (
 	// CB


### PR DESCRIPTION
This PR fixes the reminder of the failing tests currently in the plugin.
Asside from the tests, I've added an override for the tab settings, I need to check with JetBrains if this can be done more cleanly.
Also, I've improved tests as GO will remove the unused imports but it's not relevant to the current tests scenario.
Next will be adding more tests as the current state of the formatter still doesn't match what `go fmt` from go 1.2rc3 outputs.
