### PR TITLE
Disable build options fixes #248

### DIFF
--- a/src/ro/redeul/google/go/ide/GoConfigurableForm.form
+++ b/src/ro/redeul/google/go/ide/GoConfigurableForm.form
@@ -13,7 +13,9 @@
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties/>
+        <properties>
+          <enabled value="false"/>
+        </properties>
         <clientProperties>
           <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
         </clientProperties>
@@ -24,6 +26,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <enabled value="false"/>
               <text resource-bundle="ro/redeul/google/go/GoBundle" key="go.settings.compiler.internal"/>
             </properties>
           </component>
@@ -32,6 +35,7 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <enabled value="false"/>
               <text resource-bundle="ro/redeul/google/go/GoBundle" key="go.settings.compiler.makefile"/>
             </properties>
           </component>
@@ -40,6 +44,7 @@
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <enabled value="false"/>
               <text value="&amp;Go Install"/>
             </properties>
           </component>


### PR DESCRIPTION
This disables the build options for now as we are not using them anyway due to the latest code changes.
@mtoader, if you want me to remove them completely, let me know.

I also think we should maybe cleanup the plugin from them if you think it makes sense? Thanks.
