### PR TITLE
Fix project import

### DIFF
--- a/src/ro/redeul/google/go/wizards/importWizard/GoProjectImportBuilder.java
+++ b/src/ro/redeul/google/go/wizards/importWizard/GoProjectImportBuilder.java
@@ -66,6 +66,7 @@ public class GoProjectImportBuilder extends ProjectImportBuilder<String> {
         final ModifiableModuleModel moduleModel = model != null ? model : ModuleManager.getInstance(project).getModifiableModel();
         Module myModule = moduleModel.newModule(project.getBasePath() + File.separator + project.getName() + ".iml", "GO_MODULE");
         final ModifiableRootModel mrm = ModuleRootManager.getInstance(myModule).getModifiableModel();
+        mrm.inheritSdk();
 
         ApplicationManager.getApplication().runWriteAction(new Runnable() {
             @Override


### PR DESCRIPTION
Fixed 2 small bugs within the project importer:
1. i used the wrong separator, so there would be a "Go_Test:Go_Test.iml" outside of the project root
2. The newly created module has to inherit the SDK from the project, otherwise the SDK-sources are not available in the module
