### PR TITLE
Fix  GAE local configuration to read its port from the correct value.

### DIFF
--- a/src/ro/redeul/google/go/runner/GaeLocalConfiguration.java
+++ b/src/ro/redeul/google/go/runner/GaeLocalConfiguration.java
@@ -103,7 +103,7 @@ public class GaeLocalConfiguration extends ModuleBasedConfiguration<GoApplicatio
         workingDir = JDOMExternalizerUtil.readField(element, "workingDir");
         envVars = JDOMExternalizerUtil.readField(element, "envVars");
         hostname = JDOMExternalizerUtil.readField(element, "hostname");
-        port = JDOMExternalizerUtil.readField(element, "adminPort");
+        port = JDOMExternalizerUtil.readField(element, "port");
         adminPort = JDOMExternalizerUtil.readField(element, "adminPort");
 
         readModule(element);


### PR DESCRIPTION
Ok, so I guess the best way to fix these issues is to send a patch.  :)

Every time I opened the IDE I had to reset the port on the server port; although we're storing it correctly, we're reading the wrong value on load.
