### PR TITLE
Change package name to main from src when creating a file in src folder

### DIFF
--- a/src/ro/redeul/google/go/actions/GoTemplatesFactory.java
+++ b/src/ro/redeul/google/go/actions/GoTemplatesFactory.java
@@ -40,12 +40,22 @@ public class GoTemplatesFactory implements FileTemplateGroupDescriptorFactory {
     }
 
     public static PsiElement createFromTemplate(PsiDirectory directory, String name, String fileName, Template template) {
+        String packageName = directory.getName();
+
+        if (packageName.equalsIgnoreCase("src")) {
+            packageName = "main";
+        }
+
+        return createFromTemplate(directory, packageName, name, fileName, template);
+    }
+
+    public static PsiElement createFromTemplate(PsiDirectory directory, String packageName, String name, String fileName, Template template) {
 
         final FileTemplate fileTemplate = FileTemplateManager.getInstance().getInternalTemplate(template.getFile());
 
         Properties properties = new Properties(FileTemplateManager.getInstance().getDefaultProperties());
 
-        properties.setProperty("PACKAGE_NAME", directory.getName());
+        properties.setProperty("PACKAGE_NAME", packageName);
         properties.setProperty("NAME", name);
 
         String text;


### PR DESCRIPTION
This changes the default behavior to create a package called `main` when creating a file in the `src` folder rather that name it `src`.
It's something I've wanted to do in a long time and it seems at least one user bumped into it, @asampal in https://github.com/mtoader/google-go-lang-idea-plugin/issues/309#issuecomment-30096605 
