### PR TITLE
Fixes #639: Debugger Failure when encountering "=" prefixed output

### DIFF
--- a/src/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
+++ b/src/uk/co/cwspencer/gdb/gdbmi/GdbMiParser2.java
@@ -126,10 +126,11 @@ public class GdbMiParser2 {
     }
 
     private Boolean isGdbMiLine(String line) {
-        if (line.length() < 1) {
+        if (line.length() < 2) {
             return false;
         }
-        if (START_TOKENS.contains(line.substring(0, 1))) {
+        if (START_TOKENS.contains(line.substring(0, 1)) &&
+                !line.substring(0, 1).equals(line.substring(1, 2))) {
             return true;
         }
 


### PR DESCRIPTION
**This is a hack**. for some unknown reason, GDB is outputting lines which are clearly stdout from the debugged program, but are not `@` prefixed. This means that lines that happen to start with mi2 control characters are being passed into mi2 parsing functions that themselves do _very little_ validation before `substring`ing everywhere.

That being said, it works, and it should protect against a whole class of invalid parsing (as described in #639).
