### PR TITLE
Fix build on Java 1.6.0_65

### DIFF
--- a/src/ro/redeul/google/go/runner/GoConsoleFilter.java
+++ b/src/ro/redeul/google/go/runner/GoConsoleFilter.java
@@ -6,8 +6,6 @@ import com.intellij.execution.filters.OpenFileHyperlinkInfo;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 
-import java.io.File;
-import java.nio.file.FileSystem;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
`java.nio.file.FileSystem` does not exists on Java 6. Besides, the two imports are not used.
