### PR TITLE
Use the file-name without the extension for new RunConfigurations

### DIFF
--- a/src/ro/redeul/google/go/runner/GoApplicationConfiguration.java
+++ b/src/ro/redeul/google/go/runner/GoApplicationConfiguration.java
@@ -133,7 +133,7 @@ public class GoApplicationConfiguration extends ModuleBasedConfiguration<GoAppli
     @Override
     public String suggestedName() {
         try {
-            return scriptName.equals("") ? "go run" : GoSdkUtil.getVirtualFile(scriptName).getName();
+            return scriptName.equals("") ? "go run" : GoSdkUtil.getVirtualFile(scriptName).getNameWithoutExtension();
         } catch (NullPointerException ignored) {
             return "go run";
         }


### PR DESCRIPTION
RunConfigurations created from the context menu should be called
the same as the source-file without the extension.

e.g. "main.go" -> "main"
#664
