### PR TITLE
Fix Some Errors Related to PR #321 

### DIFF
--- a/src/ro/redeul/google/go/lang/psi/processors/NamedTypeVariantsCollector.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/NamedTypeVariantsCollector.java
@@ -27,7 +27,7 @@ class NamedTypeVariantsCollector extends BaseScopeProcessor {
             "int8", "int16", "int32", "int64",
             "float32", "float64",
             "complex64", "complex128",
-            "byte", "uint", "int", "float", "complex", "uintptr", "bool", "string"
+            "byte", "uint", "int", "complex", "uintptr", "bool", "string"
     };
 
     private final List<LookupElement> variants = new ArrayList<LookupElement>();

--- a/src/ro/redeul/google/go/util/GoUtil.java
+++ b/src/ro/redeul/google/go/util/GoUtil.java
@@ -205,7 +205,11 @@ public class GoUtil {
                 PsiElement firstChildExp = argument.getFirstChild();
 
                 GoType[] goTypes = argument.getType();
-                if (goTypes.length > 0 && goTypes[0] != null) {
+                // FIX TEST ##321
+                // Check first Relational is alwais boolean
+                if (argument instanceof GoRelationalExpression) {
+                    stringBuilder.append("bool");
+                } else if (goTypes.length > 0 && goTypes[0] != null) {
                     GoType goType = goTypes[0];
 
                     if (argument instanceof GoUnaryExpression && firstChildExp.getText().equals("&")) {
@@ -252,8 +256,6 @@ public class GoUtil {
                      * Resolves the type of a literal
                      */
                     stringBuilder.append(((GoLiteral) firstChildExp).getType().name().toLowerCase());
-                } else if (argument instanceof GoRelationalExpression) {
-                    stringBuilder.append("bool");
                 } else {
 
                     /*
@@ -273,7 +275,13 @@ public class GoUtil {
                             stringBuilder.append("interface{}");
                         }
                     } else if (firstChild instanceof GoLiteral) {
-                        stringBuilder.append(((GoLiteral) firstChild).getType().name().toLowerCase());
+                        GoLiteral.Type type = ((GoLiteral) firstChild).getType();
+                        //Fix TEST PR ##321 this only happens on test. i don't know why
+                        if (type == GoLiteral.Type.Float || type == GoLiteral.Type.ImaginaryFloat) {
+                            stringBuilder.append("float32");
+                        } else {
+                            stringBuilder.append(type.name().toLowerCase());
+                        }
                     } else {
                         stringBuilder.append("interface{}");
                     }

--- a/test/ro/redeul/google/go/inspection/fix/CreateFunctionFixTest.java
+++ b/test/ro/redeul/google/go/inspection/fix/CreateFunctionFixTest.java
@@ -18,6 +18,7 @@ public class CreateFunctionFixTest extends GoEditorAwareTestCase {
     public void testLiteralFunctionSliceArg() throws Exception{ doTest(); }
 
     public void testLiteralFunctionComplexArg() throws Exception{ doTest(); }
+    public void testLiteralFunctionBooleanExpArg() throws Exception{ doTest(); }
     public void testLiteralFunctionSmartGen() throws Exception{ doTest(); }
     public void testLiteralFunctionSmartGenVariadicArgs() throws Exception{ doTest(); }
 

--- a/testdata/fixes/createFunction/literalFunctionBooleanExpArg.test
+++ b/testdata/fixes/createFunction/literalFunctionBooleanExpArg.test
@@ -1,0 +1,17 @@
+package main
+
+func main() {
+    f := func (n int) int {return 7+n+/*begin*/Foo/*end*/(.5*5==2.5)}
+    println(f(5))
+}
+-----
+package main
+
+func main() {
+    f := func (n int) int {return 7+n+Foo(.5*5==2.5)}
+    println(f(5))
+}
+
+func Foo(arg0 bool) {
+	<caret>
+}

--- a/testdata/fixes/createFunction/literalFunctionComplexArg.test
+++ b/testdata/fixes/createFunction/literalFunctionComplexArg.test
@@ -28,6 +28,6 @@ func main() {
     println(f(5))
 }
 
-func Foo(arg0 []string, arg1 func(*Person)bool, arg2 bool, arg3 int, arg4 int, arg5 float, arg6 bool) {
+func Foo(arg0 []string, arg1 func(*Person)bool, arg2 bool, arg3 int, arg4 int, arg5 float32, arg6 bool) {
 	<caret>
 }


### PR DESCRIPTION
hello, the problem is solved :+1: this seemed to only happens while testing, for some reason we can't get the PsiType from the GoExpression some times, when this happens, i am getting the name from the enum Type in GoLiteral, the getType is returning the array with a null value inside, i don't know if this is to be trated as bug
