### PR TITLE
Fix nil assignability

### DIFF
--- a/src/ro/redeul/google/go/util/GoTypeInspectUtil.java
+++ b/src/ro/redeul/google/go/util/GoTypeInspectUtil.java
@@ -64,7 +64,7 @@ public class GoTypeInspectUtil {
                     resolved instanceof GoPsiTypePointer ||
                     resolved instanceof GoPsiTypeSlice ||
                     resolved instanceof GoPsiTypeMap ||
-                    resolved instanceof GoPsiTypeArray;
+                    resolved instanceof GoPsiTypeChannel;
         } else if (expr.isConstantExpression()) {
 
             String resolvedTypeName = resolved.getText();

--- a/testdata/inspection/functionCall/funcCall.go
+++ b/testdata/inspection/functionCall/funcCall.go
@@ -99,6 +99,17 @@ func HandleMyFunc(a MyFunc) {
 
 }
 
+func HandleChan(c chan string){
+
+}
+
+func HandleInChan(c <-chan string){
+
+}
+
+func HandleOutChan(c chan<- string){
+
+}
 
 type iFunc interface {
 
@@ -356,6 +367,11 @@ func main() {
 	// HandleMyFunc(MyFunc2(func(map[string]string){})) TODO: should generate "Expression type mismatch, the expected type is MyFunc|CastTypeFix"
 	//issue #520
 	HandleIFunc(nil)
-	HandleArray(nil)
+	HandleArray(/*begin*/nil/*end.Expression type mismatch, the expected type is [3]string|CastTypeFix*/)
 	HandleMap(nil)
+	HandleSlice(nil)
+	HandleChan(nil)
+	HandleInChan(nil)
+	HandleOutChan(nil)
+	Accept(nil)
 }


### PR DESCRIPTION
Fix issue #520 for channel and array types.

From golang specs http://golang.org/ref/spec#Assignability:

A value nil is assignable to a variable of type T in cases when T is a pointer, function, slice, map, channel, or interface type.
