### PR TITLE
Support terminating statement inspection.

### DIFF
--- a/testdata/inspection/functionDeclaration/withoutReturn.test
+++ b/testdata/inspection/functionDeclaration/withoutReturn.test
@@ -18,6 +18,44 @@ Label:
     return 3
 }
 
+func Ok4() bool {
+    for {
+
+    }
+}
+
+func Ok5() bool {
+    a := 0
+    if a > 0 {
+        return true
+    }else if a < 0 {
+        return true
+    }else{
+        return false
+    }
+}
+
+func Ok6() bool {
+    a := make(chan bool)
+    select {
+    case <-a:
+        return false
+    default:
+        return true
+    }
+}
+
+func Ok7() bool {
+    a := 3
+    switch a {
+    case 1:
+        return false
+    case 2:
+        return true
+    default:
+        return true
+    }
+}
 
 func NoReturn1() int {
 /*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/
@@ -32,3 +70,60 @@ func NoReturn3(a int) (int, int) {
     }
 /*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
 
+func NoReturn4(a int) (int, int) {
+    a := 3
+    for a > 0 {
+
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
+
+func NoReturn5(a int) (int, int) {
+    a := 3
+    if a > 0 {
+        return 0, 0
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
+
+func NoReturn6(a int) (int, int) {
+    a := 3
+    if a > 0 {
+        return 0, 0
+    }else if a < 2 {
+        return 0, 0
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
+
+func NoReturn6(a int) (int, int) {
+    a := 3
+    if a > 0 {
+        return 0, 0
+    }else {
+
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
+
+func NoReturn7(a int) (int, int) {
+    a := 3
+    switch a {
+    case 1:
+        return 0, 0
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
+
+func NoReturn8(a int) (int, int) {
+    a := 3
+    switch a {
+    case 1:
+        return 0, 0
+    default:
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/>
+
+func NoReturn9(a int) (int, int) {
+    a := make(chan bool)
+    select {
+    case <-a:
+        return 0, 0
+    default:
+    }
+/*begin*/}/*end.Function ends without a return statement|AddReturnStmtFix|RemoveFunctionResultFix*/


### PR DESCRIPTION
Follows most of the specification at http://golang.org/ref/spec#Terminating_statements except for "break" statement detection in "for/switch/select" because it is too complicated.
