### PR TITLE
Fixed the debug flag setting when application is configured to run/debug

### DIFF
--- a/src/ro/redeul/google/go/runner/GoApplicationConfigurationProducer.java
+++ b/src/ro/redeul/google/go/runner/GoApplicationConfigurationProducer.java
@@ -119,7 +119,7 @@ public class GoApplicationConfigurationProducer extends RunConfigurationProducer
 
             ((GoApplicationConfiguration) configuration).autoStartGdb = true;
             ((GoApplicationConfiguration) configuration).GDB_PATH = "gdb";
-            ((GoApplicationConfiguration) configuration).debugBuilderArguments = "-gcflags \"-N -I\"";
+            ((GoApplicationConfiguration) configuration).debugBuilderArguments = "-gcflags \"-N -l\"";
 
 
             ((GoApplicationConfiguration) configuration).setModule(module);


### PR DESCRIPTION
When you run an application for the first time, IntelliJ will create the app run/debug configuration. The debug gcflags had the wrong options.
