### PR TITLE
Added debug tools menu, improved environment generation, updated readme (fixes #392)

### DIFF
--- a/README 0.9.15.md
+++ b/README 0.9.15.md
@@ -10,9 +10,12 @@ or fixing the existing ones.
 
 This plugin has been tested against IDEA 13.0.1 and PHPStorm 7.0.1 with
 Go 1.2 installed from [golang.org](http://golang.org). While other setups
-may work, there are reported issues with Homebrew installation on Mac OS X.
+may work, there are reported issues with Homebrew installation on Mac OS X. For
+Mac OS X, if you installed Go SDK via Homebrew, point the SDK root directory
+to ``` libexec ``` not to ``` 1.2 ```.
 
 Thank you.
+
 
 Known issues
 ===
@@ -29,3 +32,19 @@ Known issues
  report for it
 - Can't run various processes (like gofmt): sometimes IDEA doesn't seem to be
  aware of the environment variables, please check the ticket here: [IDEA-118483](http://youtrack.jetbrains.com/issue/IDEA-118483)
+- On non-IDEA IDEs it's not possible to create a new project from existing sources.
+ Please create an empty project then put the project files in it.
+
+
+Report an issue
+===
+
+Please use the ``` Tools -> Go Tools -> go plugin Debug internals ``` to get the internal
+state of the plugin and paste that into the ticket. Also please try to include
+a way to reproduce the issue and the full code snipet (if possible) that triggers
+the issue. If not, at least a minimum sample of code that can reproduce the issue
+is welcomed.
+
+NOTE: The above output may contain private or confidential information, be sure
+to filter it first.
+

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              url="http://github.com/mtoader/google-go-lang-idea-plugin">
     <id>ro.redeul.google.go</id>
     <name>golang.org support plugin</name>
-    <version>0.9.15</version>
+    <version>0.9.15-dev</version>
     <vendor email="mtoader@gmail.com" url="http://redeul.ro">mtoader@gmail.com</vendor>
     <description>
         <![CDATA[<h2>Support for Go programming language.</h2>(see <a href="http://golang.org">http://golang.org</a>)
@@ -193,6 +193,29 @@
             </action>
 
             <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </group>
+
+        <group id="Go.Tools.Debug" popup="true" text="go plugin Debug internals"
+               description="Go plugin debug utilites" icon="/icons/go_13x13.png" class="ro.redeul.google.go.actions.NewGoDebugGroup">
+            <action id="Go.Debug.SdkData"
+                    class="ro.redeul.google.go.ide.actions.GoDebugSDK"
+                    text="go sdk data" description="Print the current go sdk data"
+                    icon="/icons/go_13x13.png">
+            </action>
+
+            <action id="Go.Debug.Env"
+                    class="ro.redeul.google.go.ide.actions.GoDebugEnv"
+                    text="go env" description="Print the current go env"
+                    icon="/icons/go_13x13.png">
+            </action>
+
+            <action id="Go.Debug.SysEnv"
+                    class="ro.redeul.google.go.ide.actions.GoDebugSysEnv"
+                    text="system env" description="Print the current System Env"
+                    icon="/icons/go_13x13.png">
+            </action>
+
+            <add-to-group group-id="Go.Tools" anchor="last"/>
         </group>
 
     </actions>

--- a/src/ro/redeul/google/go/actions/NewGoDebugGroup.java
+++ b/src/ro/redeul/google/go/actions/NewGoDebugGroup.java
@@ -1,0 +1,26 @@
+package ro.redeul.google.go.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.module.Module;
+
+public class NewGoDebugGroup extends DefaultActionGroup
+{
+    private static final boolean debugEnabled = true;
+
+    @Override
+    public void update(AnActionEvent e)
+    {
+        super.update(e);
+
+        final Module data = LangDataKeys.MODULE.getData(e.getDataContext());
+        e.getPresentation().setVisible(data != null);
+
+        if (!e.getPresentation().isVisible()) {
+            return;
+        }
+
+        e.getPresentation().setVisible(debugEnabled);
+    }
+}

--- a/src/ro/redeul/google/go/ide/actions/GoCommonDebugAction.java
+++ b/src/ro/redeul/google/go/ide/actions/GoCommonDebugAction.java
@@ -1,0 +1,10 @@
+package ro.redeul.google.go.ide.actions;
+
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.actionSystem.AnAction;
+
+public abstract class GoCommonDebugAction extends AnAction {
+    protected static final String ID = "go Debug Console";
+    protected static String TITLE = "";
+    protected static ConsoleView consoleView;
+}

--- a/src/ro/redeul/google/go/ide/actions/GoDebugEnv.java
+++ b/src/ro/redeul/google/go/ide/actions/GoDebugEnv.java
@@ -1,0 +1,99 @@
+package ro.redeul.google.go.ide.actions;
+
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.EmptyRunnable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowAnchor;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import ro.redeul.google.go.GoIcons;
+import ro.redeul.google.go.config.sdk.GoSdkData;
+import ro.redeul.google.go.sdk.GoSdkUtil;
+
+public class GoDebugEnv extends GoCommonDebugAction {
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent) {
+
+        final Project project = anActionEvent.getData(LangDataKeys.PROJECT);
+
+        if (project == null) {
+            return;
+        }
+
+        if (consoleView == null) {
+            consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).getConsole();
+        }
+
+        Sdk sdk = GoSdkUtil.getGoogleGoSdkForProject(project);
+        if ( sdk == null ) {
+            return;
+        }
+
+        final GoSdkData sdkData = (GoSdkData)sdk.getSdkAdditionalData();
+        if ( sdkData == null ) {
+            return;
+        }
+
+        String goExecName = sdkData.GO_BIN_PATH;
+
+        String projectDir = project.getBasePath();
+
+        if (projectDir == null) {
+            return;
+        }
+
+        FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
+        VirtualFile selectedFile = fileEditorManager.getSelectedFiles()[0];
+        String fileName = selectedFile.getCanonicalPath();
+
+        try {
+            ToolWindowManager manager = ToolWindowManager.getInstance(project);
+            ToolWindow window = manager.getToolWindow(ID);
+
+            if (window == null) {
+                window = manager.registerToolWindow(ID, false, ToolWindowAnchor.BOTTOM);
+
+                ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+                Content content = contentFactory.createContent(consoleView.getComponent(), "go env", false);
+                window.getContentManager().addContent(content);
+                window.setIcon(GoIcons.GO_ICON_13x13);
+                window.setToHideOnEmptyContent(true);
+                window.setTitle(TITLE);
+
+            }
+            window.show(EmptyRunnable.getInstance());
+
+            String[] goEnv = GoSdkUtil.getExtendedGoEnv(sdkData, projectDir, "");
+
+            String command = String.format(
+                    "%s env",
+                    goExecName
+            );
+
+            consoleView.clear();
+
+            Runtime rt = Runtime.getRuntime();
+            Process proc = rt.exec(command, goEnv);
+            OSProcessHandler handler = new OSProcessHandler(proc, null);
+            consoleView.attachToProcess(handler);
+            consoleView.print(String.format("%s -> %s%n", "Project dir", projectDir), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s%n", command), ConsoleViewContentType.NORMAL_OUTPUT);
+            handler.startNotify();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Messages.showErrorDialog("Error while processing go env command.", "Error on go env");
+        }
+    }
+}

--- a/src/ro/redeul/google/go/ide/actions/GoDebugSDK.java
+++ b/src/ro/redeul/google/go/ide/actions/GoDebugSDK.java
@@ -1,0 +1,98 @@
+package ro.redeul.google.go.ide.actions;
+
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.EmptyRunnable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowAnchor;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import ro.redeul.google.go.GoIcons;
+import ro.redeul.google.go.config.sdk.GoSdkData;
+import ro.redeul.google.go.sdk.GoSdkUtil;
+
+public class GoDebugSDK extends GoCommonDebugAction {
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent) {
+
+        final Project project = anActionEvent.getData(LangDataKeys.PROJECT);
+
+        if (project == null) {
+            return;
+        }
+
+        if (consoleView == null) {
+            consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).getConsole();
+        }
+
+        Sdk sdk = GoSdkUtil.getGoogleGoSdkForProject(project);
+        if ( sdk == null ) {
+            return;
+        }
+
+        final GoSdkData sdkData = (GoSdkData)sdk.getSdkAdditionalData();
+        if ( sdkData == null ) {
+            return;
+        }
+
+        String goExecName = sdkData.GO_BIN_PATH;
+
+        String projectDir = project.getBasePath();
+
+        if (projectDir == null) {
+            return;
+        }
+
+        FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
+        VirtualFile selectedFile = fileEditorManager.getSelectedFiles()[0];
+        String fileName = selectedFile.getCanonicalPath();
+
+        try {
+            ToolWindowManager manager = ToolWindowManager.getInstance(project);
+            ToolWindow window = manager.getToolWindow(ID);
+
+            if (window == null) {
+                window = manager.registerToolWindow(ID, false, ToolWindowAnchor.BOTTOM);
+
+                ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+                Content content = contentFactory.createContent(consoleView.getComponent(), "go env", false);
+                window.getContentManager().addContent(content);
+                window.setIcon(GoIcons.GO_ICON_13x13);
+                window.setToHideOnEmptyContent(true);
+                window.setTitle(TITLE);
+
+            }
+            window.show(EmptyRunnable.getInstance());
+
+            consoleView.clear();
+
+            consoleView.print(String.format("%s -> %s%n", "Project dir", projectDir), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "GO_GOROOT_PATH", sdkData.GO_GOROOT_PATH), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "GO_BIN_PATH", sdkData.GO_BIN_PATH), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "GO_GOPATH_PATH", sdkData.GO_GOPATH_PATH), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "TARGET_OS", sdkData.TARGET_OS), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "TARGET_ARCH", sdkData.TARGET_ARCH), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "VERSION_MAJOR", sdkData.VERSION_MAJOR), ConsoleViewContentType.NORMAL_OUTPUT);
+            consoleView.print(String.format("%s -> %s%n", "VERSION_MINOR", sdkData.VERSION_MINOR), ConsoleViewContentType.NORMAL_OUTPUT);
+
+            consoleView.print(String.format("%s -> %n", "Extended Go Env"), ConsoleViewContentType.NORMAL_OUTPUT);
+
+            String[] goEnv = GoSdkUtil.getExtendedGoEnv(sdkData, projectDir, "");
+            for (String goenv : goEnv) {
+                consoleView.print(String.format("%s%n", goenv), ConsoleViewContentType.NORMAL_OUTPUT);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Messages.showErrorDialog("Error while processing go env command.", "Error on go env");
+        }
+    }
+}

--- a/src/ro/redeul/google/go/ide/actions/GoDebugSysEnv.java
+++ b/src/ro/redeul/google/go/ide/actions/GoDebugSysEnv.java
@@ -1,0 +1,93 @@
+package ro.redeul.google.go.ide.actions;
+
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.EmptyRunnable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowAnchor;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import ro.redeul.google.go.GoIcons;
+import ro.redeul.google.go.config.sdk.GoSdkData;
+import ro.redeul.google.go.sdk.GoSdkUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GoDebugSysEnv extends GoCommonDebugAction {
+
+    @Override
+    public void actionPerformed(AnActionEvent anActionEvent) {
+
+        final Project project = anActionEvent.getData(LangDataKeys.PROJECT);
+
+        if (project == null) {
+            return;
+        }
+
+        if (consoleView == null) {
+            consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).getConsole();
+        }
+
+        Sdk sdk = GoSdkUtil.getGoogleGoSdkForProject(project);
+        if ( sdk == null ) {
+            return;
+        }
+
+        final GoSdkData sdkData = (GoSdkData)sdk.getSdkAdditionalData();
+        if ( sdkData == null ) {
+            return;
+        }
+
+        String goExecName = sdkData.GO_BIN_PATH;
+
+        String projectDir = project.getBasePath();
+
+        if (projectDir == null) {
+            return;
+        }
+
+        FileEditorManager fileEditorManager = FileEditorManager.getInstance(project);
+        VirtualFile selectedFile = fileEditorManager.getSelectedFiles()[0];
+        String fileName = selectedFile.getCanonicalPath();
+
+        try {
+            ToolWindowManager manager = ToolWindowManager.getInstance(project);
+            ToolWindow window = manager.getToolWindow(ID);
+
+            if (window == null) {
+                window = manager.registerToolWindow(ID, false, ToolWindowAnchor.BOTTOM);
+
+                ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+                Content content = contentFactory.createContent(consoleView.getComponent(), "System Env", false);
+                window.getContentManager().addContent(content);
+                window.setIcon(GoIcons.GO_ICON_13x13);
+                window.setToHideOnEmptyContent(true);
+                window.setTitle(TITLE);
+
+            }
+            window.show(EmptyRunnable.getInstance());
+
+            String[] sysEnv = GoSdkUtil.convertEnvMapToArray(System.getenv());
+
+            consoleView.clear();
+
+            consoleView.print(String.format("%s -> %s%n", "Project dir", projectDir), ConsoleViewContentType.NORMAL_OUTPUT);
+            for (String env : sysEnv) {
+                consoleView.print(String.format("%s%n", env), ConsoleViewContentType.NORMAL_OUTPUT);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Messages.showErrorDialog("Error while processing go env command.", "Error on go env");
+        }
+    }
+}

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -596,13 +596,39 @@ public class GoSdkUtil {
     }
 
     public static String prependToGoPath(String prependedPath) {
-        return format("%s%s%s", prependedPath, File.pathSeparator,
-                      System.getenv("GOPATH"));
+        String sysGoPath = System.getenv("GOPATH");
+        if (sysGoPath == null || sysGoPath.isEmpty()) {
+            return prependedPath;
+        }
+
+        return format("%s%s%s", prependedPath, File.pathSeparator, sysGoPath);
     }
 
-    public static String appendToGoPath(String prependedPath) {
-        return format("%s%s%s", System.getenv("GOPATH"), File.pathSeparator,
-                prependedPath);
+    public static String appendToGoPath(String appendedPath) {
+        String sysGoPath = System.getenv("GOPATH");
+        if (sysGoPath == null || sysGoPath.isEmpty()) {
+            return appendedPath;
+        }
+
+        return format("%s%s%s", sysGoPath, File.pathSeparator, appendedPath);
+    }
+
+    public static String appendGoPathToPath(String goPath) {
+        String binarizedPath = "";
+        String[] splitGoPath = goPath.split(File.pathSeparator);
+
+        for (String path : splitGoPath) {
+            binarizedPath += path + File.separator + "bin" + File.pathSeparator;
+        }
+
+        binarizedPath = binarizedPath.substring(0, binarizedPath.length()-1);
+
+        String sysPath = System.getenv("PATH");
+        if (sysPath == null || sysPath.isEmpty()) {
+            return binarizedPath;
+        }
+
+        return format("%s%s%s", sysPath, File.pathSeparator, binarizedPath);
     }
 
     public static String getSysGoRootPath() {
@@ -647,8 +673,11 @@ public class GoSdkUtil {
 
     public static Map<String, String> getExtendedSysEnv(GoSdkData sdkData, String projectDir, String envVars) {
         Map<String,String> sysEnv = new HashMap<String, String>(System.getenv());
-        sysEnv.put("GOROOT", getSdkRootPath(sdkData));
-        sysEnv.put("GOPATH", GoSdkUtil.appendToGoPath(projectDir));
+        String goRoot = getSdkRootPath(sdkData);
+        String goPath = appendToGoPath(projectDir);
+        sysEnv.put("GOROOT", goRoot);
+        sysEnv.put("GOPATH", goPath);
+        sysEnv.put("PATH", appendGoPathToPath(goRoot + File.pathSeparator + goPath));
 
         if (envVars.length() > 0) {
             String[] envVarsArray = envVars.split(";");


### PR DESCRIPTION
As the description says:
- I've added some debug options in the `Go Tools` menu so that we can point users to give us meaningful details
- I've fixed some issues with env variables missing on some environments
- `PATH` now has auto-prepended the `GOROOT` and `GOPATH` `bin` folders from each paths (this should fix #392)
- I've updated the readme for this version to contain some extra pointers
