### PR TITLE
make tests pass: fixed test data location detemination + windows newline...

### DIFF
--- a/test/ro/redeul/google/go/GoLightCodeInsightFixtureTestCase.java
+++ b/test/ro/redeul/google/go/GoLightCodeInsightFixtureTestCase.java
@@ -24,6 +24,12 @@ public abstract class GoLightCodeInsightFixtureTestCase
         return (GoFile) myFixture.configureByText(GoFileType.INSTANCE, fileText);
     }
 
+
+    @Override
+    protected String getTestDataPath() {
+        return testDataRoot + getTestDataRelativePath();
+    }
+
     protected String getTestFileName() {
         String baseName = getTestDataPath() + getTestName(true);
         if (new File(baseName + ".test").exists()) {

--- a/test/ro/redeul/google/go/GoPsiTestCase.java
+++ b/test/ro/redeul/google/go/GoPsiTestCase.java
@@ -22,7 +22,7 @@ import ro.redeul.google.go.util.GoTestUtils;
 public abstract class GoPsiTestCase extends PsiTestCase {
 
     protected String getTestDataPath() {
-        return GoTestUtils.getTestDataPath() + getTestDataRelativePath();
+        return "testData/" + getTestDataRelativePath();
     }
 
     protected String getTestDataRelativePath() {

--- a/test/ro/redeul/google/go/annotator/GoAnnotatorHighlightTest.java
+++ b/test/ro/redeul/google/go/annotator/GoAnnotatorHighlightTest.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import org.junit.Assert;
 import ro.redeul.google.go.GoFileType;
 import ro.redeul.google.go.GoLightCodeInsightFixtureTestCase;
@@ -41,7 +42,7 @@ public class GoAnnotatorHighlightTest extends GoLightCodeInsightFixtureTestCase 
         myFixture.addFileToProject("builtin.go", "package builtin\ntype byte byte\ntype int int\n");
         List<String> data;
         data = readInput(getTestDataPath() + getTestName(true) + ".go");
-        String expected = data.get(1).trim();
+        String expected = StringUtil.convertLineSeparators(data.get(1).trim());
         Assert.assertEquals(expected, processFile(data.get(0)).trim());
     }
 

--- a/test/ro/redeul/google/go/completion/GoCompletionTestCase.java
+++ b/test/ro/redeul/google/go/completion/GoCompletionTestCase.java
@@ -50,30 +50,8 @@ public abstract class GoCompletionTestCase
         }
 
         if (testRoot != null && testRoot.isDirectory()) {
-            VfsUtil.processFilesRecursively(
-                testRoot,
-                new FilteringProcessor<VirtualFile>(
-                    new Condition<VirtualFile>() {
-                        @Override
-                        public boolean value(VirtualFile file) {
-                            return !file.isDirectory() &&
-                                !file.getName().equals(
-                                    getTestName(false) + ".go");
-                        }
-                    },
-                    new AdapterProcessor<VirtualFile, String>(
-                        new CommonProcessors.CollectProcessor<String>(files),
-                        new Function<VirtualFile, String>() {
-                            @Override
-                            public String fun(VirtualFile virtualFile) {
-                                return VfsUtil.getRelativePath(virtualFile,
-                                                               testRoot.getParent(),
-                                                               File.separatorChar);
-                            }
-                        }
-                    )
-                ));
-
+            String path = getTestName(false);
+            myFixture.copyDirectoryToProject(path, path);
             files.add(getTestName(false) + File.separator + getTestName(false) + ".go");
         } else {
             files.add(getTestName(false) + ".go");


### PR DESCRIPTION
after the change I can run junit tests without problems finding test data
