### PR TITLE
Fix for issue #689

### DIFF
--- a/src/ro/redeul/google/go/runner/GoApplicationRunner.java
+++ b/src/ro/redeul/google/go/runner/GoApplicationRunner.java
@@ -78,6 +78,7 @@ public class GoApplicationRunner extends DefaultProgramRunner {
 
             if (GoSdkUtil.isHostOsWindows()) {
                 execName = execName.concat(".exe");
+                execName = execName.replaceAll("\\\\", "/");
             }
 
             final XDebugSession debugSession = XDebuggerManager.getInstance(project).startSession(this,

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -997,7 +997,12 @@ public class GoSdkUtil {
     public static String getPackageOfFile(String projectRoot, String file) {
         String pkg = null;
 
-        if(file.startsWith(projectRoot)) {
+        // More portable solution than "file.startsWith(projectRoot)" as in Windows it creates problem
+        // due to path separator character
+        String root = new File(projectRoot).getAbsolutePath();
+        String child = new File(file).getAbsolutePath();
+
+        if(child.startsWith(root)) {
             String src = File.separator + "src" + File.separator;
 
             String fileFolder = new File(file).getParent();


### PR DESCRIPTION
Windows path separators are not properly handled in Run/Debug
configuration, hence plugin does not work out of the box in Windows. In
this fix I have made the path handling more portable to include Windows
scenario as well.
