### PR TITLE
Exclude go files for other OS and ARCH in GoNamesCache

### DIFF
--- a/src/ro/redeul/google/go/lang/stubs/GoNamesCache.java
+++ b/src/ro/redeul/google/go/lang/stubs/GoNamesCache.java
@@ -2,12 +2,16 @@ package ro.redeul.google.go.lang.stubs;
 
 import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.stubs.StubIndex;
 import com.intellij.util.containers.HashSet;
 import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
+import ro.redeul.google.go.config.sdk.GoSdkData;
+import ro.redeul.google.go.config.sdk.GoTargetArch;
+import ro.redeul.google.go.config.sdk.GoTargetOs;
 import ro.redeul.google.go.lang.psi.GoFile;
 import ro.redeul.google.go.lang.psi.stubs.index.GoPackageImportPath;
 import ro.redeul.google.go.lang.psi.stubs.index.GoPackageName;
@@ -29,9 +33,33 @@ public class GoNamesCache {
 
     private final Project project;
 
+    private static GoSdkData sdkData;
+
+    private static Collection<String> allOsNames;
+
+    private static Collection<String> linuxExcludeNames;
+    private static Collection<String> windowsExcludeNames;
+    private static Collection<String> darwinExcludeNames;
+    private static Collection<String> freeBsdExcludeNames;
+
+    private static Collection<String> allArchNames;
+
+    private static Collection<String> _386ExcludeNames;
+    private static Collection<String> _amd64ExcludeNames;
+    private static Collection<String> _armExcludeNames;
+
     // TODO: Make this a singleton ?!
     @NotNull
     public static GoNamesCache getInstance(Project project) {
+        if (allOsNames == null) {
+            initExcludeNames();
+        }
+        if (sdkData == null) {
+            Sdk sdk = GoSdkUtil.getGoogleGoSdkForProject(project);
+            if (sdk != null) {
+                sdkData = (GoSdkData)sdk.getSdkAdditionalData();
+            }
+        }
         return new GoNamesCache(project);
     }
 
@@ -79,8 +107,10 @@ public class GoNamesCache {
     public Collection<GoFile> getFilesByPackageName(String packageName) {
         StubIndex index = StubIndex.getInstance();
 
-        return index.safeGet(GoPackageName.KEY, packageName, project,
+        Collection<GoFile> files = index.safeGet(GoPackageName.KEY, packageName, project,
                          GlobalSearchScope.allScope(project), GoFile.class);
+        removeExcludedFiles(files);
+        return files;
     }
 
     public Collection<GoFile> getFilesByPackageImportPath(@NotNull String importPath) {
@@ -91,7 +121,9 @@ public class GoNamesCache {
                                                           @NotNull GlobalSearchScope scope) {
         StubIndex index = StubIndex.getInstance();
 
-        return index.safeGet(GoPackageImportPath.KEY, importPath, project, scope, GoFile.class);
+        Collection<GoFile> files = index.safeGet(GoPackageImportPath.KEY, importPath, project, scope, GoFile.class);
+        removeExcludedFiles(files);
+        return files;
     }
 
 
@@ -158,4 +190,116 @@ public class GoNamesCache {
         return ArrayUtils.EMPTY_STRING_ARRAY;
     }
 
+    public void removeExcludedFiles(Collection<GoFile> files) {
+        if (sdkData == null) {
+            return;
+        }
+        String goos = System.getenv("GOOS");
+        GoTargetOs targetOs = GoTargetOs.fromString(goos);
+        if (targetOs == null) {
+            targetOs = sdkData.TARGET_OS;
+        }
+        Collection<String> excludeOsNames;
+        switch (targetOs) {
+            case Windows:
+                excludeOsNames = windowsExcludeNames;
+                break;
+            case Linux:
+                excludeOsNames = linuxExcludeNames;
+                break;
+            case Darwin:
+                excludeOsNames = darwinExcludeNames;
+                break;
+            case FreeBsd:
+                excludeOsNames = freeBsdExcludeNames;
+                break;
+            default:
+                excludeOsNames = new ArrayList<String>();
+        }
+        Collection<GoFile> osExcluded = new ArrayList<GoFile>();
+        for (GoFile file:files) {
+            String filename = file.getName();
+            for (String excludeName:excludeOsNames) {
+                if (filename.contains(excludeName)) {
+                    osExcluded.add(file);
+                }
+            }
+        }
+        files.removeAll(osExcluded);
+
+        String goarch = System.getenv("GOARCH");
+        GoTargetArch targetArch = GoTargetArch.fromString(goarch);
+        if (targetArch == null) {
+            targetArch = sdkData.TARGET_ARCH;
+        }
+        Collection<String> excludeArchNames;
+        switch (targetArch) {
+            case _386:
+                excludeArchNames = _386ExcludeNames;
+                break;
+            case _amd64:
+                excludeArchNames = _amd64ExcludeNames;
+                break;
+            case _arm:
+                excludeArchNames = _armExcludeNames;
+                break;
+            default:
+                excludeArchNames = new ArrayList<String>();
+        }
+
+        Collection<GoFile> archExcluded = new ArrayList<GoFile>();
+        for (GoFile file:files) {
+            String filename = file.getName();
+            for (String excludeName:excludeArchNames) {
+                if (filename.contains(excludeName)) {
+                    archExcluded.add(file);
+                }
+            }
+        }
+        files.removeAll(archExcluded);
+    }
+
+    private static void initExcludeNames() {
+        allOsNames = new HashSet<String>();
+        allOsNames.add("_unix");
+        allOsNames.add("_linux");
+        allOsNames.add("_darwin");
+        allOsNames.add("_bsd");
+        allOsNames.add("_netbsd");
+        allOsNames.add("_freebsd");
+        allOsNames.add("_openbsd");
+        allOsNames.add("_dragonfly");
+        allOsNames.add("_windows");
+        allOsNames.add("_plan9");
+
+        linuxExcludeNames = new HashSet<String>(allOsNames);
+        linuxExcludeNames.remove("_linux");
+        linuxExcludeNames.remove("_unix");
+
+        windowsExcludeNames = new HashSet<String>(allOsNames);
+        windowsExcludeNames.remove("_windows");
+
+        darwinExcludeNames = new HashSet<String>(allOsNames);
+        darwinExcludeNames.remove("_darwin");
+        darwinExcludeNames.remove("_unix");
+
+        freeBsdExcludeNames = new HashSet<String>(allOsNames);
+        freeBsdExcludeNames.remove("_freebsd");
+        freeBsdExcludeNames.remove("_bsd");
+        freeBsdExcludeNames.remove("_unix");
+
+        allArchNames = new HashSet<String>();
+        allArchNames.add("_386");
+        allArchNames.add("_amd64");
+        allArchNames.add("_arm");
+
+        _386ExcludeNames = new HashSet<String>(allArchNames);
+        _386ExcludeNames.remove("_386");
+
+        _amd64ExcludeNames = new HashSet<String>(allArchNames);
+        _amd64ExcludeNames.remove("_amd64");
+
+        _armExcludeNames = new HashSet<String>(allArchNames);
+        _armExcludeNames.remove("_arm");
+    }
 }


### PR DESCRIPTION
This will dramatically increase resolving speed for files that imports "runtime", "syscall", "net", etc.
And also remove duplication in completion list.

The target OS/ARCH in GoSdkData is actually host OS/ARCH, but if user want to develop for other OS/ARCH, he can set environment variable "GOOS"/"GOARCH", then those will be used to exclude files.
