### PR TITLE
Revert back to Java6 support for the plugin

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -31,7 +31,7 @@
         <processorPath useClasspath="true" />
       </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel target="1.7" />
+    <bytecodeTargetLevel target="1.6" />
   </component>
   <component name="EclipseCompilerSettings">
     <option name="GENERATE_NO_WARNINGS" value="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -294,7 +294,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IU-132.947" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IU-132.947" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ResourceManagerContainer">

--- a/src/com/redeul/google/go/spellchecker/tokenizer/GoIdentifierTokenizerStrategy.java
+++ b/src/com/redeul/google/go/spellchecker/tokenizer/GoIdentifierTokenizerStrategy.java
@@ -40,7 +40,7 @@ public class GoIdentifierTokenizerStrategy extends SpellcheckingStrategy {
         }
 
       private List<TextRange> splitByDot(String text, TextRange range) {
-          List<TextRange> result = new ArrayList<>();
+          List<TextRange> result = new ArrayList<TextRange>();
           int i = range.getStartOffset();
           int s = i;
           while (i < range.getEndOffset())  {

--- a/src/ro/redeul/google/go/GoBundle.java
+++ b/src/ro/redeul/google/go/GoBundle.java
@@ -26,7 +26,7 @@ public class GoBundle {
 
         if (bundle == null) {
             bundle = ResourceBundle.getBundle(BUNDLE);
-            ourBundle = new SoftReference<>(bundle);
+            ourBundle = new SoftReference<ResourceBundle>(bundle);
         }
         return bundle;
     }

--- a/src/ro/redeul/google/go/actions/NewGoFileAction.java
+++ b/src/ro/redeul/google/go/actions/NewGoFileAction.java
@@ -120,7 +120,7 @@ public class NewGoFileAction extends CreateTemplateInPackageAction<PsiElement>
 
         PsiFile childs[] = directory.getFiles();
 
-        Set<String> packages = new HashSet<>();
+        Set<String> packages = new HashSet<String>();
 
         for (PsiFile child : childs) {
             if (child instanceof GoFile) {

--- a/src/ro/redeul/google/go/actions/NewGoLibraryAction.java
+++ b/src/ro/redeul/google/go/actions/NewGoLibraryAction.java
@@ -108,7 +108,7 @@ public class NewGoLibraryAction extends CreateTemplateInPackageAction<PsiElement
 
         PsiFile childs[] = directory.getFiles();
 
-        Set<String> packages = new HashSet<>();
+        Set<String> packages = new HashSet<String>();
 
         for (PsiFile child : childs) {
             if (child instanceof GoFile) {

--- a/src/ro/redeul/google/go/compilation/GoCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoCompiler.java
@@ -65,7 +65,7 @@ public class GoCompiler implements TranslatingCompiler {
 
         final VirtualFile files[] = scope.getFiles(GoFileType.INSTANCE, true);
 
-        final Set<Module> affectedModules = new HashSet<>();
+        final Set<Module> affectedModules = new HashSet<Module>();
 
         ApplicationManager.getApplication().runReadAction(new Runnable() {
             public void run() {
@@ -123,7 +123,7 @@ public class GoCompiler implements TranslatingCompiler {
 
     private VirtualFile[] findAllFiles(Chunk<Module> moduleChunk) {
 
-        final CommonProcessors.CollectUniquesProcessor<VirtualFile> collector = new CommonProcessors.CollectUniquesProcessor<>();
+        final CommonProcessors.CollectUniquesProcessor<VirtualFile> collector = new CommonProcessors.CollectUniquesProcessor<VirtualFile>();
 
         for (Module module : moduleChunk.getNodes()) {
 
@@ -134,7 +134,7 @@ public class GoCompiler implements TranslatingCompiler {
                 public void run() {
                     for (final VirtualFile sourceRoot : sourceRoots) {
                         VfsUtil.processFilesRecursively(sourceRoot,
-                                                        new FilteringProcessor<>(
+                                                        new FilteringProcessor<VirtualFile>(
                                                             new Condition<VirtualFile>() {
                                                                 @Override
                                                                 public boolean value(VirtualFile virtualFile) {
@@ -199,7 +199,7 @@ public class GoCompiler implements TranslatingCompiler {
         }
 
         // sorting reverse by relative paths.
-        List<String> relativePaths = new ArrayList<>(
+        List<String> relativePaths = new ArrayList<String>(
             filesToCompile.keySet());
         Collections.sort(relativePaths, new Comparator<String>() {
             public int compare(String o1, String o2) {
@@ -212,7 +212,7 @@ public class GoCompiler implements TranslatingCompiler {
         }
 
         // packageName | applicationName -> Package | Application, dependencies, files
-        Map<String, Trinity<TargetType, Set<String>, List<VirtualFile>>> targets = new HashMap<>();
+        Map<String, Trinity<TargetType, Set<String>, List<VirtualFile>>> targets = new HashMap<String, Trinity<TargetType, Set<String>, List<VirtualFile>>>();
 
         for (String relativePath : relativePaths) {
             List<Pair<VirtualFile, GoFileMetadata>> list = filesToCompile.get(
@@ -239,7 +239,7 @@ public class GoCompiler implements TranslatingCompiler {
             }
 
             String currentPackage = "";
-            List<Pair<VirtualFile, GoFileMetadata>> targetFiles = new ArrayList<>();
+            List<Pair<VirtualFile, GoFileMetadata>> targetFiles = new ArrayList<Pair<VirtualFile, GoFileMetadata>>();
             for (Pair<VirtualFile, GoFileMetadata> fileMetadata : list) {
                 // file, declaredPackage, imports
 
@@ -251,7 +251,7 @@ public class GoCompiler implements TranslatingCompiler {
                     targetFiles.clear();
                 }
 
-                targetFiles.add(new Pair<>(
+                targetFiles.add(new Pair<VirtualFile, GoFileMetadata>(
                     fileMetadata.getFirst(), fileMetadata.getSecond()));
             }
 
@@ -280,7 +280,7 @@ public class GoCompiler implements TranslatingCompiler {
                               Map<String, Trinity<TargetType, Set<String>, List<VirtualFile>>> targets,
                               String baseOutputPath, Sdk sdk) {
         // collect only library targets
-        Set<String> allLibraries = new HashSet<>();
+        Set<String> allLibraries = new HashSet<String>();
         for (Map.Entry<String, Trinity<TargetType, Set<String>, List<VirtualFile>>> targetEntry : targets
             .entrySet()) {
             if (targetEntry.getValue().getFirst() == TargetType.Library) {
@@ -289,12 +289,12 @@ public class GoCompiler implements TranslatingCompiler {
         }
 
         // extract the local dependency graph and also initialize the starting set for the topological sort
-        Set<String> startSet = new HashSet<>();
-        Map<String, Set<String>> mutableDependenciesGraph = new HashMap<>();
+        Set<String> startSet = new HashSet<String>();
+        Map<String, Set<String>> mutableDependenciesGraph = new HashMap<String, Set<String>>();
 
         for (Map.Entry<String, Trinity<TargetType, Set<String>, List<VirtualFile>>> targetEntry : targets
             .entrySet()) {
-            Set<String> properDependencies = new HashSet<>();
+            Set<String> properDependencies = new HashSet<String>();
 
             for (String dependency : targetEntry.getValue().getSecond()) {
                 if (allLibraries.contains(dependency)) {
@@ -311,7 +311,7 @@ public class GoCompiler implements TranslatingCompiler {
         }
 
         // do a topological sorting
-        List<String> buildOrder = new ArrayList<>();
+        List<String> buildOrder = new ArrayList<String>();
         while (startSet.size() > 0) {
 
             for (String node : startSet) {
@@ -415,7 +415,7 @@ public class GoCompiler implements TranslatingCompiler {
             return;
         }
 
-        Collection<OutputItem> outputItems = new ArrayList<>();
+        Collection<OutputItem> outputItems = new ArrayList<OutputItem>();
         for (VirtualFile file : targetDescription.getThird()) {
             outputItems.add(new MyOutputItem(outputBinary, file));
         }
@@ -454,7 +454,7 @@ public class GoCompiler implements TranslatingCompiler {
             return;
         }
 
-        Collection<OutputItem> items = new ArrayList<>();
+        Collection<OutputItem> items = new ArrayList<OutputItem>();
         items.add(new MyOutputItem(outputApplication, intermediateFile));
         sink.add(targetPath.getAbsolutePath(), items, VirtualFile.EMPTY_ARRAY);
     }
@@ -514,7 +514,7 @@ public class GoCompiler implements TranslatingCompiler {
             return;
         }
 
-        Collection<OutputItem> outputItems = new ArrayList<>();
+        Collection<OutputItem> outputItems = new ArrayList<OutputItem>();
         for (VirtualFile file : targetDescription.getThird()) {
             outputItems.add(new MyOutputItem(outputBinary, file));
         }
@@ -548,7 +548,7 @@ public class GoCompiler implements TranslatingCompiler {
             return;
         }
 
-        Collection<OutputItem> items = new ArrayList<>();
+        Collection<OutputItem> items = new ArrayList<OutputItem>();
         items.add(new MyOutputItem(libraryFile.getPath(), intermediateFile));
         sink.add(outputFolder.getAbsolutePath(), items,
                  VirtualFile.EMPTY_ARRAY);
@@ -579,8 +579,8 @@ public class GoCompiler implements TranslatingCompiler {
             targetName = makefileTarget;
         }
 
-        List<VirtualFile> targetFiles = new ArrayList<>();
-        Set<String> imports = new HashSet<>();
+        List<VirtualFile> targetFiles = new ArrayList<VirtualFile>();
+        Set<String> imports = new HashSet<String>();
 
         for (Pair<VirtualFile, GoFileMetadata> file : files) {
             targetFiles.add(file.getFirst());
@@ -598,7 +598,7 @@ public class GoCompiler implements TranslatingCompiler {
         }
 
         targets.put(targetName,
-                    new Trinity<>(
+                    new Trinity<TargetType, Set<String>, List<VirtualFile>>(
                         targetType, imports, targetFiles));
     }
 
@@ -617,7 +617,7 @@ public class GoCompiler implements TranslatingCompiler {
 
         // relative path to source
         final Map<VirtualFile, Map<String, List<Pair<VirtualFile, GoFileMetadata>>>>
-            sourceRootsMap = new HashMap<>();
+            sourceRootsMap = new HashMap<VirtualFile, Map<String, List<Pair<VirtualFile, GoFileMetadata>>>>();
 
         // we need to find and sort the files as packages in order to compile them properly
         for (final VirtualFile virtualFile : files) {
@@ -636,7 +636,7 @@ public class GoCompiler implements TranslatingCompiler {
             relativePathsMap = sourceRootsMap.get(sourceRoot);
 
             if (relativePathsMap == null) {
-                relativePathsMap = new HashMap<>();
+                relativePathsMap = new HashMap<String, List<Pair<VirtualFile, GoFileMetadata>>>();
                 sourceRootsMap.put(sourceRoot, relativePathsMap);
             }
 

--- a/src/ro/redeul/google/go/compilation/GoCompilerOutputStreamParser.java
+++ b/src/ro/redeul/google/go/compilation/GoCompilerOutputStreamParser.java
@@ -25,7 +25,7 @@ class GoCompilerOutputStreamParser implements ProcessUtil.StreamParser<List<Comp
 
     public List<CompilerMessage> parseStream(String data) {
 
-        List<CompilerMessage> messages = new ArrayList<>();
+        List<CompilerMessage> messages = new ArrayList<CompilerMessage>();
 
         Matcher matcher = pattern.matcher(data);
 

--- a/src/ro/redeul/google/go/compilation/GoFileMetadata.java
+++ b/src/ro/redeul/google/go/compilation/GoFileMetadata.java
@@ -25,7 +25,7 @@ class GoFileMetadata {
         packageName = file.getPackage().getPackageName();
         main = file.getMainFunction() != null;
 
-        imports = new ArrayList<>();
+        imports = new ArrayList<String>();
 
         GoImportDeclarations[] importDeclarations = file.getImportDeclarations();
 

--- a/src/ro/redeul/google/go/compilation/GoInstallCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoInstallCompiler.java
@@ -35,7 +35,7 @@ public class GoInstallCompiler implements TranslatingCompiler {
     public void compile(CompileContext compileContext, Chunk<Module> moduleChunk, VirtualFile[] virtualFiles, OutputSink outputSink) {
 
         String basePath = compileContext.getProject().getBasePath();
-        HashSet<String> packages = new HashSet<>();
+        HashSet<String> packages = new HashSet<String>();
 
         for (VirtualFile vf : virtualFiles) {
             String fullPath = vf.getParent().getPath();
@@ -54,7 +54,7 @@ public class GoInstallCompiler implements TranslatingCompiler {
 
         command.setWorkDirectory(basePath);
 
-        HashMap<String, String> envparams = new HashMap<>();
+        HashMap<String, String> envparams = new HashMap<String, String>();
         envparams.put("GOROOT", projectSdk.getHomePath());
 
         envparams.put("GOPATH", GoSdkUtil.prependToGoPath(project.getBasePath()));

--- a/src/ro/redeul/google/go/compilation/GoMakefileCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoMakefileCompiler.java
@@ -146,7 +146,7 @@ public class GoMakefileCompiler implements TranslatingCompiler {
 
         public List<CompilerMessage> parseStream(String data) {
 
-            List<CompilerMessage> messages = new ArrayList<>();
+            List<CompilerMessage> messages = new ArrayList<CompilerMessage>();
 
             Matcher matcher = pattern.matcher(data);
 

--- a/src/ro/redeul/google/go/components/GoCompilerLoader.java
+++ b/src/ro/redeul/google/go/components/GoCompilerLoader.java
@@ -65,13 +65,13 @@ public class GoCompilerLoader extends AbstractProjectComponent {
                 compilerManager.addTranslatingCompiler(
                     new GoMakefileCompiler(myProject),
                     new HashSet<FileType>(Arrays.asList(GoFileType.INSTANCE)),
-                    new HashSet<>(Arrays.asList(FileType.EMPTY_ARRAY)));
+                    new HashSet<FileType>(Arrays.asList(FileType.EMPTY_ARRAY)));
                 break;
             case Install:
                 compilerManager.addTranslatingCompiler(
                         new GoInstallCompiler(myProject),
                         new HashSet<FileType>(Arrays.asList(GoFileType.INSTANCE)),
-                        new HashSet<>(Arrays.asList(FileType.EMPTY_ARRAY)));
+                        new HashSet<FileType>(Arrays.asList(FileType.EMPTY_ARRAY)));
         }
     }
 

--- a/src/ro/redeul/google/go/components/GoSdkParsingHelper.java
+++ b/src/ro/redeul/google/go/components/GoSdkParsingHelper.java
@@ -36,7 +36,7 @@ import java.util.*;
  */
 public class GoSdkParsingHelper implements ApplicationComponent {
 
-    private final Map<Sdk, Map<String, String>> sdkPackageMappings = new HashMap<>();
+    private final Map<Sdk, Map<String, String>> sdkPackageMappings = new HashMap<Sdk, Map<String, String>>();
 
     public static GoSdkParsingHelper getInstance() {
         return ApplicationManager.getApplication().getComponent(GoSdkParsingHelper.class);
@@ -74,7 +74,7 @@ public class GoSdkParsingHelper implements ApplicationComponent {
             ProjectRootManager.getInstance(project).getFileIndex();
 
         ProjectJdkTable jdkTable = ProjectJdkTable.getInstance();
-        List<Sdk> sdkList = new ArrayList<>();
+        List<Sdk> sdkList = new ArrayList<Sdk>();
 
 
         sdkList.addAll(GoSdkUtil.getSdkOfType(GoSdkType.getInstance(), jdkTable));
@@ -138,7 +138,7 @@ public class GoSdkParsingHelper implements ApplicationComponent {
     }
 
     private Map<String, String> findPackageMappings(Sdk ownerSdk) {
-        Map<String, String> result = new HashMap<>();
+        Map<String, String> result = new HashMap<String, String>();
 
         if (ownerSdk.getSdkType() != GoSdkType.getInstance() && ownerSdk.getSdkType() != GoAppEngineSdkType.getInstance())
             return result;
@@ -175,7 +175,7 @@ public class GoSdkParsingHelper implements ApplicationComponent {
             return result;
         }
 
-        CommonProcessors.CollectUniquesProcessor<String> libraryNames = new CommonProcessors.CollectUniquesProcessor<>();
+        CommonProcessors.CollectUniquesProcessor<String> libraryNames = new CommonProcessors.CollectUniquesProcessor<String>();
 
         final VirtualFile librariesRoot = packageRoot.findFileByRelativePath(activeTarget);
 
@@ -184,14 +184,14 @@ public class GoSdkParsingHelper implements ApplicationComponent {
         }
 
         VfsUtil.processFilesRecursively(librariesRoot,
-                new FilteringProcessor<>(
+                new FilteringProcessor<VirtualFile>(
                         new Condition<VirtualFile>() {
                             @Override
                             public boolean value(VirtualFile virtualFile) {
                                 return !virtualFile.isDirectory() && virtualFile.getName().matches(".*\\.a");
                             }
                         },
-                        new AdapterProcessor<>(
+                        new AdapterProcessor<VirtualFile, String>(
                                 libraryNames,
                                 new Function<VirtualFile, String>() {
                                     @Override
@@ -203,17 +203,17 @@ public class GoSdkParsingHelper implements ApplicationComponent {
                         ))
         );
 
-        Set<String> librariesSet = new HashSet<>(libraryNames.getResults());
+        Set<String> librariesSet = new HashSet<String>(libraryNames.getResults());
 
         // find makefiles
-        CommonProcessors.CollectUniquesProcessor<VirtualFile> makefiles = new CommonProcessors.CollectUniquesProcessor<>();
+        CommonProcessors.CollectUniquesProcessor<VirtualFile> makefiles = new CommonProcessors.CollectUniquesProcessor<VirtualFile>();
         final VirtualFile sourcesRoot = home.findFileByRelativePath(ownerSdk.getSdkType() == GoSdkType.getInstance() ? "src/pkg" : "goroot/src/pkg");
         if (sourcesRoot == null) {
             return result;
         }
 
         VfsUtil.processFilesRecursively(sourcesRoot,
-                new FilteringProcessor<>(
+                new FilteringProcessor<VirtualFile>(
                         new Condition<VirtualFile>() {
                             @Override
                             public boolean value(VirtualFile virtualFile) {

--- a/src/ro/redeul/google/go/components/ProjectSdkValidator.java
+++ b/src/ro/redeul/google/go/components/ProjectSdkValidator.java
@@ -26,7 +26,7 @@ public class ProjectSdkValidator extends AbstractProjectComponent {
     @Override
     public void initComponent() {
         ProjectJdkTable jdkTable = ProjectJdkTable.getInstance();
-        List<Sdk> sdkList = new ArrayList<>();
+        List<Sdk> sdkList = new ArrayList<Sdk>();
 
         sdkList.addAll(GoSdkUtil.getSdkOfType(GoSdkType.getInstance(), jdkTable));
 

--- a/src/ro/redeul/google/go/config/facet/GoFacetType.java
+++ b/src/ro/redeul/google/go/config/facet/GoFacetType.java
@@ -13,7 +13,7 @@ import javax.swing.*;
 
 public class GoFacetType extends FacetType<GoFacet, GoFacetConfiguration> {
 
-    public static final FacetTypeId<GoFacet> GO_FACET_TYPE_ID = new FacetTypeId<>("Google Go Facet");
+    public static final FacetTypeId<GoFacet> GO_FACET_TYPE_ID = new FacetTypeId<GoFacet>("Google Go Facet");
 
     public GoFacetType() {
         super(GO_FACET_TYPE_ID, "id", "google go");

--- a/src/ro/redeul/google/go/editor/highlighting/GoColorsAndFontsPage.java
+++ b/src/ro/redeul/google/go/editor/highlighting/GoColorsAndFontsPage.java
@@ -104,7 +104,7 @@ public class GoColorsAndFontsPage implements ColorSettingsPage {
     }
 
     public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
-        final Map<String, TextAttributesKey> map = new HashMap<>();
+        final Map<String, TextAttributesKey> map = new HashMap<String, TextAttributesKey>();
 
         map.put("unused.parameter", CodeInsightColors.NOT_USED_ELEMENT_ATTRIBUTES);
         map.put("unused.import", CodeInsightColors.NOT_USED_ELEMENT_ATTRIBUTES);

--- a/src/ro/redeul/google/go/findUsages/GoVariableUsageStatVisitor.java
+++ b/src/ro/redeul/google/go/findUsages/GoVariableUsageStatVisitor.java
@@ -61,7 +61,7 @@ public class GoVariableUsageStatVisitor extends GoRecursiveElementVisitor {
 
     @Override
     public void visitFile(GoFile file) {
-        HashMap<String, VariableUsage> global = new HashMap<>();
+        HashMap<String, VariableUsage> global = new HashMap<String, VariableUsage>();
         ctx = new Context(result, global);
         getGlobalVariables(file, global);
 
@@ -164,7 +164,7 @@ public class GoVariableUsageStatVisitor extends GoRecursiveElementVisitor {
         }
 
         int nonBlankIdCount = 0;
-        List<GoLiteralIdentifier> redeclaredIds = new ArrayList<>();
+        List<GoLiteralIdentifier> redeclaredIds = new ArrayList<GoLiteralIdentifier>();
         for (GoLiteralIdentifier id : identifiers) {
             if (!id.isBlank()) {
                 nonBlankIdCount++;
@@ -349,7 +349,7 @@ public class GoVariableUsageStatVisitor extends GoRecursiveElementVisitor {
 
     private static class Context {
         public final InspectionResult result;
-        public final List<Map<String, VariableUsage>> variables = new ArrayList<>();
+        public final List<Map<String, VariableUsage>> variables = new ArrayList<Map<String, VariableUsage>>();
 
         Context(InspectionResult result, Map<String, VariableUsage> global) {
             this.result = result;
@@ -357,7 +357,7 @@ public class GoVariableUsageStatVisitor extends GoRecursiveElementVisitor {
         }
 
         public Map<String, VariableUsage> addNewScopeLevel() {
-            Map<String, VariableUsage> variables = new HashMap<>();
+            Map<String, VariableUsage> variables = new HashMap<String, VariableUsage>();
             this.variables.add(variables);
             return variables;
         }

--- a/src/ro/redeul/google/go/findUsages/GoVariableUsageStatVisitor2.java
+++ b/src/ro/redeul/google/go/findUsages/GoVariableUsageStatVisitor2.java
@@ -114,8 +114,8 @@ public class GoVariableUsageStatVisitor2 extends GoRecursiveElementVisitor {
         }
     }
 
-    private final Set<GoPsiElement> declarations = new HashSet<>();
-    private final Set<GoPsiElement> usages = new HashSet<>();
+    private final Set<GoPsiElement> declarations = new HashSet<GoPsiElement>();
+    private final Set<GoPsiElement> usages = new HashSet<GoPsiElement>();
 
     @Override
     public void visitConstDeclaration(GoConstDeclaration declaration) {

--- a/src/ro/redeul/google/go/findUsages/VariableUsage.java
+++ b/src/ro/redeul/google/go/findUsages/VariableUsage.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 class VariableUsage {
     public final PsiElement element;
-    private final List<PsiElement> usages = new ArrayList<>();
+    private final List<PsiElement> usages = new ArrayList<PsiElement>();
     public final boolean ignoreAnyProblem;
 
     VariableUsage(PsiElement element) {

--- a/src/ro/redeul/google/go/formatter/blocks/GoAssignBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoAssignBlock.java
@@ -24,7 +24,7 @@ class GoAssignBlock extends GoBlock {
 
     @Override
     protected List<Block> buildChildren() {
-        List<Block> children = new ArrayList<>();
+        List<Block> children = new ArrayList<Block>();
         for (ASTNode child : getGoChildren()) {
             Block block;
             Indent indent = Indent.getNormalIndent();

--- a/src/ro/redeul/google/go/formatter/blocks/GoAssignListBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoAssignListBlock.java
@@ -34,7 +34,7 @@ class GoAssignListBlock extends GoBlock {
 
     @Override
     protected List<Block> buildChildren() {
-        List<Block> children = new ArrayList<>();
+        List<Block> children = new ArrayList<Block>();
         int newLinesAfterLastAssign = 0;
         int newLinesAfterLastComment = 0;
         Alignment assignAlignment = null;

--- a/src/ro/redeul/google/go/formatter/blocks/GoBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoBlock.java
@@ -142,7 +142,7 @@ class GoBlock implements Block, GoElementTypes {
 
     @Nullable
     List<Block> buildChildren() {
-        List<Block> children = new ArrayList<>();
+        List<Block> children = new ArrayList<Block>();
 
         ASTNode prevChild = null;
         for (ASTNode child : getGoChildren()) {
@@ -310,7 +310,7 @@ class GoBlock implements Block, GoElementTypes {
         PsiElement psi = myNode.getPsi();
         if (psi instanceof OuterLanguageElement) {
             TextRange range = myNode.getTextRange();
-            List<ASTNode> childList = new ArrayList<>();
+            List<ASTNode> childList = new ArrayList<ASTNode>();
             PsiFile goFile = psi.getContainingFile()
                                 .getViewProvider()
                                 .getPsi(GoLanguage.INSTANCE);

--- a/src/ro/redeul/google/go/formatter/blocks/GoTypeInterfaceBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoTypeInterfaceBlock.java
@@ -21,7 +21,7 @@ class GoTypeInterfaceBlock extends GoBlock {
 
     @Override
     protected List<Block> buildChildren() {
-        List<Block> children = new ArrayList<>();
+        List<Block> children = new ArrayList<Block>();
         int newLinesAfterLastField = 0;
         int newLinesAfterLastComment = 0;
         Alignment fieldAlignment = null;

--- a/src/ro/redeul/google/go/formatter/blocks/GoTypeStructBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoTypeStructBlock.java
@@ -21,7 +21,7 @@ class GoTypeStructBlock extends GoBlock {
 
     @Override
     protected List<Block> buildChildren() {
-        List<Block> children = new ArrayList<>();
+        List<Block> children = new ArrayList<Block>();
         int newLinesAfterLastField = 0;
         int newLinesAfterLastComment = 0;
         Alignment fieldAlignment = null;

--- a/src/ro/redeul/google/go/formatter/blocks/GoTypeStructFieldBlock.java
+++ b/src/ro/redeul/google/go/formatter/blocks/GoTypeStructFieldBlock.java
@@ -31,7 +31,7 @@ class GoTypeStructFieldBlock extends GoBlock {
 
     @Override
     protected List<Block> buildChildren() {
-        List<Block> children = new ArrayList<>();
+        List<Block> children = new ArrayList<Block>();
         for (ASTNode child : getGoChildren()) {
             if (isNewLineNode(child.getPsi())) {
                 continue;

--- a/src/ro/redeul/google/go/highlight/GoSyntaxHighlighter.java
+++ b/src/ro/redeul/google/go/highlight/GoSyntaxHighlighter.java
@@ -24,7 +24,7 @@ import static ro.redeul.google.go.lang.lexer.GoTokenTypeSets.*;
 public class GoSyntaxHighlighter extends SyntaxHighlighterBase
     implements GoTokenTypes {
 
-    private static final Map<IElementType, TextAttributesKey> ATTRIBUTES = new HashMap<>();
+    private static final Map<IElementType, TextAttributesKey> ATTRIBUTES = new HashMap<IElementType, TextAttributesKey>();
 
     public static final String DEFAULT_SETTINGS_ID = "go.default";
     public static final String LINE_COMMENT_ID = "go.line.comment";

--- a/src/ro/redeul/google/go/ide/GoAppEngineModuleType.java
+++ b/src/ro/redeul/google/go/ide/GoAppEngineModuleType.java
@@ -65,7 +65,7 @@ public class GoAppEngineModuleType extends ModuleType<GoAppEngineModuleBuilder> 
     @Override
     public ModuleWizardStep[] createWizardSteps(WizardContext wizardContext, GoAppEngineModuleBuilder moduleBuilder, ModulesProvider modulesProvider)
     {
-        List<ModuleWizardStep> steps = new ArrayList<>();
+        List<ModuleWizardStep> steps = new ArrayList<ModuleWizardStep>();
 
 //        ProjectWizardStepFactory factory = ProjectWizardStepFactory.getInstance();
 //        steps.add(factory.createSourcePathsStep(wizardContext, moduleBuilder, null, "reference.dialogs.new.project.fromScratch.source"));

--- a/src/ro/redeul/google/go/ide/GoConfigurable.java
+++ b/src/ro/redeul/google/go/ide/GoConfigurable.java
@@ -104,20 +104,20 @@ public class GoConfigurable implements SearchableConfigurable {
             compilerManager.addTranslatingCompiler(
                     new GoCompiler(project),
                     new HashSet<FileType>(Arrays.asList(GoFileType.INSTANCE)),
-                    new HashSet<>(Arrays.asList(FileType.EMPTY_ARRAY)));
+                    new HashSet<FileType>(Arrays.asList(FileType.EMPTY_ARRAY)));
 
             break;
         case Makefile:
             compilerManager.addTranslatingCompiler(
                     new GoMakefileCompiler(project),
                     new HashSet<FileType>(Arrays.asList(GoFileType.INSTANCE)),
-                    new HashSet<>(Arrays.asList(FileType.EMPTY_ARRAY)));
+                    new HashSet<FileType>(Arrays.asList(FileType.EMPTY_ARRAY)));
             break;
         case Install:
             compilerManager.addTranslatingCompiler(
                     new GoInstallCompiler(project),
                     new HashSet<FileType>(Arrays.asList(GoFileType.INSTANCE)),
-                    new HashSet<>(Arrays.asList(FileType.EMPTY_ARRAY)));
+                    new HashSet<FileType>(Arrays.asList(FileType.EMPTY_ARRAY)));
         }
     }
 

--- a/src/ro/redeul/google/go/ide/GoModuleEditorsProvider.java
+++ b/src/ro/redeul/google/go/ide/GoModuleEditorsProvider.java
@@ -29,7 +29,7 @@ public class GoModuleEditorsProvider implements ModuleConfigurationEditorProvide
         }
 
         final DefaultModuleConfigurationEditorFactory editorFactory = DefaultModuleConfigurationEditorFactory.getInstance();
-        List<ModuleConfigurationEditor> editors = new ArrayList<>();
+        List<ModuleConfigurationEditor> editors = new ArrayList<ModuleConfigurationEditor>();
         editors.add(editorFactory.createModuleContentRootsEditor(state));
         editors.add(editorFactory.createOutputEditor(state));
         editors.add(editorFactory.createClasspathEditor(state));

--- a/src/ro/redeul/google/go/ide/GoModuleType.java
+++ b/src/ro/redeul/google/go/ide/GoModuleType.java
@@ -68,7 +68,7 @@ public class GoModuleType extends ModuleType<GoModuleBuilder> {
     @Override
     public ModuleWizardStep[] createWizardSteps(WizardContext wizardContext, GoModuleBuilder moduleBuilder, ModulesProvider modulesProvider)
     {
-        List<ModuleWizardStep> steps = new ArrayList<>();
+        List<ModuleWizardStep> steps = new ArrayList<ModuleWizardStep>();
 
         ProjectWizardStepFactory factory = ProjectWizardStepFactory.getInstance();
 
@@ -76,7 +76,7 @@ public class GoModuleType extends ModuleType<GoModuleBuilder> {
 //        steps.add(factory.createProjectJdkStep(wizardContext));
 //        steps.add(new AndroidModuleWizardStep(moduleBuilder, wizardContext.getProject()));
         steps.add(factory.createSourcePathsStep(wizardContext, moduleBuilder, null, "reference.dialogs.new.project.fromScratch.source"));
-        steps.add(factory.createProjectJdkStep(wizardContext, SdkType.findInstance(GoSdkType.class), moduleBuilder, new Computable.PredefinedValueComputable<>(true), null, ""));
+        steps.add(factory.createProjectJdkStep(wizardContext, SdkType.findInstance(GoSdkType.class), moduleBuilder, new Computable.PredefinedValueComputable<Boolean>(true), null, ""));
 //        steps.add(new GoModuleWizardStep(moduleBuilder, wizardContext.getProject()));
         return steps.toArray(new ModuleWizardStep[steps.size()]);
     }

--- a/src/ro/redeul/google/go/ide/contributor/GoGoToSymbolContributor.java
+++ b/src/ro/redeul/google/go/ide/contributor/GoGoToSymbolContributor.java
@@ -13,7 +13,7 @@ public class GoGoToSymbolContributor implements ChooseByNameContributor {
     @Override
     public String[] getNames(Project project, boolean includeNonProjectItems) {
         GoNamesCache namesCache = GoNamesCache.getInstance(project);
-        Set<String> names = new HashSet<>();
+        Set<String> names = new HashSet<String>();
         namesCache.getAllTypeNames(names);
         namesCache.getAllFunctionNames();
         namesCache.getAllVariableNames();
@@ -25,7 +25,7 @@ public class GoGoToSymbolContributor implements ChooseByNameContributor {
     public NavigationItem[] getItemsByName(String name, String pattern, Project project,
                                            boolean includeNonProjectItems) {
         GoNamesCache namesCache = GoNamesCache.getInstance(project);
-        List<NavigationItem> result = new ArrayList<>();
+        List<NavigationItem> result = new ArrayList<NavigationItem>();
         Collections.addAll(result, namesCache.getTypesByName(name, includeNonProjectItems));
         Collections.addAll(result, namesCache.getFunctionsByName());
         Collections.addAll(result, namesCache.getVariablesByName());

--- a/src/ro/redeul/google/go/ide/structureview/GoStructureViewElement.java
+++ b/src/ro/redeul/google/go/ide/structureview/GoStructureViewElement.java
@@ -157,7 +157,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
         TreeElement[] getChildren() {
             GoFile psiFile = (GoFile) element;
 
-            ArrayList<StructureViewTreeElement> children = new ArrayList<>();
+            ArrayList<StructureViewTreeElement> children = new ArrayList<StructureViewTreeElement>();
 
             for (GoLiteralIdentifier id : getConstDeclarations(psiFile)) {
                 children.add(new GoStructureViewElement(new ConstLiteralIdentifierInfo(id)));
@@ -379,7 +379,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
         @Override
         TreeElement[] getChildren() {
             GoTypeSpec typeSpec = (GoTypeSpec) element;
-            ArrayList<TreeElement> children = new ArrayList<>();
+            ArrayList<TreeElement> children = new ArrayList<TreeElement>();
             for (PsiNamedElement psi : getMembers(typeSpec)) {
                 children.add(new GoStructureViewElement(psi));
             }
@@ -412,7 +412,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
                 return Collections.emptyList();
             }
 
-            List<PsiNamedElement> members = new ArrayList<>();
+            List<PsiNamedElement> members = new ArrayList<PsiNamedElement>();
             members.addAll(getMethods(typeSpec));
             members.addAll(getFields((GoPsiTypeStruct) type));
             return members;
@@ -432,7 +432,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
                 return Collections.emptyList();
             }
 
-            List<PsiNamedElement> children = new ArrayList<>();
+            List<PsiNamedElement> children = new ArrayList<PsiNamedElement>();
             for (GoFile f : getAllSamePackageFiles((GoFile) file)) {
                 getMethodsInFile(children, name, f);
             }
@@ -446,7 +446,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
                 return Collections.singleton(goFile);
             }
 
-            List<GoFile> files = new ArrayList<>();
+            List<GoFile> files = new ArrayList<GoFile>();
             String packageName = goFile.getPackageName();
             GoNamesCache namesCache = GoNamesCache.getInstance(goFile.getProject());
             for (GoFile file : namesCache.getFilesByPackageName(packageName)) {
@@ -494,7 +494,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
         }
 
         private List<PsiNamedElement> getAnonymousFields(GoPsiTypeStruct struct) {
-            List<PsiNamedElement> children = new ArrayList<>();
+            List<PsiNamedElement> children = new ArrayList<PsiNamedElement>();
             for (GoTypeStructAnonymousField field : struct.getAnonymousFields()) {
                 children.add(field.getType());
             }
@@ -502,7 +502,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
         }
 
         private List<PsiNamedElement> getNamedFields(GoPsiTypeStruct struct) {
-            List<PsiNamedElement> children = new ArrayList<>();
+            List<PsiNamedElement> children = new ArrayList<PsiNamedElement>();
             for (GoTypeStructField field : struct.getFields()) {
                 for (GoLiteralIdentifier identifier : field.getIdentifiers()) {
                     if (!identifier.isBlank()) {
@@ -531,7 +531,7 @@ public class GoStructureViewElement implements StructureViewTreeElement, ItemPre
 
         @Override
         List<PsiNamedElement> getMembers(GoTypeSpec typeSpec) {
-            List<PsiNamedElement> children = new ArrayList<>();
+            List<PsiNamedElement> children = new ArrayList<PsiNamedElement>();
             GoPsiType type = typeSpec.getType();
             if (!(type instanceof GoPsiTypeInterface)) {
                 return Collections.emptyList();

--- a/src/ro/redeul/google/go/imports/AutoImportHighlightingPass.java
+++ b/src/ro/redeul/google/go/imports/AutoImportHighlightingPass.java
@@ -71,7 +71,7 @@ public class AutoImportHighlightingPass extends TextEditorHighlightingPass {
             return null;
         }
 
-        Set<String> imported = new HashSet<>();
+        Set<String> imported = new HashSet<String>();
         for (GoImportDeclarations ids : file.getImportDeclarations()) {
             for (GoImportDeclaration id : ids.getDeclarations()) {
                 String name = id.getPackageName();
@@ -141,7 +141,7 @@ public class AutoImportHighlightingPass extends TextEditorHighlightingPass {
 
     public static List<String> getPackagesByName(Collection<String> allPackages,
                                                  String expectedName) {
-        List<String> packageFiles = new ArrayList<>();
+        List<String> packageFiles = new ArrayList<String>();
         for (String p : allPackages) {
             if (expectedName.equals(p) || p.endsWith(
                 "/" + expectedName)) {
@@ -233,7 +233,7 @@ public class AutoImportHighlightingPass extends TextEditorHighlightingPass {
                     return;
                 }
 
-                List<String> allPackages = new ArrayList<>(
+                List<String> allPackages = new ArrayList<String>(
                     data.projectPackages);
                 allPackages.addAll(data.sdkPackages);
                 String importMessage = getPromptMessage(allPackages);

--- a/src/ro/redeul/google/go/imports/GoImportOptimizer.java
+++ b/src/ro/redeul/google/go/imports/GoImportOptimizer.java
@@ -54,7 +54,7 @@ public class GoImportOptimizer implements ImportOptimizer {
         final Project project = goFile.getProject();
         GoCodeManager goCodeManager = GoCodeManager.getInstance(project);
         final Set<GoImportDeclaration> unusedImports =
-            new HashSet<>(goCodeManager.findUnusedImports(goFile));
+            new HashSet<GoImportDeclaration>(goCodeManager.findUnusedImports(goFile));
 
         for (GoImportDeclaration id : unusedImports) {
             GoLiteralString importPath = id.getImportPath();

--- a/src/ro/redeul/google/go/inspection/FunctionCallInspection.java
+++ b/src/ro/redeul/google/go/inspection/FunctionCallInspection.java
@@ -35,16 +35,15 @@ public class FunctionCallInspection extends AbstractWholeGoFileInspection {
 
                 GoPrimaryExpression baseExpression = expression.getBaseExpression();
                 String expressionText = baseExpression.getText();
-                switch (expressionText) {
-                    case "make":
-                        checkMakeCall(expression, result);
-                        break;
-                    case "new":
-                        checkNewCall(expression, result);
-                        break;
-                    default:
-                        checkFunctionCallArguments(expression, result);
-                        break;
+                if (expressionText.equals("make")) {
+                    checkMakeCall(expression, result);
+
+                } else if (expressionText.equals("new")) {
+                    checkNewCall(expression, result);
+
+                } else {
+                    checkFunctionCallArguments(expression, result);
+
                 }
             }
         }.visitFile(file);

--- a/src/ro/redeul/google/go/inspection/FunctionDeclarationInspection.java
+++ b/src/ro/redeul/google/go/inspection/FunctionDeclarationInspection.java
@@ -74,7 +74,7 @@ public class FunctionDeclarationInspection
     }
 
     private static void hasDuplicateArgument(Context ctx) {
-        Set<String> parameters = new HashSet<>();
+        Set<String> parameters = new HashSet<String>();
         for (GoFunctionParameter fp : ctx.function.getParameters()) {
             for (GoLiteralIdentifier id : fp.getIdentifiers()) {
                 if (id.isBlank()) {
@@ -92,7 +92,7 @@ public class FunctionDeclarationInspection
     }
 
     private static void hasRedeclaredParameterInResultList(Context ctx) {
-        Set<String> parameters = new HashSet<>(getParameterNames(ctx.function.getParameters()));
+        Set<String> parameters = new HashSet<String>(getParameterNames(ctx.function.getParameters()));
 
         for (GoFunctionParameter fp : ctx.function.getResults()) {
             for (GoLiteralIdentifier id : fp.getIdentifiers()) {
@@ -172,7 +172,7 @@ public class FunctionDeclarationInspection
     }
 
     private static List<String> getParameterNames(GoFunctionParameter[] parameters) {
-        List<String> parameterNames = new ArrayList<>();
+        List<String> parameterNames = new ArrayList<String>();
         for (GoFunctionParameter fp : parameters) {
             for (GoLiteralIdentifier id : fp.getIdentifiers()) {
                 if (!id.isBlank()) {

--- a/src/ro/redeul/google/go/inspection/InspectionResult.java
+++ b/src/ro/redeul/google/go/inspection/InspectionResult.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class InspectionResult {
     private final InspectionManager manager;
-    private final List<ProblemDescriptor> problems = new ArrayList<>();
+    private final List<ProblemDescriptor> problems = new ArrayList<ProblemDescriptor>();
 
     public InspectionResult(Project project) {
         this(InspectionManager.getInstance(project));

--- a/src/ro/redeul/google/go/inspection/LabelUsageInspection.java
+++ b/src/ro/redeul/google/go/inspection/LabelUsageInspection.java
@@ -47,8 +47,8 @@ public class LabelUsageInspection extends AbstractWholeGoFileInspection {
     }
 
     private static void checkFunction(final InspectionResult result, GoFunctionDeclaration function) {
-        final Map<String, GoLiteralIdentifier> labelDeclarations = new HashMap<>();
-        final List<GoLiteralIdentifier> labelUsages = new ArrayList<>();
+        final Map<String, GoLiteralIdentifier> labelDeclarations = new HashMap<String, GoLiteralIdentifier>();
+        final List<GoLiteralIdentifier> labelUsages = new ArrayList<GoLiteralIdentifier>();
         new GoRecursiveElementVisitor() {
             @Override
             public void visitLabeledStatement(GoLabeledStatement statement) {
@@ -97,7 +97,7 @@ public class LabelUsageInspection extends AbstractWholeGoFileInspection {
             }
         }.visitElement(function);
 
-        Set<String> usedLabels = new HashSet<>();
+        Set<String> usedLabels = new HashSet<String>();
         for (GoLiteralIdentifier label : labelUsages) {
             String name = label.getName();
             if (labelDeclarations.containsKey(name)) {

--- a/src/ro/redeul/google/go/inspection/TypeStructDeclarationInspection.java
+++ b/src/ro/redeul/google/go/inspection/TypeStructDeclarationInspection.java
@@ -75,7 +75,7 @@ public class TypeStructDeclarationInspection
     }
 
     private static void checkFields(GoPsiTypeStruct struct, InspectionResult result) {
-        Set<String> fields = new HashSet<>();
+        Set<String> fields = new HashSet<String>();
         for (GoTypeStructField field : struct.getFields()) {
             if (typeContainsStruct(field.getType(), struct)) {
                 result.addProblem(field, GoBundle.message(

--- a/src/ro/redeul/google/go/inspection/fix/AddImportFix.java
+++ b/src/ro/redeul/google/go/inspection/fix/AddImportFix.java
@@ -23,7 +23,7 @@ import static ro.redeul.google.go.util.EditorUtil.reformatLines;
 import static ro.redeul.google.go.util.EditorUtil.reformatPositions;
 
 public class AddImportFix implements QuestionAction {
-    private final List<String> pathsToImport = new ArrayList<>();
+    private final List<String> pathsToImport = new ArrayList<String>();
     private final List<String> sdkPackages;
     private final GoFile file;
     private final Editor editor;

--- a/src/ro/redeul/google/go/intentions/GoIntentionsBundle.java
+++ b/src/ro/redeul/google/go/intentions/GoIntentionsBundle.java
@@ -25,7 +25,7 @@ public class GoIntentionsBundle {
 
         if (bundle == null) {
             bundle = ResourceBundle.getBundle(BUNDLE);
-            ourBundle = new SoftReference<>(bundle);
+            ourBundle = new SoftReference<ResourceBundle>(bundle);
         }
         return bundle;
     }

--- a/src/ro/redeul/google/go/intentions/control/InvertIfIntention.java
+++ b/src/ro/redeul/google/go/intentions/control/InvertIfIntention.java
@@ -157,7 +157,7 @@ public class InvertIfIntention extends Intention {
             return Collections.emptyList();
         }
 
-        List<PsiElement> siblings = new ArrayList<>();
+        List<PsiElement> siblings = new ArrayList<PsiElement>();
         while ((element = element.getNextSibling()) != null) {
             siblings.add(element);
         }

--- a/src/ro/redeul/google/go/intentions/conversions/ConvertSwitchToIfIntention.java
+++ b/src/ro/redeul/google/go/intentions/conversions/ConvertSwitchToIfIntention.java
@@ -111,7 +111,7 @@ public class ConvertSwitchToIfIntention extends Intention {
             boolean expressionIsFalse = expression != null && "false".equals(expression.getText());
             String es = expressionIsTrue || expressionIsFalse ? "" : expression.getText();
             CaseElement defaultCase = null;
-            List<CaseElement> cases = new ArrayList<>();
+            List<CaseElement> cases = new ArrayList<CaseElement>();
             for (GoSwitchExpressionClause clause : se.getClauses()) {
                 CaseElement c = CaseElement.create(document, clause, expressionIsFalse);
                 if (clause.isDefault()) {
@@ -149,7 +149,7 @@ public class ConvertSwitchToIfIntention extends Intention {
         }
 
         private static CaseElement create(Document document, GoSwitchExpressionClause clause, boolean flipExpression) {
-            List<String> expressions = new ArrayList<>();
+            List<String> expressions = new ArrayList<String>();
             for (GoExpr expr : clause.getExpressions()) {
                 expressions.add(flipExpression ? FlipBooleanExpression.flip(expr) : expr.getText());
             }

--- a/src/ro/redeul/google/go/intentions/statements/MoveSimpleStatementOutIntention.java
+++ b/src/ro/redeul/google/go/intentions/statements/MoveSimpleStatementOutIntention.java
@@ -192,7 +192,7 @@ public class MoveSimpleStatementOutIntention extends Intention {
 
     private static List<GoIfStatement> findAllDependentIfs(GoIfStatement ifStatement,
                                                            GoSimpleStatement simpleStatement) {
-        final List<GoIfStatement> dependentIfs = new ArrayList<>();
+        final List<GoIfStatement> dependentIfs = new ArrayList<GoIfStatement>();
         final Set<GoIfStatement> outerIfs = findAllOuterIfs(ifStatement);
 
         new GoRecursiveElementVisitor() {
@@ -219,7 +219,7 @@ public class MoveSimpleStatementOutIntention extends Intention {
     }
 
     private static Set<GoIfStatement> findAllOuterIfs(GoIfStatement ifStatement) {
-        final Set<GoIfStatement> outerIfs = new HashSet<>();
+        final Set<GoIfStatement> outerIfs = new HashSet<GoIfStatement>();
         while (ifStatement != null && ifStatement.getParent() instanceof GoIfStatement) {
             ifStatement = (GoIfStatement) ifStatement.getParent();
             outerIfs.add(ifStatement);

--- a/src/ro/redeul/google/go/lang/completion/GoCompletionContributor.java
+++ b/src/ro/redeul/google/go/lang/completion/GoCompletionContributor.java
@@ -381,7 +381,7 @@ public class GoCompletionContributor extends CompletionContributor {
 
     private static void addPackageAutoCompletion(CompletionParameters parameters, CompletionResultSet result) {
         PsiFile originalFile = parameters.getOriginalFile();
-        Set<String> importedPackages = new HashSet<>();
+        Set<String> importedPackages = new HashSet<String>();
         for (LookupElement element : getImportedPackagesNames(originalFile)) {
             result.addElement(element);
             importedPackages.add(element.getLookupString());
@@ -435,7 +435,7 @@ public class GoCompletionContributor extends CompletionContributor {
     }
 
     private static Map<String, List<String>> getPackageNameToImportPathMapping(Project project, Set<String> importedPackages) {
-        Map<String, List<String>> packageMap = new HashMap<>();
+        Map<String, List<String>> packageMap = new HashMap<String, List<String>>();
         for (String pkg : GoNamesCache.getInstance(project).getAllPackages()) {
             String visibleName = pkg;
             if (visibleName.contains("/")) {
@@ -444,7 +444,7 @@ public class GoCompletionContributor extends CompletionContributor {
             if (!importedPackages.contains(visibleName)) {
                 List<String> packages = packageMap.get(visibleName);
                 if (packages == null) {
-                    packages = new ArrayList<>();
+                    packages = new ArrayList<String>();
                     packageMap.put(visibleName, packages);
                 }
                 packages.add(pkg);

--- a/src/ro/redeul/google/go/lang/completion/GoCompletionUtil.java
+++ b/src/ro/redeul/google/go/lang/completion/GoCompletionUtil.java
@@ -50,7 +50,7 @@ public class GoCompletionUtil {
             return LookupElement.EMPTY_ARRAY;
         }
 
-        Set<String> completions = new HashSet<>();
+        Set<String> completions = new HashSet<String>();
         VirtualFile roots[] = sdk.getRootProvider().getFiles(OrderRootType.CLASSES);
 
         for (VirtualFile root : roots) {
@@ -76,7 +76,7 @@ public class GoCompletionUtil {
             }
         }
 
-        List<LookupElement> list = new ArrayList<>();
+        List<LookupElement> list = new ArrayList<LookupElement>();
         for (String completion : completions) {
             list.add(LookupElementBuilder.create(completion));
         }
@@ -105,7 +105,7 @@ public class GoCompletionUtil {
 
         final PsiManager psiManager = PsiManager.getInstance(project);
 
-        CommonProcessors.CollectUniquesProcessor<String> localPackages = new CommonProcessors.CollectUniquesProcessor<>();
+        CommonProcessors.CollectUniquesProcessor<String> localPackages = new CommonProcessors.CollectUniquesProcessor<String>();
 
         Function<VirtualFile, String> convertor = new Function<VirtualFile, String>() {
             public String fun(VirtualFile virtualFile) {
@@ -151,7 +151,7 @@ public class GoCompletionUtil {
 
         VfsUtil.processFilesRecursively(targetFile.getParent(), processor);
 
-        List<LookupElementBuilder> elements = new ArrayList<>();
+        List<LookupElementBuilder> elements = new ArrayList<LookupElementBuilder>();
         for (String localPackage : localPackages.getResults()) {
             LookupElementBuilder elementBuilder = null;
 
@@ -218,7 +218,7 @@ public class GoCompletionUtil {
 
         GoFile goFile = (GoFile) file;
 
-        List<LookupElement> elements = new ArrayList<>();
+        List<LookupElement> elements = new ArrayList<LookupElement>();
         for (GoImportDeclaration importDeclaration : GoFileUtils.getImportDeclarations(goFile)) {
             String visiblePackageName = importDeclaration.getVisiblePackageName();
             String importPath = importDeclaration.getImportPath().getValue();

--- a/src/ro/redeul/google/go/lang/documentation/DocumentUtil.java
+++ b/src/ro/redeul/google/go/lang/documentation/DocumentUtil.java
@@ -28,7 +28,7 @@ public class DocumentUtil {
 
     private static String getTailingDocumentOfElement(PsiElement element) {
         boolean foundNewLine = false;
-        List<String> comments = new ArrayList<>();
+        List<String> comments = new ArrayList<String>();
         while ((element = element.getNextSibling()) != null) {
             if (isNodeOfType(element, GoElementTypes.COMMENTS)) {
                 foundNewLine = false;
@@ -49,7 +49,7 @@ public class DocumentUtil {
 
     private static String getHeaderDocumentOfElement(PsiElement element) {
         boolean foundNewLine = false;
-        List<String> comments = new ArrayList<>();
+        List<String> comments = new ArrayList<String>();
         while ((element = element.getPrevSibling()) != null) {
             if (isNodeOfType(element, GoElementTypes.COMMENTS)) {
                 foundNewLine = false;

--- a/src/ro/redeul/google/go/lang/folding/GoFoldingBuilder.java
+++ b/src/ro/redeul/google/go/lang/folding/GoFoldingBuilder.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class GoFoldingBuilder implements FoldingBuilder, DumbAware, GoElementTypes {
     @NotNull
     public FoldingDescriptor[] buildFoldRegions(@NotNull ASTNode node, @NotNull Document document) {
-        List<FoldingDescriptor> descriptors = new ArrayList<>();
+        List<FoldingDescriptor> descriptors = new ArrayList<FoldingDescriptor>();
         appendDescriptors(node.getPsi(), document, descriptors);
         return descriptors.toArray(new FoldingDescriptor[descriptors.size()]);
     }

--- a/src/ro/redeul/google/go/lang/lexer/_GoLexer.java
+++ b/src/ro/redeul/google/go/lang/lexer/_GoLexer.java
@@ -1243,8 +1243,8 @@ public class _GoLexer implements FlexLexer, GoTokenTypes {
 
   /* user code: */
 
-  private Stack <IElementType> gStringStack = new Stack<>();
-  private Stack <IElementType> blockStack = new Stack<>();
+  private Stack <IElementType> gStringStack = new Stack<IElementType>();
+  private Stack <IElementType> blockStack = new Stack<IElementType>();
 
   private int afterComment = YYINITIAL;
   private int afterNls = YYINITIAL;
@@ -1255,7 +1255,7 @@ public class _GoLexer implements FlexLexer, GoTokenTypes {
     blockStack.clear();
   }
 
-  private Stack<IElementType> braceCount = new Stack<>();
+  private Stack<IElementType> braceCount = new Stack<IElementType>();
 
 
 

--- a/src/ro/redeul/google/go/lang/parser/GoParser.java
+++ b/src/ro/redeul/google/go/lang/parser/GoParser.java
@@ -37,7 +37,7 @@ public class GoParser extends ParserUtils implements PsiParser {
 
     private final EnumSet<ParsingFlag> flags = EnumSet.noneOf(ParsingFlag.class);
 
-    private final Set<String> packageNames = new HashSet<>();
+    private final Set<String> packageNames = new HashSet<String>();
 
     public boolean isSet(ParsingFlag parseFlag) {
         return flags.contains(parseFlag);

--- a/src/ro/redeul/google/go/lang/psi/GoPsiElementFactory.java
+++ b/src/ro/redeul/google/go/lang/psi/GoPsiElementFactory.java
@@ -32,7 +32,7 @@ public class GoPsiElementFactory {
             return new PsiElement[0];
         }
 
-        List<PsiElement> nodes = new ArrayList<>();
+        List<PsiElement> nodes = new ArrayList<PsiElement>();
         while ((child = child.getNextSibling()) != null) {
             nodes.add(child);
         }

--- a/src/ro/redeul/google/go/lang/psi/impl/declarations/GoVarDeclarationImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/declarations/GoVarDeclarationImpl.java
@@ -63,7 +63,7 @@ public class GoVarDeclarationImpl extends GoPsiElementBase implements GoVarDecla
         GoLiteralIdentifier[] identifiers = getIdentifiers();
         GoExpr[] expressions = getExpressions();
 
-        List<GoType> types = new ArrayList<>();
+        List<GoType> types = new ArrayList<GoType>();
         for (GoExpr expression : expressions) {
             Collections.addAll(types, expression.getType());
         }

--- a/src/ro/redeul/google/go/lang/psi/impl/expressions/literals/GoLiteralFunctionImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/expressions/literals/GoLiteralFunctionImpl.java
@@ -120,7 +120,7 @@ public class GoLiteralFunctionImpl extends GoPsiElementBase
 
     @Override
     public GoPsiType[] getReturnType() {
-        List<GoPsiType> types = new ArrayList<>();
+        List<GoPsiType> types = new ArrayList<GoPsiType>();
 
         GoFunctionParameter[] results = getResults();
         for (GoFunctionParameter result : results) {

--- a/src/ro/redeul/google/go/lang/psi/impl/toplevel/GoFunctionDeclarationImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/toplevel/GoFunctionDeclarationImpl.java
@@ -117,7 +117,7 @@ public class GoFunctionDeclarationImpl extends GoPsiElementBase
     @Override
     public GoPsiType[] getReturnType() {
 
-        List<GoPsiType> types = new ArrayList<>();
+        List<GoPsiType> types = new ArrayList<GoPsiType>();
 
         GoFunctionParameter[] results = getResults();
         for (GoFunctionParameter result : results) {

--- a/src/ro/redeul/google/go/lang/psi/impl/types/struct/PromotedFieldsDiscover.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/types/struct/PromotedFieldsDiscover.java
@@ -11,8 +11,8 @@ import ro.redeul.google.go.lang.psi.typing.GoTypes;
 import java.util.*;
 
 public class PromotedFieldsDiscover {
-    private final Map<String, List<GoLiteralIdentifier>> namedFieldsMap = new HashMap<>();
-    private final Map<String, List<GoTypeStructAnonymousField>> anonymousFieldsMap = new HashMap<>();
+    private final Map<String, List<GoLiteralIdentifier>> namedFieldsMap = new HashMap<String, List<GoLiteralIdentifier>>();
+    private final Map<String, List<GoTypeStructAnonymousField>> anonymousFieldsMap = new HashMap<String, List<GoTypeStructAnonymousField>>();
 
     private final GoPsiTypeStruct struct;
     private final Set<String> ignoreNames;
@@ -23,7 +23,7 @@ public class PromotedFieldsDiscover {
 
     private PromotedFieldsDiscover(GoPsiTypeStruct struct, Set<String> ignoreNames) {
         this.struct = struct;
-        this.ignoreNames = new HashSet<>(ignoreNames);
+        this.ignoreNames = new HashSet<String>(ignoreNames);
         this.ignoreNames.addAll(getDirectFieldNameSet());
     }
 
@@ -41,7 +41,7 @@ public class PromotedFieldsDiscover {
     }
 
     private GoLiteralIdentifier[] getNamedFields() {
-        List<GoLiteralIdentifier> namedFields = new ArrayList<>();
+        List<GoLiteralIdentifier> namedFields = new ArrayList<GoLiteralIdentifier>();
         for (List<GoLiteralIdentifier> identifiers : namedFieldsMap.values()) {
             if (identifiers.size() == 1 && !ignore(identifiers.get(0))) {
                 namedFields.add(identifiers.get(0));
@@ -52,7 +52,7 @@ public class PromotedFieldsDiscover {
     }
 
     private GoTypeStructAnonymousField[] getAnonymousFields() {
-        List<GoTypeStructAnonymousField> anonymousFields = new ArrayList<>();
+        List<GoTypeStructAnonymousField> anonymousFields = new ArrayList<GoTypeStructAnonymousField>();
         for (List<GoTypeStructAnonymousField> fields : anonymousFieldsMap.values()) {
             if (fields.size() == 1 && !ignore(fields.get(0))) {
                 anonymousFields.add(fields.get(0));
@@ -118,7 +118,7 @@ public class PromotedFieldsDiscover {
         String name = field.getFieldName();
         List<GoTypeStructAnonymousField> fields = anonymousFieldsMap.get(name);
         if (fields == null) {
-            fields = new ArrayList<>();
+            fields = new ArrayList<GoTypeStructAnonymousField>();
             anonymousFieldsMap.put(name, fields);
         }
         fields.add(field);
@@ -132,14 +132,14 @@ public class PromotedFieldsDiscover {
         String name = identifier.getUnqualifiedName();
         List<GoLiteralIdentifier> fields = namedFieldsMap.get(name);
         if (fields == null) {
-            fields = new ArrayList<>();
+            fields = new ArrayList<GoLiteralIdentifier>();
             namedFieldsMap.put(name, fields);
         }
         fields.add(identifier);
     }
 
     private Set<String> getDirectFieldNameSet() {
-        Set<String> directFields = new HashSet<>();
+        Set<String> directFields = new HashSet<String>();
         for (GoTypeStructField field : struct.getFields()) {
             for (GoLiteralIdentifier identifier : field.getIdentifiers()) {
                 if (!identifier.isBlank()) {

--- a/src/ro/redeul/google/go/lang/psi/processors/GoExpressionTypeResolver.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/GoExpressionTypeResolver.java
@@ -19,7 +19,7 @@ import java.util.List;
  */
 class GoExpressionTypeResolver extends BaseScopeProcessor {
 
-    private final List<GoFunctionDeclaration> nodeFunctions = new ArrayList<>();
+    private final List<GoFunctionDeclaration> nodeFunctions = new ArrayList<GoFunctionDeclaration>();
 
     public GoExpressionTypeResolver() {
     }

--- a/src/ro/redeul/google/go/lang/psi/processors/GoNamesUtil.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/GoNamesUtil.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 public class GoNamesUtil {
 
     private static final Pattern RE_PUBLIC_NAME = Pattern.compile("^\\p{Lu}.*$");
-    private static final Set<String> PREDEFINED_CONSTANT = new HashSet<>();
+    private static final Set<String> PREDEFINED_CONSTANT = new HashSet<String>();
 
     static {
         PREDEFINED_CONSTANT.add("true");

--- a/src/ro/redeul/google/go/lang/psi/processors/GoResolveStates.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/GoResolveStates.java
@@ -36,11 +36,11 @@ public class GoResolveStates {
                 .put(IsOriginalPackage, true);
     }
 
-    private static final Key<Boolean> ResolvingVariables = new Key<>("ResolvingVariables");
-    public static final Key<Boolean> IsOriginalFile = new Key<>("IsOriginalFile");
-    public static final Key<Boolean> IsOriginalPackage = new Key<>("IsOriginalPackage");
+    private static final Key<Boolean> ResolvingVariables = new Key<Boolean>("ResolvingVariables");
+    public static final Key<Boolean> IsOriginalFile = new Key<Boolean>("IsOriginalFile");
+    public static final Key<Boolean> IsOriginalPackage = new Key<Boolean>("IsOriginalPackage");
 
-    public static final Key<String> VisiblePackageName = new Key<>("VisiblePackageName");
+    public static final Key<String> VisiblePackageName = new Key<String>("VisiblePackageName");
 
-    public static final Key<String> PackageName = new Key<>("PackageName");
+    public static final Key<String> PackageName = new Key<String>("PackageName");
 }

--- a/src/ro/redeul/google/go/lang/psi/processors/IdentifierVariantsCollector.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/IdentifierVariantsCollector.java
@@ -36,8 +36,8 @@ class IdentifierVariantsCollector extends BaseScopeProcessor{
             "append", "cap", "close", "complex", "copy", "imag", "len", "make", "new", "panic", "print", "println", "real", "recover"
     };
 
-    private final List<LookupElement> variants = new ArrayList<>();
-    private final Set<String> names = new HashSet<>();
+    private final List<LookupElement> variants = new ArrayList<LookupElement>();
+    private final Set<String> names = new HashSet<String>();
 
     @Override
     public boolean execute(PsiElement element, ResolveState state) {

--- a/src/ro/redeul/google/go/lang/psi/processors/ImportedPackagesCollectorProcessor.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/ImportedPackagesCollectorProcessor.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public class ImportedPackagesCollectorProcessor extends BaseScopeProcessor {
 
-    private final List<GoImportDeclaration> imports = new ArrayList<>();
+    private final List<GoImportDeclaration> imports = new ArrayList<GoImportDeclaration>();
 
     public boolean execute(PsiElement element, ResolveState state) {
 
@@ -38,7 +38,7 @@ public class ImportedPackagesCollectorProcessor extends BaseScopeProcessor {
 
     public String[] getPackageImports() {
 
-        List<String> packageImports = new ArrayList<>();
+        List<String> packageImports = new ArrayList<String>();
 
         for (GoImportDeclaration importSpec : imports) {
             GoPackageReference packageReference = importSpec.getPackageReference();

--- a/src/ro/redeul/google/go/lang/psi/processors/LibraryContentsProcessor.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/LibraryContentsProcessor.java
@@ -19,7 +19,7 @@ class LibraryContentsProcessor extends BaseScopeProcessor {
 
     private final GoQualifiedNameElement qualifiedName;
 
-    private final List<Object> objects = new ArrayList<>();
+    private final List<Object> objects = new ArrayList<Object>();
 
     public LibraryContentsProcessor(GoQualifiedNameElement qualifiedName) {
         this.qualifiedName = qualifiedName;

--- a/src/ro/redeul/google/go/lang/psi/processors/NamedTypeVariantsCollector.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/NamedTypeVariantsCollector.java
@@ -30,7 +30,7 @@ class NamedTypeVariantsCollector extends BaseScopeProcessor {
             "byte", "uint", "int", "float", "complex", "uintptr", "bool", "string"
     };
 
-    private final List<LookupElement> variants = new ArrayList<>();
+    private final List<LookupElement> variants = new ArrayList<LookupElement>();
 
     public boolean execute(PsiElement element, ResolveState state) {
 

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/AbstractStructFieldsReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/AbstractStructFieldsReference.java
@@ -46,7 +46,7 @@ abstract class AbstractStructFieldsReference
         if (typeStruct == null || typeStruct.getPsiType() == null)
             return LookupElementBuilder.EMPTY_ARRAY;
 
-        List<LookupElementBuilder> variants = new ArrayList<>();
+        List<LookupElementBuilder> variants = new ArrayList<LookupElementBuilder>();
 
         GoPsiTypeStruct psiType = typeStruct.getPsiType();
         for (GoTypeStructField field : psiType.getFields()) {

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/BuiltinCallOrConversionReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/BuiltinCallOrConversionReference.java
@@ -78,7 +78,7 @@ public class BuiltinCallOrConversionReference extends AbstractCallOrConversionRe
 
         PsiElement element = getElement();
 
-        final List<LookupElementBuilder> variants = new ArrayList<>();
+        final List<LookupElementBuilder> variants = new ArrayList<LookupElementBuilder>();
 
         MethodOrTypeNameResolver processor = new MethodOrTypeNameResolver(this) {
             @Override

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/CallOrConversionReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/CallOrConversionReference.java
@@ -52,7 +52,7 @@ public class CallOrConversionReference extends AbstractCallOrConversionReference
 
         GoLiteralExpression expression = getElement();
 
-        final List<LookupElementBuilder> variants = new ArrayList<>();
+        final List<LookupElementBuilder> variants = new ArrayList<LookupElementBuilder>();
 
         MethodOrTypeNameResolver processor =
             new MethodOrTypeNameResolver(this) {

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/ImportReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/ImportReference.java
@@ -81,7 +81,7 @@ public class ImportReference extends GoPsiReference.Single<GoImportDeclaration, 
 
         GoNamesCache namesCache = GoNamesCache.getInstance(element.getProject());
 
-        List<ResolveResult> files = new ArrayList<>();
+        List<ResolveResult> files = new ArrayList<ResolveResult>();
         for (GoFile file : namesCache.getFilesByPackageImportPath(importPath.getValue())) {
             files.add(new PsiElementResolveResult(file.getOriginalFile()));
         }

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/InterfaceMethodReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/InterfaceMethodReference.java
@@ -116,7 +116,7 @@ public class InterfaceMethodReference extends
         GoTypeInterfaceMethodSet methodSet =
             new MethodSetDiscover(type.getPsiType()).getMethodSet();
 
-        List<LookupElementBuilder> variants = new ArrayList<>();
+        List<LookupElementBuilder> variants = new ArrayList<LookupElementBuilder>();
         for (GoFunctionDeclaration functionDeclaration : methodSet.getMethods()) {
             variants.add(functionDeclaration.getCompletionPresentation());
         }

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/LabelReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/LabelReference.java
@@ -45,7 +45,7 @@ public class LabelReference
                     return null;
                 }
 
-                final AtomicReference<PsiElement> declaration = new AtomicReference<>();
+                final AtomicReference<PsiElement> declaration = new AtomicReference<PsiElement>();
 
                 new GoRecursiveElementVisitor() {
                     @Override
@@ -122,7 +122,7 @@ public class LabelReference
             return new Object[0];
         }
 
-        final TreeSet<String> labels = new TreeSet<>();
+        final TreeSet<String> labels = new TreeSet<String>();
         new GoRecursiveElementVisitor() {
             @Override
             public void visitLabeledStatement(GoLabeledStatement statement) {

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/MethodReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/MethodReference.java
@@ -88,7 +88,7 @@ public class MethodReference
         if (resolverTypeNames.size() == 0)
             return LookupElementBuilder.EMPTY_ARRAY;
 
-        final List<LookupElementBuilder> variants = new ArrayList<>();
+        final List<LookupElementBuilder> variants = new ArrayList<LookupElementBuilder>();
 
         MethodResolver processor = new MethodResolver(this) {
             @Override
@@ -116,7 +116,7 @@ public class MethodReference
         if ( receiverTypes != null )
             return receiverTypes;
 
-        receiverTypes = new HashSet<>();
+        receiverTypes = new HashSet<GoTypeName>();
 
         GoType[] types = getElement().getBaseExpression().getType();
 
@@ -132,7 +132,7 @@ public class MethodReference
 
         GoTypeName typeName = (GoTypeName) type;
 
-        Queue<GoTypeName> typeNamesToExplore = new LinkedList<>();
+        Queue<GoTypeName> typeNamesToExplore = new LinkedList<GoTypeName>();
         typeNamesToExplore.offer(typeName);
 
         while ( ! typeNamesToExplore.isEmpty() ) {

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/TypeNameReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/TypeNameReference.java
@@ -87,7 +87,7 @@ public class TypeNameReference
     @Override
     public Object[] getVariants() {
 
-        final List<LookupElement> variants = new ArrayList<>();
+        final List<LookupElement> variants = new ArrayList<LookupElement>();
 
         // According to the spec, method receiver type "T" could not be an interface or a pointer.
         final boolean rejectInterfaceAndPointer = TYPE_IN_METHOD_RECEIVER.accepts(getElement());

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/VarOrConstReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/VarOrConstReference.java
@@ -73,7 +73,7 @@ public class VarOrConstReference
     @Override
     public Object[] getVariants() {
 
-        final List<LookupElementBuilder> variants = new ArrayList<>();
+        final List<LookupElementBuilder> variants = new ArrayList<LookupElementBuilder>();
 
         VarOrConstResolver processor = new VarOrConstResolver(this) {
             @Override

--- a/src/ro/redeul/google/go/lang/psi/types/interfaces/GoTypeInterfaceMethodSet.java
+++ b/src/ro/redeul/google/go/lang/psi/types/interfaces/GoTypeInterfaceMethodSet.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public class GoTypeInterfaceMethodSet {
 
     private final Set<GoFunctionDeclaration> myFunctions =
-        new HashSet<>();
+        new HashSet<GoFunctionDeclaration>();
 
     public void add(GoFunctionDeclaration functionDeclaration) {
         myFunctions.add(functionDeclaration);

--- a/src/ro/redeul/google/go/lang/psi/types/underlying/GoUnderlyingTypePredeclared.java
+++ b/src/ro/redeul/google/go/lang/psi/types/underlying/GoUnderlyingTypePredeclared.java
@@ -9,7 +9,7 @@ import java.util.Map;
 public class GoUnderlyingTypePredeclared implements GoUnderlyingType {
 
     private static final Map<String, GoUnderlyingTypePredeclared> predeclaredTypes =
-        new HashMap<>();
+        new HashMap<String, GoUnderlyingTypePredeclared>();
 
     static {
         for (GoTypes.Builtin builtin : GoTypes.Builtin.values())

--- a/src/ro/redeul/google/go/lang/psi/typing/GoTypes.java
+++ b/src/ro/redeul/google/go/lang/psi/typing/GoTypes.java
@@ -51,7 +51,7 @@ public class GoTypes {
         uInt, uInt8, uInt16, uInt32, uInt64, uIntPtr
     }
 
-    private static final Map<Builtin, GoType> cachedTypes = new HashMap<>();
+    private static final Map<Builtin, GoType> cachedTypes = new HashMap<Builtin, GoType>();
 
     public static GoType getBuiltin(Builtin builtinType, GoNamesCache namesCache) {
         GoType type = cachedTypes.get(builtinType);

--- a/src/ro/redeul/google/go/lang/psi/utils/GoFileUtils.java
+++ b/src/ro/redeul/google/go/lang/psi/utils/GoFileUtils.java
@@ -25,7 +25,7 @@ public class GoFileUtils {
             return Collections.emptyList();
         }
 
-        List<GoConstDeclaration> consts = new ArrayList<>();
+        List<GoConstDeclaration> consts = new ArrayList<GoConstDeclaration>();
         for (GoConstDeclarations cds : constDeclarations) {
             Collections.addAll(consts, cds.getDeclarations());
         }
@@ -43,7 +43,7 @@ public class GoFileUtils {
             return Collections.emptyList();
         }
 
-        List<GoLiteralIdentifier> consts = new ArrayList<>();
+        List<GoLiteralIdentifier> consts = new ArrayList<GoLiteralIdentifier>();
         for (GoConstDeclarations cds : constDeclarations) {
             for (GoConstDeclaration cd : cds.getDeclarations()) {
                 Collections.addAll(consts, cd.getIdentifiers());
@@ -63,7 +63,7 @@ public class GoFileUtils {
             return Collections.emptyList();
         }
 
-        List<GoLiteralIdentifier> vars = new ArrayList<>();
+        List<GoLiteralIdentifier> vars = new ArrayList<GoLiteralIdentifier>();
         for (GoVarDeclarations vds : varDeclarations) {
             for (GoVarDeclaration vd : vds.getDeclarations()) {
                 Collections.addAll(vars, vd.getIdentifiers());
@@ -83,7 +83,7 @@ public class GoFileUtils {
             return Collections.emptyList();
         }
 
-        List<GoImportDeclaration> declarations = new ArrayList<>();
+        List<GoImportDeclaration> declarations = new ArrayList<GoImportDeclaration>();
         for (GoImportDeclarations ids : importDeclarations) {
             Collections.addAll(declarations, ids.getDeclarations());
         }
@@ -109,7 +109,7 @@ public class GoFileUtils {
             return Collections.emptyList();
         }
 
-        List<GoVarDeclaration> vars = new ArrayList<>();
+        List<GoVarDeclaration> vars = new ArrayList<GoVarDeclaration>();
         for (GoVarDeclarations vds : varDeclarations) {
             Collections.addAll(vars, vds.getDeclarations());
         }
@@ -124,10 +124,10 @@ public class GoFileUtils {
 
         GoFunctionDeclaration[] functionDeclarations = psiFile.getFunctions();
         if (functionDeclarations == null) {
-            return new ArrayList<>();
+            return new ArrayList<GoFunctionDeclaration>();
         }
 
-        return new ArrayList<>(Arrays.asList(functionDeclarations));
+        return new ArrayList<GoFunctionDeclaration>(Arrays.asList(functionDeclarations));
     }
 
     public static List<GoMethodDeclaration> getMethodDeclarations(@Nullable GoFile psiFile) {
@@ -137,10 +137,10 @@ public class GoFileUtils {
 
         GoMethodDeclaration[] methodDeclarations = psiFile.getMethods();
         if (methodDeclarations == null) {
-            return new ArrayList<>();
+            return new ArrayList<GoMethodDeclaration>();
         }
 
-        return new ArrayList<>(Arrays.asList(methodDeclarations));
+        return new ArrayList<GoMethodDeclaration>(Arrays.asList(methodDeclarations));
     }
 
     public static List<GoTypeSpec> getTypeSpecs(@Nullable GoFile psiFile) {
@@ -150,10 +150,10 @@ public class GoFileUtils {
 
         GoTypeDeclaration[] typeDeclarations = psiFile.getTypeDeclarations();
         if (typeDeclarations == null) {
-            return new ArrayList<>();
+            return new ArrayList<GoTypeSpec>();
         }
 
-        List<GoTypeSpec> specs = new ArrayList<>();
+        List<GoTypeSpec> specs = new ArrayList<GoTypeSpec>();
         for (GoTypeDeclaration typeDec : typeDeclarations) {
             Collections.addAll(specs, typeDec.getTypeSpecs());
         }

--- a/src/ro/redeul/google/go/lang/psi/utils/GoPsiUtils.java
+++ b/src/ro/redeul/google/go/lang/psi/utils/GoPsiUtils.java
@@ -170,7 +170,7 @@ public class GoPsiUtils {
 
         VirtualFile[] children = packageFilesLocation.getChildren();
 
-        List<GoFile> files = new ArrayList<>();
+        List<GoFile> files = new ArrayList<GoFile>();
 
         for (VirtualFile child : children) {
             if (child.getFileType() != GoFileType.INSTANCE ||
@@ -273,7 +273,7 @@ public class GoPsiUtils {
             return Collections.emptyList();
         }
 
-        List<T> children = new ArrayList<>();
+        List<T> children = new ArrayList<T>();
         for (PsiElement element : node.getChildren()) {
             if (ReflectionCache.isInstance(element, type)) {
                 children.add(type.cast(element));
@@ -289,7 +289,7 @@ public class GoPsiUtils {
             return Collections.emptyList();
         }
 
-        List<PsiElement> children = new ArrayList<>();
+        List<PsiElement> children = new ArrayList<PsiElement>();
         PsiElement child = node.getFirstChild();
         while (child != null) {
             if (isNodeOfType(child, type)) {

--- a/src/ro/redeul/google/go/lang/psi/visitors/GoImportUsageCheckingVisitor.java
+++ b/src/ro/redeul/google/go/lang/psi/visitors/GoImportUsageCheckingVisitor.java
@@ -44,7 +44,7 @@ public class GoImportUsageCheckingVisitor extends GoRecursiveElementVisitor {
     private void checkQualifiedIdentifier(GoLiteralIdentifier identifier) {
         if ( identifier != null && identifier.isQualified() ) {
             if ( imports.remove(identifier.getLocalPackageName()) == null ) {
-                for (String s : new HashSet<>(imports.keySet())) {
+                for (String s : new HashSet<String>(imports.keySet())) {
                     if (s.toLowerCase()
                          .equals(identifier.getLocalPackageName()))  {
                         imports.remove(s);

--- a/src/ro/redeul/google/go/lang/stubs/GoNamesCache.java
+++ b/src/ro/redeul/google/go/lang/stubs/GoNamesCache.java
@@ -59,7 +59,7 @@ public class GoNamesCache {
         Collection<String> keys = index.getAllKeys(GoPackageImportPath.KEY,
                                                    project);
 
-        Collection<String> packagesCollection = new ArrayList<>();
+        Collection<String> packagesCollection = new ArrayList<String>();
 
         for (String key : keys) {
             Collection<GoFile> files = index.get(GoPackageImportPath.KEY, key,
@@ -111,7 +111,7 @@ public class GoNamesCache {
 
         StubIndex index = StubIndex.getInstance();
         GlobalSearchScope scope = getSearchScope(includeNonProjectItems);
-        Collection<NavigationItem> items = new ArrayList<>();
+        Collection<NavigationItem> items = new ArrayList<NavigationItem>();
         for (GoTypeNameDeclaration type : index.get(GoTypeName.KEY, name,
                                                     project, scope)) {
             if (type instanceof NavigationItem) {
@@ -124,7 +124,7 @@ public class GoNamesCache {
 
     @NotNull
     public String[] getAllTypeNames() {
-        HashSet<String> classNames = new HashSet<>();
+        HashSet<String> classNames = new HashSet<String>();
         getAllTypeNames(classNames);
         return classNames.toArray(new String[classNames.size()]);
     }

--- a/src/ro/redeul/google/go/refactoring/inline/InlineLocalVariableActionHandler.java
+++ b/src/ro/redeul/google/go/refactoring/inline/InlineLocalVariableActionHandler.java
@@ -410,8 +410,8 @@ public class InlineLocalVariableActionHandler extends InlineActionHandler {
 
     private static Usage findUsage(final GoLiteralIdentifier identifier, GoPsiElement scope) {
         final String identifierText = identifier.getText();
-        final List<PsiElement> writeUsages = new ArrayList<>();
-        final List<PsiElement> readUsages = new ArrayList<>();
+        final List<PsiElement> writeUsages = new ArrayList<PsiElement>();
+        final List<PsiElement> readUsages = new ArrayList<PsiElement>();
 
         final GoReadWriteAccessDetector detector = new GoReadWriteAccessDetector();
         new GoRecursiveElementVisitor() {

--- a/src/ro/redeul/google/go/refactoring/introduce/ExpressionOccurrenceManager.java
+++ b/src/ro/redeul/google/go/refactoring/introduce/ExpressionOccurrenceManager.java
@@ -30,7 +30,7 @@ class ExpressionOccurrenceManager {
     private static final TokenSet VAR_DECL_TYPE =
             TokenSet.create(VAR_DECLARATION, CONST_DECLARATION, SHORT_VAR_STATEMENT);
 
-    private final List<GoExpr> occurrences = new ArrayList<>();
+    private final List<GoExpr> occurrences = new ArrayList<GoExpr>();
     private final GoExpr expr;
     private final GoFunctionDeclaration parentFunction;
 
@@ -74,7 +74,7 @@ class ExpressionOccurrenceManager {
     }
 
     private Set<PsiElement> getParentsOfIdentifierDeclarations(Map<GoLiteralIdentifier, PsiElement> identifiers) {
-        Set<PsiElement> parents = new HashSet<>();
+        Set<PsiElement> parents = new HashSet<PsiElement>();
         for (PsiElement element : identifiers.values()) {
             GoStatement statement = findParentOfType(element, GoStatement.class);
             if (statement != null) {
@@ -85,7 +85,7 @@ class ExpressionOccurrenceManager {
     }
 
     private Map<GoLiteralIdentifier, PsiElement> getAllLocalIdentifiers() {
-        final Map<GoLiteralIdentifier, PsiElement> identifiers = new HashMap<>();
+        final Map<GoLiteralIdentifier, PsiElement> identifiers = new HashMap<GoLiteralIdentifier, PsiElement>();
         final AtomicBoolean error = new AtomicBoolean(false);
         new GoRecursiveElementVisitor() {
             @Override

--- a/src/ro/redeul/google/go/refactoring/introduce/GoIntroduceHandlerBase.java
+++ b/src/ro/redeul/google/go/refactoring/introduce/GoIntroduceHandlerBase.java
@@ -106,8 +106,8 @@ abstract class GoIntroduceHandlerBase implements RefactoringActionHandler {
     }
 
     List<GoExpr> collectExpressions(PsiFile file, int offset) {
-        Set<TextRange> expressionRanges = new HashSet<>();
-        List<GoExpr> expressions = new ArrayList<>();
+        Set<TextRange> expressionRanges = new HashSet<TextRange>();
+        List<GoExpr> expressions = new ArrayList<GoExpr>();
         for (GoExpr expression = PsiTreeUtil.findElementOfClassAtOffset(file, offset, GoExpr.class, false);
              expression != null;
              expression = PsiTreeUtil.getParentOfType(expression, GoExpr.class)) {

--- a/src/ro/redeul/google/go/refactoring/introduce/GoIntroduceVariableHandler.java
+++ b/src/ro/redeul/google/go/refactoring/introduce/GoIntroduceVariableHandler.java
@@ -84,7 +84,7 @@ public class GoIntroduceVariableHandler extends GoIntroduceVariableHandlerBase {
 
     private List<String> getFunctionResultNames(GoFunctionDeclaration function) {
         int index = 0;
-        List<String> parameterNames = new ArrayList<>();
+        List<String> parameterNames = new ArrayList<String>();
         for (GoFunctionParameter fp : function.getResults()) {
             GoLiteralIdentifier[] identifiers = fp.getIdentifiers();
             // unnamed parameter

--- a/src/ro/redeul/google/go/refactoring/introduce/GoIntroduceVariableHandlerBase.java
+++ b/src/ro/redeul/google/go/refactoring/introduce/GoIntroduceVariableHandlerBase.java
@@ -97,7 +97,7 @@ abstract class GoIntroduceVariableHandlerBase extends GoIntroduceHandlerBase {
     private Map<OccurrencesChooser.ReplaceChoice, List<PsiElement>> fillChoiceMap(GoExpr current,
                                                                                   GoExpr[] occurrences) {
         Map<OccurrencesChooser.ReplaceChoice, List<PsiElement>> map =
-                new LinkedHashMap<>();
+                new LinkedHashMap<OccurrencesChooser.ReplaceChoice, List<PsiElement>>();
         map.put(OccurrencesChooser.ReplaceChoice.NO, Collections.<PsiElement>singletonList(current));
         if (occurrences.length > 1) {
             map.put(OccurrencesChooser.ReplaceChoice.ALL, Arrays.<PsiElement>asList(occurrences));

--- a/src/ro/redeul/google/go/runner/ui/GoTestConfigurationEditorForm.java
+++ b/src/ro/redeul/google/go/runner/ui/GoTestConfigurationEditorForm.java
@@ -41,7 +41,7 @@ public class GoTestConfigurationEditorForm
             }
         });
 
-        Vector<String> myPackages = new Vector<>();
+        Vector<String> myPackages = new Vector<String>();
         Collection<String> allPackages =
             GoNamesCache.getInstance(project).getProjectPackages();
 

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -553,7 +553,7 @@ public class GoSdkUtil {
     public static List<Sdk> getSdkOfType(SdkType sdkType, ProjectJdkTable table) {
         Sdk[] sdks = table.getAllJdks();
 
-        List<Sdk> goSdks = new LinkedList<>();
+        List<Sdk> goSdks = new LinkedList<Sdk>();
         for (Sdk sdk : sdks) {
             if (sdk.getSdkType() == sdkType) {
                 goSdks.add(sdk);

--- a/src/ro/redeul/google/go/services/GoCodeManager.java
+++ b/src/ro/redeul/google/go/services/GoCodeManager.java
@@ -29,7 +29,7 @@ public class GoCodeManager {
     public Collection<GoImportDeclaration> findUnusedImports(GoFile file) {
 
         Map<String, GoImportDeclaration> imports =
-            new HashMap<>();
+            new HashMap<String, GoImportDeclaration>();
 
         for (GoImportDeclarations importDeclarations : file.getImportDeclarations()) {
             for (GoImportDeclaration declaration : importDeclarations.getDeclarations()) {

--- a/src/ro/redeul/google/go/services/GoPsiManager.java
+++ b/src/ro/redeul/google/go/services/GoPsiManager.java
@@ -30,7 +30,7 @@ public class GoPsiManager {
     private static final Logger LOG = Logger.getInstance("ro.redeul.google.go.services.GoPsiManager");
 
     private final ConcurrentMap<GoPsiElement, GoType[]> myCalculatedTypes =
-        new ConcurrentWeakHashMap<>();
+        new ConcurrentWeakHashMap<GoPsiElement, GoType[]>();
 
     private static final RecursionGuard ourGuard =
         RecursionManager.createGuard("goPsiManager");

--- a/src/ro/redeul/google/go/template/TemplateBundle.java
+++ b/src/ro/redeul/google/go/template/TemplateBundle.java
@@ -25,7 +25,7 @@ public class TemplateBundle {
 
         if (bundle == null) {
             bundle = ResourceBundle.getBundle(BUNDLE);
-            ourBundle = new SoftReference<>(bundle);
+            ourBundle = new SoftReference<ResourceBundle>(bundle);
         }
         return bundle;
     }

--- a/src/ro/redeul/google/go/testIntegration/GoTestFinder.java
+++ b/src/ro/redeul/google/go/testIntegration/GoTestFinder.java
@@ -57,7 +57,7 @@ public class GoTestFinder implements TestFinder {
             return Collections.emptyList();
         }
 
-        List<PsiElement> tests = new ArrayList<>();
+        List<PsiElement> tests = new ArrayList<PsiElement>();
         for (VirtualFile virtualFile : file.getParent().getChildren()) {
             if (isTestFile(virtualFile)) {
                 PsiFile psiFile = getPsiFile(containingFile.getProject(), virtualFile);

--- a/src/ro/redeul/google/go/util/expression/FlipBooleanExpression.java
+++ b/src/ro/redeul/google/go/util/expression/FlipBooleanExpression.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import static ro.redeul.google.go.lang.lexer.GoTokenTypes.oCOND_AND;
 
 public class FlipBooleanExpression {
-    private static final Map<IElementType, IElementType> BINARY_FLIP = new HashMap<>();
+    private static final Map<IElementType, IElementType> BINARY_FLIP = new HashMap<IElementType, IElementType>();
 
     private static void addBinaryFlip(IElementType type1, IElementType type2) {
         BINARY_FLIP.put(type1, type2);


### PR DESCRIPTION
Since Mac and Windows versions ship with their own version of Java and it's Java6 not Java7 it's better to revert this.

It also should help issues like #276 never happen again.
