### PR TITLE
Automatically add GOPATH to SDK paths even when only one dir is in GOPATH

### DIFF
--- a/src/ro/redeul/google/go/config/sdk/GoSdkType.java
+++ b/src/ro/redeul/google/go/config/sdk/GoSdkType.java
@@ -151,9 +151,7 @@ public class GoSdkType extends SdkType {
         VirtualFile goPathDirectory;
         VirtualFile pathSourcesRoot = null;
 
-        if (goPathFirst != null &&
-                !goPathFirst.equals("") &&
-                goPathFirst.contains(File.pathSeparator)) {
+        if (goPathFirst != null && !goPathFirst.equals("")) {
 
             // If there are multiple directories under GOPATH then we extract only the first one
             if (goPathFirst.contains(File.pathSeparator)) {


### PR DESCRIPTION
The first directory of GOPATH should always be added to the SDK path.
Since PHPStorm users can't add it manually we need to do it for them.
Also it's easier this way for IDEA users as well.
