### PR TITLE
Remove deprecated calls and suppress warnings which can't be fixed

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -37,5 +37,8 @@
     <option name="GENERATE_NO_WARNINGS" value="true" />
     <option name="DEPRECATION" value="false" />
   </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_STRING" value="-Xlint:unchecked" />
+  </component>
 </project>
 

--- a/build-distribution.xml
+++ b/build-distribution.xml
@@ -8,9 +8,9 @@
     <property name="go.plugin" value="${dist}/ro.redeul.google.go.jar"/>
 
     <property name="idea.community.build"
-              location="${dist}/idea-IC-107.SNAPSHOT/"/>
+              location="idea-home/idea-IC-107.SNAPSHOT/"/>
     <property name="go.sdk.build"
-              location="${user.home}/Tools/google-go/release/"/>
+              location="idea-home/go/"/>
 
     <property name="target.platform" value="current"/>
 

--- a/build-package.xml
+++ b/build-package.xml
@@ -7,7 +7,7 @@
     <property name="dist" location="dist"/>
 
     <property name="go.plugin.name" value="ro.redeul.google.go" />
-    <property name="idea.community.build" location="${user.home}/Tools/idea-IU-107.322/" />
+    <property name="idea.community.build" location="${user.home}/Tools/idea-IU-133.193/" />
 
 
     <taskdef name="javac2" classname="com.intellij.ant.Javac2">

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -622,9 +622,9 @@
                 implementation="ro.redeul.google.go.runner.GoTestConfigurationType"/>
         <configurationType
                 implementation="ro.redeul.google.go.runner.GoAppEngineRunConfigurationType"/>
-        <configurationProducer
+        <runConfigurationProducer
                 implementation="ro.redeul.google.go.runner.GoRunConfigurationProducer"/>
-        <configurationProducer
+        <runConfigurationProducer
                 implementation="ro.redeul.google.go.runner.GoTestConfigurationProducer"/>
 
         <liveTemplateContext

--- a/src/ro/redeul/google/go/compilation/CompilationTaskWorker.java
+++ b/src/ro/redeul/google/go/compilation/CompilationTaskWorker.java
@@ -45,12 +45,10 @@ class CompilationTaskWorker {
                     buf.append("\t").append(pair).append("\n");
                 }
 
-                Map<String, String> map = command.getEnvParams();
-                if (map != null) {
-                    buf.append("===== Custom environment:").append("\n");
-                    for (String key : map.keySet()) {
-                        buf.append("\t").append(key).append("=").append(map.get(key)).append("\n");
-                    }
+                Map<String, String> map = command.getEnvironment();
+                buf.append("===== Custom environment:").append("\n");
+                for (String key : map.keySet()) {
+                    buf.append("\t").append(key).append("=").append(map.get(key)).append("\n");
                 }
                 buf.append("===== Working folder:===========================\n");
                 buf.append("\t").append(path).append("\n");

--- a/src/ro/redeul/google/go/compilation/GoCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoCompiler.java
@@ -388,9 +388,7 @@ public class GoCompiler implements TranslatingCompiler {
         command.addParameter(baseOutputPath);
         command.addParameter("-o");
         command.addParameter(outputBinary);
-        command.setEnvParams(new HashMap<String, String>() {{
-            put("GOROOT", sdk.getHomePath());
-        }});
+        command.getEnvironment().put("GOROOT", sdk.getHomePath());
 
         for (VirtualFile file : targetDescription.getThird()) {
             String fileRelativePath = VfsUtil.getRelativePath(file, sourceRoot,
@@ -438,9 +436,7 @@ public class GoCompiler implements TranslatingCompiler {
             fixApplicationExtension(outputApplication, sdk));
         linkCommand.addParameter(outputBinary);
         linkCommand.setWorkDirectory(sourceRoot.getPath());
-        linkCommand.setEnvParams(new HashMap<String, String>() {{
-            put("GOROOT", sdk.getHomePath());
-        }});
+        linkCommand.getEnvironment().put("GOROOT", sdk.getHomePath());
 
         if (compilationTaskWorker.executeTask(linkCommand, sourceRoot.getPath(),
                                               context) == null) {
@@ -488,9 +484,7 @@ public class GoCompiler implements TranslatingCompiler {
         command.addParameter("-o");
         command.addParameter(outputBinary);
         command.setWorkDirectory(sourceRoot.getPath());
-        command.setEnvParams(new HashMap<String, String>() {{
-            put("GOROOT", sdk.getHomePath());
-        }});
+        command.getEnvironment().put("GOROOT", sdk.getHomePath());
 
         for (VirtualFile file : targetDescription.getThird()) {
             String fileRelativePath = VfsUtil.getRelativePath(file, sourceRoot,
@@ -531,9 +525,7 @@ public class GoCompiler implements TranslatingCompiler {
         libraryPackCommand.addParameter("grc");
         libraryPackCommand.addParameter(libraryFile.getPath());
         libraryPackCommand.addParameter(outputBinary);
-        libraryPackCommand.setEnvParams(new HashMap<String, String>() {{
-            put("GOROOT", sdk.getHomePath());
-        }});
+        libraryPackCommand.getEnvironment().put("GOROOT", sdk.getHomePath());
 
         if (compilationTaskWorker.executeTask(libraryPackCommand,
                                               sourceRoot.getPath(),

--- a/src/ro/redeul/google/go/compilation/GoInstallCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoInstallCompiler.java
@@ -59,7 +59,7 @@ public class GoInstallCompiler implements TranslatingCompiler {
 
         envparams.put("GOPATH", GoSdkUtil.prependToGoPath(project.getBasePath()));
 
-        command.setEnvParams(envparams);
+        command.getEnvironment().putAll(envparams);
 
         CompilationTaskWorker compilationTaskWorker = new CompilationTaskWorker(
                 new GoCompilerOutputStreamParser(basePath));

--- a/src/ro/redeul/google/go/compilation/GoMakefileCompiler.java
+++ b/src/ro/redeul/google/go/compilation/GoMakefileCompiler.java
@@ -101,7 +101,7 @@ public class GoMakefileCompiler implements TranslatingCompiler {
             command.addParameter("-e");
             command.addParameter("install");
             command.addParameter("clean");
-            command.setEnvParams(new HashMap<String, String>() {{
+            command.getEnvironment().putAll(new HashMap<String, String>() {{
                 put("GOROOT", projectSdk.getHomePath());
                 put("GOARCH", goSdkData.TARGET_ARCH.getName());
                 put("GOOS", goSdkData.TARGET_OS.getName());

--- a/src/ro/redeul/google/go/config/facet/GoFacetConfiguration.java
+++ b/src/ro/redeul/google/go/config/facet/GoFacetConfiguration.java
@@ -46,12 +46,16 @@ public class GoFacetConfiguration implements FacetConfiguration, PersistentState
         return new FacetEditorTab[]{new GoFacetTab(this, libraries)};
     }
 
+    @Override
+    @Deprecated
     public void readExternal(Element element) throws InvalidDataException {
-//        XmlSerializer.deserializeInto(this, element);
+
     }
 
+    @Override
+    @Deprecated
     public void writeExternal(Element element) throws WriteExternalException {
-//        XmlSerializer.serializeInto(this, element);
+
     }
 
     public Sdk getSdk() {

--- a/src/ro/redeul/google/go/config/ui/GoFacetTab.java
+++ b/src/ro/redeul/google/go/config/ui/GoFacetTab.java
@@ -34,6 +34,7 @@ public class GoFacetTab extends FacetEditorTab {
     private final GoFacetConfiguration facetConfiguration;
     private boolean modified;
 
+    @SuppressWarnings("unchecked")
     public GoFacetTab(GoFacetConfiguration facetConfiguration, List<Sdk> SDKs) {
         this.facetConfiguration = facetConfiguration;
         final DefaultComboBoxModel model = new DefaultComboBoxModel(SDKs.toArray());

--- a/src/ro/redeul/google/go/highlight/GoSyntaxHighlighter.java
+++ b/src/ro/redeul/google/go/highlight/GoSyntaxHighlighter.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.NotNull;
 import ro.redeul.google.go.lang.lexer.GoLexer;
 import ro.redeul.google.go.lang.lexer.GoTokenTypes;
 
-import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,15 +67,15 @@ public class GoSyntaxHighlighter extends SyntaxHighlighterBase
 
     public static final TextAttributesKey IDENTIFIER = createKey(IDENTIFIER_ID, CodeInsightColors.LOCAL_VARIABLE_ATTRIBUTES);
 
-    public static final TextAttributesKey TYPE_NAME = createKey(TYPE_NAME_ID, changeFont(CodeInsightColors.ANNOTATION_NAME_ATTRIBUTES, Font.ITALIC));
+    public static final TextAttributesKey TYPE_NAME = createKey(TYPE_NAME_ID, CodeInsightColors.ANNOTATION_NAME_ATTRIBUTES);
 
-    public static final TextAttributesKey VARIABLE = createKey(VARIABLE_ID, changeFont(CodeInsightColors.INSTANCE_FIELD_ATTRIBUTES, Font.PLAIN));
+    public static final TextAttributesKey VARIABLE = createKey(VARIABLE_ID, CodeInsightColors.INSTANCE_FIELD_ATTRIBUTES);
 
     public static final TextAttributesKey CONST = createKey(CONST_ID, CodeInsightColors.STATIC_FINAL_FIELD_ATTRIBUTES);
 
     public static final TextAttributesKey GLOBAL_VARIABLE = createKey(GLOBAL_VARIABLE_ID, CodeInsightColors.STATIC_FIELD_ATTRIBUTES);
 
-    public static final TextAttributesKey METHOD_DECLARATION = createKey(METHOD_DECLARATION_ID, changeFont(CodeInsightColors.METHOD_DECLARATION_ATTRIBUTES, Font.PLAIN));
+    public static final TextAttributesKey METHOD_DECLARATION = createKey(METHOD_DECLARATION_ID, CodeInsightColors.METHOD_DECLARATION_ATTRIBUTES);
 
     static {
         fillMap(ATTRIBUTES, LINE_COMMENTS, LINE_COMMENT);
@@ -102,13 +101,8 @@ public class GoSyntaxHighlighter extends SyntaxHighlighterBase
         return pack(ATTRIBUTES.get(tokenType));
     }
 
-    private static TextAttributesKey createKey(String externalName, TextAttributes attrs) {
-        return createTextAttributesKey(externalName, attrs);
-    }
-
     private static TextAttributesKey createKey(String externalName, TextAttributesKey fallbackAttrs) {
-        return createTextAttributesKey(externalName,
-                                       fallbackAttrs.getDefaultAttributes());
+        return createTextAttributesKey(externalName, fallbackAttrs);
     }
 
     private static TextAttributes changeFont(TextAttributes under, @JdkConstants.FontStyle int fontStyle) {

--- a/src/ro/redeul/google/go/ide/structureview/GoStructureView.java
+++ b/src/ro/redeul/google/go/ide/structureview/GoStructureView.java
@@ -2,8 +2,10 @@ package ro.redeul.google.go.ide.structureview;
 
 import com.intellij.ide.structureView.*;
 import com.intellij.lang.PsiStructureViewFactory;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * User: jhonny
@@ -14,7 +16,7 @@ public class GoStructureView implements PsiStructureViewFactory {
     public StructureViewBuilder getStructureViewBuilder(final PsiFile psiFile) {
         return new TreeBasedStructureViewBuilder() {
             @NotNull
-            public StructureViewModel createStructureViewModel() {
+            public StructureViewModel createStructureViewModel(@Nullable Editor editor) {
                 return new TextEditorBasedStructureViewModel(psiFile) {
                     @NotNull
                     @Override

--- a/src/ro/redeul/google/go/lang/completion/GoCompletionContributor.java
+++ b/src/ro/redeul/google/go/lang/completion/GoCompletionContributor.java
@@ -61,6 +61,7 @@ public class GoCompletionContributor extends CompletionContributor {
     };
 
     // Check whether a PsiElement is a valid position for a type name.
+    @SuppressWarnings("unchecked")
     private static final PsiElementPattern.Capture<PsiElement> TYPE_DECLARATION = psiElement().withParent(
             psiElement(GoLiteralIdentifier.class).withParent(
                     or(psiElement(GoPsiTypeName.class),             // where type name is expected
@@ -95,6 +96,7 @@ public class GoCompletionContributor extends CompletionContributor {
             );
 
     // Check whether a PsiElement is a valid position for a qualified identifier (identifier with package name).
+    @SuppressWarnings("unchecked")
     public static final PsiElementPattern.Capture<PsiElement> VALID_PACKAGE_NAME_POSITION = psiElement().withParent(
             psiElement(GoLiteralIdentifier.class).withParent(
                     or(psiElement(GoPsiTypeName.class),             // where type name is expected
@@ -114,6 +116,7 @@ public class GoCompletionContributor extends CompletionContributor {
             )
     );
 
+    @SuppressWarnings("unchecked")
     private static final PsiElementPattern.Capture<PsiElement> GO_OR_DEFER_STATEMENT = psiElement().withParent(
             psiElement(GoLiteralIdentifier.class).withParent(
                     psiElement(GoLiteralExpression.class).withParent(
@@ -164,6 +167,7 @@ public class GoCompletionContributor extends CompletionContributor {
             }
         };
 
+    @SuppressWarnings("unchecked")
     public GoCompletionContributor() {
 
 //        extend(CompletionType.BASIC,

--- a/src/ro/redeul/google/go/lang/completion/smartEnter/fixers/FunctionFixer.java
+++ b/src/ro/redeul/google/go/lang/completion/smartEnter/fixers/FunctionFixer.java
@@ -24,6 +24,7 @@ public class FunctionFixer implements SmartEnterFixer {
             GoElementTypes.DEFER_STATEMENT
     );
 
+    @SuppressWarnings("unchecked")
     private static final PsiElementPattern.Capture<GoLiteralFunction> LITERAL_FUNCTION_IN_GO_OR_DEFER =
             psiElement(GoLiteralFunction.class)
             .withParent(

--- a/src/ro/redeul/google/go/lang/psi/impl/expressions/literals/GoLiteralIdentifierImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/expressions/literals/GoLiteralIdentifierImpl.java
@@ -103,6 +103,7 @@ public class GoLiteralIdentifierImpl extends GoPsiElementBase
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     private static final ElementPattern<PsiElement> NO_REFERENCE =
         or(
             psiElement(GoLiteralIdentifier.class)

--- a/src/ro/redeul/google/go/lang/psi/patterns/GoElementPatterns.java
+++ b/src/ro/redeul/google/go/lang/psi/patterns/GoElementPatterns.java
@@ -51,6 +51,7 @@ public class GoElementPatterns {
             psiElement(GoLiteralIdentifier.class)
                     .withParent(GoFunctionDeclaration.class);
 
+    @SuppressWarnings("unchecked")
     public static final ElementPattern<GoLiteralIdentifier> VAR_DECLARATION =
         psiElement(GoLiteralIdentifier.class)
             .withParent(
@@ -75,6 +76,7 @@ public class GoElementPatterns {
         psiElement(GoLiteralIdentifier.class)
             .withParent(GoFunctionParameter.class);
 
+    @SuppressWarnings("unchecked")
     public static final ElementPattern<? extends PsiElement> BLOCK_DECLARATIONS =
         or(
             psiElement(GoShortVarDeclaration.class),

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/LabelReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/LabelReference.java
@@ -23,6 +23,7 @@ import static ro.redeul.google.go.lang.psi.utils.GoPsiUtils.findParentOfType;
 public class LabelReference
     extends GoPsiReference.Single<GoLiteralIdentifier, LabelReference> {
 
+    @SuppressWarnings("unchecked")
     public static final ElementPattern<GoLiteralIdentifier> MATCHER =
         psiElement(GoLiteralIdentifier.class)
             .withParent(

--- a/src/ro/redeul/google/go/lang/psi/resolve/references/TypeNameReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/TypeNameReference.java
@@ -34,6 +34,7 @@ public class TypeNameReference
     public static final ElementPattern<GoPsiTypeName> MATCHER =
         psiElement(GoPsiTypeName.class);
 
+    @SuppressWarnings("unchecked")
     private static final ElementPattern<GoPsiTypeName> TYPE_IN_METHOD_RECEIVER =
             psiElement(GoPsiTypeName.class).withParent(
                     or(

--- a/src/ro/redeul/google/go/refactoring/inline/InlineLocalVariableActionHandler.java
+++ b/src/ro/redeul/google/go/refactoring/inline/InlineLocalVariableActionHandler.java
@@ -61,6 +61,7 @@ import static ro.redeul.google.go.util.EditorUtil.reformatPositions;
 
 public class InlineLocalVariableActionHandler extends InlineActionHandler {
 
+    @SuppressWarnings("unchecked")
     private static final ElementPattern<GoLiteralIdentifier> LOCAL_VAR_DECLARATION =
         psiElement(GoLiteralIdentifier.class)
             .withParent(

--- a/src/ro/redeul/google/go/runner/GoAppEngineApplicationRunner.java
+++ b/src/ro/redeul/google/go/runner/GoAppEngineApplicationRunner.java
@@ -38,8 +38,7 @@ public class GoAppEngineApplicationRunner extends DefaultProgramRunner {
             return null;
         }
 
-        final RunContentBuilder contentBuilder = new RunContentBuilder(project, this, env.getExecutor());
-        contentBuilder.setExecutionResult(executionResult);
+        final RunContentBuilder contentBuilder = new RunContentBuilder(this, executionResult, env);
         contentBuilder.setEnvironment(env);
 
         return contentBuilder.showRunContent(contentToReuse);

--- a/src/ro/redeul/google/go/runner/GoApplicationRunner.java
+++ b/src/ro/redeul/google/go/runner/GoApplicationRunner.java
@@ -39,8 +39,7 @@ public class GoApplicationRunner extends DefaultProgramRunner {
             return null;
         }
 
-        final RunContentBuilder contentBuilder = new RunContentBuilder(project, this, env.getExecutor());
-        contentBuilder.setExecutionResult(executionResult);
+        final RunContentBuilder contentBuilder = new RunContentBuilder(this, executionResult, env);
         contentBuilder.setEnvironment(env);
 
         return contentBuilder.showRunContent(contentToReuse);

--- a/src/ro/redeul/google/go/runner/GoRunConfigurationProducer.java
+++ b/src/ro/redeul/google/go/runner/GoRunConfigurationProducer.java
@@ -4,11 +4,12 @@ import com.intellij.execution.Location;
 import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.RunConfigurationProducer;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.RunConfiguration;
-import com.intellij.execution.junit.RuntimeConfigurationProducer;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
@@ -25,7 +26,7 @@ import java.util.List;
  * Date: Aug 19, 2010
  * Time: 2:49:31 PM
  */
-public class GoRunConfigurationProducer extends RuntimeConfigurationProducer {
+public class GoRunConfigurationProducer extends RunConfigurationProducer {
 
     private PsiElement element;
 
@@ -38,11 +39,19 @@ public class GoRunConfigurationProducer extends RuntimeConfigurationProducer {
     }
 
     @Override
+    public boolean isConfigurationFromContext(RunConfiguration configuration, ConfigurationContext context) {
+        return false;
+    }
+
+    @Override
+    protected boolean setupConfigurationFromContext(RunConfiguration configuration, ConfigurationContext context, Ref sourceElement) {
+        return false;
+    }
+
     public PsiElement getSourceElement() {
         return element;
     }
 
-    @Override
     protected RunnerAndConfigurationSettings createConfigurationByElement(Location location, ConfigurationContext context) {
 
         GoFile goFile = locationToFile(location);
@@ -72,7 +81,7 @@ public class GoRunConfigurationProducer extends RuntimeConfigurationProducer {
 
         element = goFile;
 
-        RunnerAndConfigurationSettings settings = RunManagerEx.getInstanceEx(project).createConfiguration("", getConfigurationFactory());
+        RunnerAndConfigurationSettings settings = RunManagerEx.getInstanceEx(project).createRunConfiguration("", getConfigurationFactory());
         GoApplicationConfiguration applicationConfiguration = (GoApplicationConfiguration) settings.getConfiguration();
 
         final PsiDirectory dir = goFile.getContainingDirectory();
@@ -89,11 +98,6 @@ public class GoRunConfigurationProducer extends RuntimeConfigurationProducer {
         applicationConfiguration.setModule(module);
 
         return settings;
-    }
-
-    @Override
-    public int compareTo(Object o) {
-        return -1;
     }
 
     protected RunnerAndConfigurationSettings findExistingByElement(Location location,

--- a/src/ro/redeul/google/go/runner/ui/GoTestConfigurationEditorForm.java
+++ b/src/ro/redeul/google/go/runner/ui/GoTestConfigurationEditorForm.java
@@ -31,6 +31,7 @@ public class GoTestConfigurationEditorForm
     private ConfigurationModuleSelector moduleSelector;
     private final Project project;
 
+    @SuppressWarnings("unchecked")
     public GoTestConfigurationEditorForm(final Project project) {
         this.project = project;
 

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -119,9 +119,7 @@ public class GoSdkUtil {
             command.setExePath(goCommand);
             command.addParameter("version");
             command.setWorkDirectory(path);
-            command.setEnvParams(new HashMap<String, String>() {{
-                put("GOROOT", path);
-            }});
+            command.getEnvironment().put("GOROOT", path);
 
             ProcessOutput output = new CapturingProcessHandler(
                 command.createProcess(),
@@ -152,9 +150,7 @@ public class GoSdkUtil {
             command.setExePath(goCommand);
             command.addParameter("env");
             command.setWorkDirectory(path);
-            command.setEnvParams(new HashMap<String, String>() {{
-                put("GOROOT", path);
-            }});
+            command.getEnvironment().put("GOROOT", path);
 
             ProcessOutput output = new CapturingProcessHandler(
                 command.createProcess(),

--- a/src/ro/redeul/google/go/tools/dialogs/AddGoSdkDialogForm.java
+++ b/src/ro/redeul/google/go/tools/dialogs/AddGoSdkDialogForm.java
@@ -30,8 +30,8 @@ public class AddGoSdkDialogForm extends DialogWrapper {
         super(canBeParent);
     }
 
-    public AddGoSdkDialogForm(boolean canBeParent, boolean toolkitModalIfPossible) {
-        super(canBeParent, toolkitModalIfPossible);
+    public AddGoSdkDialogForm(Project project, boolean canBeParent, boolean toolkitModalIfPossible) {
+        super(project, canBeParent, toolkitModalIfPossible);
     }
 
     public AddGoSdkDialogForm(Component parent, boolean canBeParent) {


### PR DESCRIPTION
This removes the deprecated method calls from the sources.
It also adds annotations to suppress warnings which can't be fixed normally.
Paths to build the plugin with `ant` are also updated to latest stable IDEA 13.
