### PR TITLE
Enable mismatched types inspection by default

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -694,7 +694,7 @@
                          level="ERROR"
                          implementationClass="ro.redeul.google.go.inspection.ConstantExpressionsInConstDeclarationsInspection"/>
         <localInspection groupName="Google Go" language="Google Go"
-                         enabledByDefault="false"
+                         enabledByDefault="true"
                          shortName="MismatchedTypes"
                          displayName="Highlights mismatched types"
                          level="ERROR"


### PR DESCRIPTION
Since the inspection is not in Annotator, it will not affect the progressing speed of upper-right green indicator, so disabling it by default doesn't make much sense.
