### PR TITLE
Fix regex for cases when parsing minimal GDB response

### DIFF
--- a/src/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
+++ b/src/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
@@ -862,7 +862,7 @@ public class GdbMiParser2 {
                 "(?:func=\"([^\"]+)\")?,?";
 
         if (hasArgs) {
-            pattern += "(?:args=\\[(.*?)\\])?,";
+            pattern += "(?:args=\\[(.*?)\\])?,?";
         }
 
         pattern += "(?:file=\"([^\"]+)\")?,?" +


### PR DESCRIPTION
It is possible to receive an extremely minimal response from GDB.  Using this simple exampe:

``` go
package main

import "fmt"

func main() {

    fmt.Printf("Hello world!")
}
```

If a breakpoint is added on the fmt.Printf(), it breaks as one would expect.  If you then "step over" the break as your next action, GDB returns the following output:

`{addr="0x00002033",func="main.main",args=[]}`

This causes an OutOfBoundsArrayException when parsing the line, since the comma after `args=[]` is required by the regex.  This output lacks anything after the args param, so the regex doesn't match, which causes the parsing to fail

This fix makes the trailing comma in the args regex optional.

I was going to add a unit test to cover this scenario, but the structure of the code (lots of private and static private) methods made testing this explicit problem difficult.
