### PR TITLE
Fixing for 1.1.2 which moves src and pkg into libexec/

### DIFF
--- a/src/ro/redeul/google/go/config/sdk/GoSdkType.java
+++ b/src/ro/redeul/google/go/config/sdk/GoSdkType.java
@@ -140,7 +140,7 @@ public class GoSdkType extends SdkType {
         if ( sdkData == null )
             return;
 
-        final VirtualFile sdkSourcesRoot = homeDirectory.findFileByRelativePath("src/pkg/");
+        final VirtualFile sdkSourcesRoot = GoSdkUtil.getSdkSourcesRoot(sdk);
 
         if (sdkSourcesRoot != null) {
             sdkSourcesRoot.refresh(false, false);

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -85,10 +85,12 @@ public class GoSdkUtil {
         if (!checkFolderExists(path))
             return null;
 
-        if (!checkFolderExists(path, "src"))
+        // 1.1.2 moves src into go/version/libexec
+        if (!checkFolderExists(path, "src") && !checkFolderExists(path, "libexec", "src"))
             return null;
 
-        if (!checkFolderExists(path, "pkg"))
+        // 1.1.2 moves pkg into go/version/libexec
+        if (!checkFolderExists(path, "pkg") && !checkFolderExists(path, "libexec", "src"))
             return null;
 
         String goCommand = findGoExecutable(path);
@@ -131,6 +133,18 @@ public class GoSdkUtil {
 
         // Well then no go executable for us :(
         return "";
+    }
+
+    public static VirtualFile getSdkSourcesRoot(Sdk sdk) {
+        final VirtualFile homeDirectory = sdk.getHomeDirectory();
+
+        if (checkFolderExists(homeDirectory.getPath(), "src")) {
+            return homeDirectory.findFileByRelativePath("src/pkg");
+        } else if (checkFolderExists(homeDirectory.getPath(), "libexec", "src")) {
+            return homeDirectory.findFileByRelativePath("libexec/src/pkg");
+        }
+
+        return null;
     }
 
     private static GoSdkData findVersion(final String path, String goCommand, GoSdkData data) {


### PR DESCRIPTION
I'm new to golang but it looks like 1.1.2 moved the src and pkg directories into go/version/libexec. This change adds in support for these new locations when adding a new Go SDK to IntelliJ.
