### PR TITLE
Disable Default Run-/Debug- Actions for GaeLocalRunner

### DIFF
--- a/src/ro/redeul/google/go/runner/GaeLocalConfiguration.java
+++ b/src/ro/redeul/google/go/runner/GaeLocalConfiguration.java
@@ -7,6 +7,7 @@ import com.intellij.execution.configurations.*;
 import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.components.PathMacroManager;
 import com.intellij.openapi.module.Module;
@@ -35,7 +36,8 @@ import java.util.Map;
  * Date: Aug 19, 2010
  * Time: 2:53:03 PM
  */
-public class GaeLocalConfiguration extends ModuleBasedConfiguration<GoApplicationModuleBasedConfiguration> {
+public class GaeLocalConfiguration extends ModuleBasedConfiguration<GoApplicationModuleBasedConfiguration>
+                                    implements RunConfigurationWithSuppressedDefaultDebugAction, RunConfigurationWithSuppressedDefaultRunAction {
 
     public String builderArguments;
     public String workingDir;


### PR DESCRIPTION
Currently, when the user has opened a Gae-Project, both Run and Debug are enabled,
When the user presses the Debug-button, the DefaultDebugAction (which does nothing) will be executed,
and the user might think something is broken.

With this patch, DefaultActions (especially Debug right now) will be disabled.
When GaeLocalRunner supports debugging at some point,
the "Debug"-Button inside Intellij will automatically be enabled again
