### PR TITLE
Add extra logging for SDK discovery.

### DIFF
--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -83,17 +83,24 @@ public class GoSdkUtil {
 
     public static GoSdkData testGoogleGoSdk(String path) {
 
-        if (!checkFolderExists(path))
+        if (!checkFolderExists(path)) {
+            LOG.warn("GO SDK: Could not find root directory @ "+path);
             return null;
+        }
 
-        if (!checkFolderExists(path, "src"))
+        if (!checkFolderExists(path, "src")) {
+            LOG.warn("GO SDK: Could not find src directory @ "+path+"/src");
             return null;
+        }
 
-        if (!checkFolderExists(path, "pkg"))
+        if (!checkFolderExists(path, "pkg")) {
+            LOG.warn("GO SDK: Could not find src directory @ "+path+"/pkg");
             return null;
+        }
 
         String goCommand = findGoExecutable(path);
         if (goCommand.equals("")) {
+            LOG.warn("GO SDK: Could not find go binary in expected locations.");
             return null;
         }
 
@@ -140,7 +147,7 @@ public class GoSdkUtil {
         if (checkFolderExists(homeDirectory.getPath(), "src")) {
             return homeDirectory.findFileByRelativePath("src/pkg");
         }
-
+        LOG.warn("Could not find GO SDK sources root (src/pkg)");
         return null;
     }
 
@@ -220,6 +227,7 @@ public class GoSdkUtil {
         if (data.TARGET_ARCH != null && data.TARGET_OS != null)
             return data;
 
+        LOG.warn("Could not determine Target Arch or OS");
         return null;
     }
 


### PR DESCRIPTION
Often when SDK discovery fails, there is absolutely no indication of why (from a user perspective). This commit adds informative logging to the Event Log, explaining to the user why the go SDK they are trying to load will not work.
