### PR TITLE
Fix type of float and complex untyped constant when it is assigned to a variable of interface type or the blank identifier (fixes #474)

### DIFF
--- a/src/ro/redeul/google/go/lang/psi/impl/expressions/primary/GoLiteralExpressionImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/expressions/primary/GoLiteralExpressionImpl.java
@@ -82,7 +82,7 @@ public class GoLiteralExpressionImpl extends GoExpressionBase
 
                 case Float:
                     return new GoType[]{
-                            GoTypes.getBuiltin(Builtin.Float32, namesCache)
+                            GoTypes.getBuiltin(Builtin.Float64, namesCache)
                     };
 
                 case Char:
@@ -93,7 +93,7 @@ public class GoLiteralExpressionImpl extends GoExpressionBase
                 case ImaginaryInt:
                 case ImaginaryFloat:
                     return new GoType[]{
-                            GoTypes.getBuiltin(Builtin.Complex64, namesCache)
+                            GoTypes.getBuiltin(Builtin.Complex128, namesCache)
                     };
 
                 case RawString:

--- a/testdata/inspection/functionCall/funcCall.go
+++ b/testdata/inspection/functionCall/funcCall.go
@@ -224,6 +224,10 @@ func main() {
 	AcceptMyInt(/*begin*/invalid/*end.Expression type mismatch, the expected type is MyInt|CastTypeFix*/)
 	//END
 
+	// issue #474
+	fVal := 0.1
+	MatchF(fVal)
+
 	MatchByte(1)
 	MatchByte(/*begin*/-128/*end.Expression type mismatch, the expected type is byte|CastTypeFix*/)
 	MatchByte(128)

--- a/testdata/psi/completion/general/HandleComplexBuiltinFunction.go
+++ b/testdata/psi/completion/general/HandleComplexBuiltinFunction.go
@@ -1,6 +1,6 @@
 package main
 
-func (*complex64) Method() {
+func (*complex128) Method() {
 
 }
 

--- a/testdata/psi/completion/general/HandleRealBuiltinFunction.go
+++ b/testdata/psi/completion/general/HandleRealBuiltinFunction.go
@@ -1,6 +1,6 @@
 package main
 
-func (*float32) Method() {
+func (*float64) Method() {
 
 }
 


### PR DESCRIPTION
According to the specification: http://golang.org/ref/spec#Assignments :

If an untyped constant is assigned to a variable of interface type or the blank identifier, the constant is first converted to type bool, rune, int, float64, complex128 or string respectively, depending on whether the value is a boolean, rune, integer, floating-point, complex, or string constant.

fixed issue #474
