### PR TITLE
Added TravisCI build icon to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Google go language plugin is an attempt to build an outstanding IDE for
 [Google Go language](http://golang.org) using Intellij IDEA.
 
+[![Build Status](https://travis-ci.org/go-lang-plugin-org/go-lang-idea-plugin.png?branch=master)](https://travis-ci.org/go-lang-plugin-org/go-lang-idea-plugin)
+
 + Project pages on github:
     + <http://github.com/go-lang-plugin-org/go-lang-idea-plugin>
     + <http://wiki.github.com/go-lang-plugin-org/go-lang-idea-plugin/> (wiki)


### PR DESCRIPTION
We still need to activate TravisCI support from GitHub hooks and from TravisCI so that we get it up and running properly.
