### PR TITLE
Add the run option back to the context menu (fixes #368)

### DIFF
--- a/src/ro/redeul/google/go/runner/GoApplicationConfiguration.java
+++ b/src/ro/redeul/google/go/runner/GoApplicationConfiguration.java
@@ -251,6 +251,11 @@ public class GoApplicationConfiguration extends ModuleBasedConfiguration<GoAppli
         return state;
     }
 
+    @Override
+    public String suggestedName() {
+        return scriptName.equals("") ? "go run" : GoSdkUtil.getVirtualFile(scriptName).getName();
+    }
+
     private String getSdkRootPath(GoSdkData sdkData) {
         if (sdkData.GO_GOROOT_PATH.isEmpty()) {
             File possibleRoot = new File(sdkData.GO_BIN_PATH).getParentFile();


### PR DESCRIPTION
This PR adds back the run option to the go files.
It will detect if the file contains a function called 'main' and it will display the menu.
I'll try and figure out how to do it for the tests files (run the debug option for them).

Thanks.
