### PR TITLE
Fix channel expression result count

### DIFF
--- a/src/ro/redeul/google/go/inspection/InspectionUtil.java
+++ b/src/ro/redeul/google/go/inspection/InspectionUtil.java
@@ -33,7 +33,7 @@ public class InspectionUtil {
     public static int getExpressionResultCount(GoExpr call) {
         if (call instanceof GoLiteralExpression
                 || call instanceof GoBinaryExpression
-                || call instanceof GoUnaryExpression
+                || (call instanceof GoUnaryExpression && ((GoUnaryExpression) call).getUnaryOp() != GoUnaryExpression.Op.Channel)
                 || call instanceof GoParenthesisedExpression
                 || call instanceof GoSelectorExpression
                 ) {

--- a/testdata/inspection/functionReturnParameter/returnParameterCountMismatch.go
+++ b/testdata/inspection/functionReturnParameter/returnParameterCountMismatch.go
@@ -96,4 +96,13 @@ func (t *StructT) MethodGet() func(string,string)bool {
 	return t.Method1
 }
 
+func testChan() {
+	ch := make(chan int)
+	go func() {
+		if _, ok := <- ch; ok {
+
+		}
+	}()
+	ch <- 1
+}
 


### PR DESCRIPTION
Plugin shows argument count mismatch error when value assigned from channel.

```
package main

import "fmt"

func main() {
    ch := make(chan int)
    go func() {
        if val, ok := <-ch; ok {
            fmt.Print(val)
        }
    }()
    ch <- 1
}
```
