### PR TITLE
Fix issue 712 - allow for paths with spaces to be used

### DIFF
--- a/src/ro/redeul/google/go/ide/actions/GoFmtFileRunner.java
+++ b/src/ro/redeul/google/go/ide/actions/GoFmtFileRunner.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import ro.redeul.google.go.ide.ui.GoToolWindow;
@@ -60,17 +61,13 @@ public class GoFmtFileRunner extends AnAction {
             FileDocumentManager.getInstance().saveDocument(doc);
         }
         try {
-            String command = String.format(
-                    "%s fmt %s",
-                    goExecName,
-                    fileName
-            );
+            String[] command = {goExecName, "fmt", fileName};
 
             Runtime rt = Runtime.getRuntime();
             Process proc = rt.exec(command, goEnv);
             OSProcessHandler handler = new OSProcessHandler(proc, null);
             toolWindow.attachConsoleViewToProcess(handler);
-            toolWindow.printNormalMessage(String.format("%s%n", command));
+            toolWindow.printNormalMessage(String.format("%s%n", StringUtil.join(command, " ")));
             handler.startNotify();
 
             if (proc.waitFor() == 0) {


### PR DESCRIPTION
...with go fmt executed from tools menu.

This turns up a general problem with the way commands are executed in the go plugin.  Runtime.exec(String) makes generally unsafe assumptions about how to split that string into individual command arguments; it's much safer to use Runtime.exec(String[]), which will preserve the atomicity of each of the individual command arguments and allows spaces to appear anywhere in the argument.

Note that this means that there are other bugs, too - anyone with a space in the path leading to the go executable will also have this problem, but the problem will be in _every_ command executed, as everyone appears to be using the non-cmdArray variant of this method.
