### PR TITLE
GdbMiParser2.parseLine throws exception when given empty line.

### DIFF
--- a/src/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
+++ b/src/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
@@ -126,6 +126,9 @@ public class GdbMiParser2 {
     }
 
     private Boolean isGdbMiLine(String line) {
+        if (line.length() < 1) {
+            return false;
+        }
         if (START_TOKENS.contains(line.substring(0, 1))) {
             return true;
         }


### PR DESCRIPTION
Checks for empty line before `substring(0, 1)`
