### PR TITLE
Skip inspection if the function declaration is inside a type declaration (fixes #437)

### DIFF
--- a/src/ro/redeul/google/go/findUsages/GoVariableUsageStatVisitor2.java
+++ b/src/ro/redeul/google/go/findUsages/GoVariableUsageStatVisitor2.java
@@ -13,6 +13,7 @@ import ro.redeul.google.go.lang.psi.declarations.GoVarDeclaration;
 import ro.redeul.google.go.lang.psi.expressions.GoExpr;
 import ro.redeul.google.go.lang.psi.expressions.literals.GoLiteralIdentifier;
 import ro.redeul.google.go.lang.psi.expressions.primary.GoLiteralExpression;
+import ro.redeul.google.go.lang.psi.impl.types.GoPsiTypeFunctionImpl;
 import ro.redeul.google.go.lang.psi.processors.GoNamesUtil;
 import ro.redeul.google.go.lang.psi.statements.GoShortVarDeclaration;
 import ro.redeul.google.go.lang.psi.toplevel.GoFunctionDeclaration;
@@ -91,6 +92,10 @@ public class GoVariableUsageStatVisitor2 extends GoRecursiveElementVisitor {
                     }
                     continue;
                 }
+            }
+
+            if (declaration.getParent().getParent().getParent() instanceof GoPsiTypeFunctionImpl) {
+                continue;
             }
 
             if (PARAMETER_DECLARATION.accepts(declaration)) {

--- a/testdata/inspection/unusedVariable/unusedParameter.go
+++ b/testdata/inspection/unusedVariable/unusedParameter.go
@@ -1,5 +1,11 @@
 package main
 
+type demo func(a int, b string)
+
+type demo struct {
+    demo func(a int, b string)
+}
+
 func Foo(a int, /*begin*/b/*end.Unused parameter 'b'*/, _ int) int {
     return a + 2
 }


### PR DESCRIPTION
This fixes the inspection for unused parameters when the function is inside a type declaration.
