### PR TITLE
Add missing properties

### DIFF
--- a/src/ro/redeul/google/go/GoBundle.properties
+++ b/src/ro/redeul/google/go/GoBundle.properties
@@ -28,6 +28,8 @@ color.go.keyword=Keywords
 color.go.number=Numbers
 color.go.const=Constants
 color.go.string=Strings
+color.go.operators=Operators (+, =, ., etc)
+color.go.brackets=Brackets
 color.go.type.name=Type name
 color.go.identifier=Identifier
 color.go.variable=Variable
@@ -57,6 +59,7 @@ new.go.file=Create Go file
 new.go.file.description=This will create a new Go file in the current project
 warning.unresolved.symbol=Unresolved symbol: ''{0}''
 error.invalid.import=Invalid package import path
+error.primitive.name.is.readonly=Can't rename primitive type ''{0}''
 error.method.name.expected=Method name expected
 error.identifier.expected=Identifier expected
 error.semicolon.expected=Semicolon expected

--- a/src/ro/redeul/google/go/editor/highlighting/GoColorsAndFontsPage.java
+++ b/src/ro/redeul/google/go/editor/highlighting/GoColorsAndFontsPage.java
@@ -87,7 +87,7 @@ public class GoColorsAndFontsPage implements ColorSettingsPage {
                 "\n" +
                 "type <typeName>T</typeName> <typeName>int</typeName>\n" +
                 "type (\n" +
-                "   <typeName>T1</typeName> []<typeName>T</typeName>\n" +
+                "   <typeName>T1</typeName> <brackets>[</brackets><brackets>]</brackets><typeName>T</typeName>\n" +
                 ")\n" +
                 "const <const>CONST_VALUE</const> = 10\n\n" +
                 "var <globalVariable>globalValue</globalVariable> = 5\n" +
@@ -115,6 +115,7 @@ public class GoColorsAndFontsPage implements ColorSettingsPage {
         map.put("typeName", TYPE_NAME);
         map.put("const", CONST);
         map.put("error", CodeInsightColors.ERRORS_ATTRIBUTES);
+        map.put("brackets", GoSyntaxHighlighter.BRACKET);
 
         return map;
 

--- a/src/ro/redeul/google/go/intentions/GoIntentionsBundle.properties
+++ b/src/ro/redeul/google/go/intentions/GoIntentionsBundle.properties
@@ -1,9 +1,12 @@
 intention.category.go=Google Go
+intention.category.control.flow=Control Flow
+intention.category.conversions=Conversions
+intention.category.parentheses=Parentheses
+intention.category.statements=Statements
 intention.category.go/intention.category.control.flow=Control Flow
 intention.category.go/intention.category.conversions=Conversions
 intention.category.go/intention.category.statements=Statements
 intention.category.go/intention.category.parentheses=Parentheses
-intention.category.statements=Statements
 
 split.if.intention.name=Split into 2 if's
 split.if.intention.family.name=Split into 2 if's


### PR DESCRIPTION
This adds back the removed properties from a previous PR. It fixes a runtime exception caused by missing 'color.go.brackets' issue as well as another one related to 'workflow.intentions'.
