### PR TITLE
Simple ProjectImporter for GoProjects

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -307,11 +307,16 @@
 
         <fileTypeFactory implementation="ro.redeul.google.go.GoFileTypeLoader"/>
 
+        <moduleType id="GO_MODULE" implementationClass="ro.redeul.google.go.ide.GoModuleType" />
+
         <projectService
                 serviceInterface="ro.redeul.google.go.ide.GoProjectSettings"
                 serviceImplementation="ro.redeul.google.go.ide.GoProjectSettings"/>
 
         <projectConfigurable instance="ro.redeul.google.go.ide.GoConfigurable"/>
+
+        <projectImportProvider implementation="ro.redeul.google.go.wizards.importWizard.GoProjectImportProvider" />
+        <projectImportBuilder implementation="ro.redeul.google.go.wizards.importWizard.GoProjectImportBuilder" />
 
         <applicationService
                 serviceInterface="ro.redeul.google.go.options.GoSettings"

--- a/src/ro/redeul/google/go/ide/GoModuleType.java
+++ b/src/ro/redeul/google/go/ide/GoModuleType.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 public class GoModuleType extends ModuleType<GoModuleBuilder> {
 
-    private static final String MODULE_TYPE_ID = "GO_MODULE";
+    public static final String MODULE_TYPE_ID = "GO_MODULE";
 
     public GoModuleType() {
         super(MODULE_TYPE_ID);

--- a/src/ro/redeul/google/go/wizards/importWizard/GoProjectImportBuilder.java
+++ b/src/ro/redeul/google/go/wizards/importWizard/GoProjectImportBuilder.java
@@ -1,0 +1,91 @@
+package ro.redeul.google.go.wizards.importWizard;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.ModifiableModuleModel;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ContentEntry;
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.packaging.artifacts.ModifiableArtifactModel;
+import com.intellij.projectImport.ProjectImportBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import ro.redeul.google.go.GoIcons;
+
+import javax.swing.*;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created by sinz on 01.03.14.
+ */
+public class GoProjectImportBuilder extends ProjectImportBuilder<String> {
+    private static final Logger LOG = Logger.getInstance(GoProjectImportBuilder.class);
+    @NotNull
+    @Override
+    public String getName() {
+        return "Go";
+    }
+
+    @Override
+    public Icon getIcon() {
+        return GoIcons.GO_ICON_13x13;
+    }
+
+    @Override
+    public List<String> getList() {
+        return new ArrayList<String>();
+    }
+
+    @Override
+    public boolean isMarked(String element) {
+        return false;
+    }
+
+    @Override
+    public void setList(List<String> list) throws ConfigurationException {
+    }
+
+    @Override
+    public void setOpenProjectSettingsAfter(boolean on) {
+
+    }
+
+    @Nullable
+    @Override
+    public List<Module> commit(final Project project, ModifiableModuleModel model, ModulesProvider modulesProvider, ModifiableArtifactModel artifactModel) {
+        //Create Module and iml-file
+        final ModifiableModuleModel moduleModel = model != null ? model : ModuleManager.getInstance(project).getModifiableModel();
+        Module myModule = moduleModel.newModule(project.getBasePath() + File.pathSeparator + project.getName() + ".iml", "GO_MODULE");
+        final ModifiableRootModel mrm = ModuleRootManager.getInstance(myModule).getModifiableModel();
+
+        ApplicationManager.getApplication().runWriteAction(new Runnable() {
+            @Override
+            public void run() {
+                //Add the default content entry
+                VirtualFile baseDir = project.getBaseDir();
+                ContentEntry entry = mrm.addContentEntry(baseDir);
+
+                //Set src-folder as SourceFolder, if it exists
+                VirtualFile srcFolder = baseDir.findFileByRelativePath("src");
+                if(srcFolder != null) {
+                    entry.addSourceFolder(srcFolder, false);
+                }
+
+                mrm.commit();
+                moduleModel.commit();
+            }
+        });
+
+
+        return Arrays.asList(myModule);
+    }
+}

--- a/src/ro/redeul/google/go/wizards/importWizard/GoProjectImportProvider.java
+++ b/src/ro/redeul/google/go/wizards/importWizard/GoProjectImportProvider.java
@@ -1,0 +1,30 @@
+package ro.redeul.google.go.wizards.importWizard;
+
+import com.intellij.ide.util.projectWizard.ModuleWizardStep;
+import com.intellij.ide.util.projectWizard.ProjectWizardStepFactory;
+import com.intellij.ide.util.projectWizard.WizardContext;
+import com.intellij.openapi.projectRoots.SdkType;
+import com.intellij.openapi.util.Computable;
+import com.intellij.projectImport.ProjectImportBuilder;
+import com.intellij.projectImport.ProjectImportProvider;
+import ro.redeul.google.go.config.sdk.GoSdkType;
+import ro.redeul.google.go.ide.GoModuleBuilder;
+
+/**
+ * Created by sinz on 01.03.14.
+ */
+public class GoProjectImportProvider extends ProjectImportProvider {
+    protected GoProjectImportProvider(final GoProjectImportBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    public ModuleWizardStep[] createSteps(WizardContext context) {
+        ProjectWizardStepFactory factory = ProjectWizardStepFactory.getInstance();
+
+        //Add a step into the importer, with which the user can choose the used Go SDK
+        return new ModuleWizardStep[] {factory.createProjectJdkStep(context,
+			SdkType.findInstance(GoSdkType.class), new GoModuleBuilder(),
+			new Computable.PredefinedValueComputable<Boolean>(true), null, "")};
+    }
+}


### PR DESCRIPTION
Created a Simple Project Importer, which creates a module for the new project
and marks the "src" folder as SourceRoot, if it exists(even though we don't make use of this feature).

During the Process, the user can choose the Go-SDK, which will be used.

In order to use the Importer, the User has to choose the "Go"-External Model. "Import from existing source" would require us to have a single project-file, which stores all the information about the project (similar to .project of eclipse), so it is not suitable for go projects.
#503 #230
