### PR TITLE
Add detection of missing GOROOT and GOPATH (fixes #422)

### DIFF
--- a/Missing ENV.md
+++ b/Missing ENV.md
@@ -1,0 +1,31 @@
+Fix missing environment paths
+===
+
+Sometimes IDEA won't properly detect the environment paths properly.
+This can happen becuase of many reasons, especially on Mac OS X and Linux,
+Windows is not reported to have similar issues.
+
+Usually, the simplest way to fix this is to launch IDEA from the command line.
+If that doesn't work then read on:
+
+- Linux
+--
+
+You need to set ``` GOROOT ``` and ``` GOPATH ``` in ``` /etc/environment ```
+to match the current values from your ``` .profile ```, ``` .bashrc ``` or ``` .zshrc ```
+After that, you need to restart your system for the changes to take effect.
+
+
+- Mac OS X
+--
+
+If you are launching the IDE the normal application launcher and you get the error message
+about missing paths then you need to add ``` GOROOT ``` and ``` GOPATH ``` to your ``` ~/.profile ```
+and then use: ```` launchctl setenv GOPATH $GOPATH ````.
+You can view more [details here](https://github.com/mtoader/google-go-lang-idea-plugin/issues/318#issuecomment-31303939).
+
+
+NOTE
+===
+
+Don't forget to keep the values in sync.

--- a/src/ro/redeul/google/go/components/ProjectSdkValidator.java
+++ b/src/ro/redeul/google/go/components/ProjectSdkValidator.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.startup.StartupManager;
+import com.intellij.openapi.ui.Messages;
 import ro.redeul.google.go.config.sdk.GoAppEngineSdkData;
 import ro.redeul.google.go.config.sdk.GoAppEngineSdkType;
 import ro.redeul.google.go.config.sdk.GoSdkData;
@@ -94,7 +96,28 @@ public class ProjectSdkValidator extends AbstractProjectComponent {
             }
         }
 
-        super.initComponent();    //To change body of overridden methods use File | Settings | File Templates.
+        String msg = "";
+
+        if (GoSdkUtil.getSysGoRootPath().isEmpty()) {
+            msg += "GOROOT environment variable is empty\n";
+        }
+
+        if (GoSdkUtil.getSysGoPathPath().isEmpty()) {
+            msg += "GOPATH environment variable is empty\n";
+        }
+
+        final String message = msg;
+
+        if (!message.isEmpty()) {
+            StartupManager.getInstance(myProject).registerPostStartupActivity(new Runnable() {
+                public void run() {
+                    String msg = message + "Please check the readme here: http://git.io/_InSxQ";
+                    Messages.showErrorDialog(myProject, msg, "GOlang: Missing Environment Variables");
+                }
+            });
+        }
+
+        super.initComponent();
     }
 
     private String getContent(String type, String name) {


### PR DESCRIPTION
This will display a nice error message when the IDE starts without a proper detected `GOROOT` and `GOPATH`.

The error message contains a link to the `Missing ENV.md` which should (be tested and) work after this PR is merged.
