### PR TITLE
Improve runtime check for goroot inside gopath (fixes #483)

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -2,7 +2,7 @@
              url="http://github.com/mtoader/google-go-lang-idea-plugin">
     <id>ro.redeul.google.go</id>
     <name>Go language (golang.org) support plugin</name>
-    <version>0.9.15.1</version>
+    <version>0.9.15.2</version>
     <vendor email="mtoader@gmail.com" url="http://redeul.ro">mtoader@gmail.com</vendor>
     <description>
         <![CDATA[<h2>Support for Go programming language.</h2>(see <a href="http://golang.org">http://golang.org</a>)

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -622,6 +622,7 @@ public class GoSdkUtil {
                   : format("%s%s%s", sysPath, File.pathSeparator, binarizedPath);
     }
 
+    @NotNull
     public static String getSysGoRootPath() {
         return getEnvVariable("GOROOT");
     }


### PR DESCRIPTION
This is now properly checking for goroot inside gopath by enumerating in all directories listed inside gopath.
Also it will append the `File.separator` char to the paths so that issues like the one reported in #483 don't happen again and prevent:

```
GOPATH="/home/rambocoder/go/path"
GOROOT="/home/rambocoder/go/"
```
