### PR TITLE
Fix missing 'packages' intention from properties file

### DIFF
--- a/src/ro/redeul/google/go/intentions/GoIntentionsBundle.properties
+++ b/src/ro/redeul/google/go/intentions/GoIntentionsBundle.properties
@@ -3,6 +3,7 @@ intention.category.control.flow=Control Flow
 intention.category.conversions=Conversions
 intention.category.parentheses=Parentheses
 intention.category.statements=Statements
+intention.category.packages=Packages
 intention.category.go/intention.category.control.flow=Control Flow
 intention.category.go/intention.category.conversions=Conversions
 intention.category.go/intention.category.statements=Statements


### PR DESCRIPTION
In #338 I've forgot to introduce a property for the new 'packages' intention so even if in 'Run as Slave IDE' IDEA won't complain it will when you run it in standalone, Sorry.

Thanks.
