### PR TITLE
Include support for webstorm now

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -106,10 +106,7 @@
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="idea-features.xml">com.intellij.modules.java</depends>
-    <depends optional="true" config-file="non-idea-features.xml">com.intellij.modules.ruby</depends>
-    <depends optional="true" config-file="non-idea-features.xml">com.intellij.modules.python</depends>
-    <depends optional="true" config-file="non-idea-features.xml">com.intellij.modules.objc-</depends>
-    <depends optional="true" config-file="non-idea-features.xml">com.jetbrains.php</depends>
+    <depends optional="true" config-file="non-idea-features.xml">com.intellij.modules.xml</depends>
 
     <application-components>
         <component>


### PR DESCRIPTION
So, I've did a round check, WebStorm doesn't support this as there's no known way to target it via xmls.
I've updated it based on the directions here and testing: http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products

Currently I've tested it with IDEA, PHPStorm and RubyMine. AppCode and PyCharm should automatically get support for it once their platforms reach 133.326 (I don't plan to make it work below that, sorry).
