### PR TITLE
Revert to Java6 support again

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -31,7 +31,7 @@
         <processorPath useClasspath="true" />
       </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel target="1.7" />
+    <bytecodeTargetLevel target="1.6" />
   </component>
   <component name="EclipseCompilerSettings">
     <option name="GENERATE_NO_WARNINGS" value="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -294,7 +294,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IC-133.SNAPSHOT" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA IC-133.SNAPSHOT" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ResourceManagerContainer">

--- a/src/ro/redeul/google/go/lang/lexer/_GoLexer.java
+++ b/src/ro/redeul/google/go/lang/lexer/_GoLexer.java
@@ -1244,8 +1244,8 @@ public class _GoLexer implements FlexLexer, GoTokenTypes {
 
   /* user code: */
 
-  private Stack <IElementType> gStringStack = new Stack<>();
-  private Stack <IElementType> blockStack = new Stack<>();
+  private Stack <IElementType> gStringStack = new Stack<IElementType>();
+  private Stack <IElementType> blockStack = new Stack<IElementType>();
 
   private int afterComment = YYINITIAL;
   private int afterNls = YYINITIAL;
@@ -1256,7 +1256,7 @@ public class _GoLexer implements FlexLexer, GoTokenTypes {
     blockStack.clear();
   }
 
-  private Stack<IElementType> braceCount = new Stack <>();
+  private Stack<IElementType> braceCount = new Stack <IElementType>();
 
 
 


### PR DESCRIPTION
In the commit that fixed the rune and `'\'` case, the target language for the plugin was changed from 1.6 to 1.7 but there are still many users that have their JVM for IDEA bound to 1.6.
Until JetBrains finally ships all IDEs with Java7 support we should leave it like this.
