### PR TITLE
Prepend Project Path to GOPATH, catch TestConfiguration Exception.

### DIFF
--- a/src/ro/redeul/google/go/compilation/GoInstallCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoInstallCompiler.java
@@ -13,6 +13,7 @@ import com.intellij.util.Chunk;
 import org.jetbrains.annotations.NotNull;
 import ro.redeul.google.go.GoFileType;
 import ro.redeul.google.go.config.sdk.GoSdkData;
+import ro.redeul.google.go.sdk.GoSdkUtil;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,7 +56,8 @@ public class GoInstallCompiler implements TranslatingCompiler {
 
         HashMap<String, String> envparams = new HashMap<>();
         envparams.put("GOROOT", projectSdk.getHomePath());
-        envparams.put("GOPATH", project.getBasePath());
+
+        envparams.put("GOPATH", GoSdkUtil.prependToGoPath(project.getBasePath()));
 
         command.setEnvParams(envparams);
 

--- a/src/ro/redeul/google/go/runner/GoTestConfiguration.java
+++ b/src/ro/redeul/google/go/runner/GoTestConfiguration.java
@@ -76,8 +76,11 @@ public class GoTestConfiguration extends ModuleBasedConfiguration<GoApplicationM
 
     public void readExternal(final Element element) throws InvalidDataException {
         PathMacroManager.getInstance(getProject()).expandPaths(element);
-        XmlSerializer.deserializeInto(this, element);
+        super.readExternal(element);
         readModule(element);
+        try{
+            XmlSerializer.deserializeInto(this, element);
+        }catch (Exception e) {}
     }
 
     public void writeExternal(final Element element) throws WriteExternalException {

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -565,6 +565,6 @@ public class GoSdkUtil {
 
     public static String prependToGoPath(String prependedPath) {
         return format("%s%s%s", prependedPath, File.pathSeparator,
-                      System.getProperty("GOPATH", ""));
+                      System.getenv("GOPATH"));
     }
 }


### PR DESCRIPTION
The TestConfiguration readExternal throw serialization Exception, and I can't address the real issue, but just catch the exception seems works fine. 

I noticed that the test config xml element in `workspace.xml` is different. there has an `<option name="module"><Module/></option>` element in it, and other runner configuration element do not have it.

And for Go Install Compiler, I changed to prepend project path to GOPATH, so the packages in original GOPATH can be imported.

And the GoSdkUtil prependPath method should call System.getenv to get GOPATH.
