### PR TITLE
Allow creation of projects that use idiomatic golang directory structures

### DIFF
--- a/src/ro/redeul/google/go/ide/GoModuleBuilder.java
+++ b/src/ro/redeul/google/go/ide/GoModuleBuilder.java
@@ -104,8 +104,9 @@ public class GoModuleBuilder extends JavaModuleBuilder implements SourcePathsBui
                 ApplicationManager.getApplication().runWriteAction(new Runnable() {
                     @Override
                     public void run() {
-                        mainPackage.checkCreateFile(projectName.concat(".go"));
-                        GoTemplatesFactory.createFromTemplate(mainPackage, "main", "main", packageName.concat(".go"), GoTemplatesFactory.Template.GoAppMain);
+                        String mainFileName = projectName.concat(".go");
+                        mainPackage.checkCreateFile(mainFileName);
+                        GoTemplatesFactory.createFromTemplate(mainPackage, "main", "main", mainFileName, GoTemplatesFactory.Template.GoAppMain);
                         toolWindow.printNormalMessage(String.format("%nFinished creating package %s from template.%n", packageName));
                         sourceRoots[0].refresh(true, true);
                     }


### PR DESCRIPTION
Currently it is difficult to create a project that uses the idiomatic golang directory structure like this:

```
/bin
/pkg
/src
    /github.com
        /jerejones
            /hello
                hello.go
```

This is because PsiDirectory.createSubdirectory can not create multiple levels at once. This pull request breaks up the project name if it contains path seperators and creates the directories one at a time.

This allows creating a project like this:
![go_new_project](https://cloud.githubusercontent.com/assets/1229385/4110542/e1857c98-31f3-11e4-806b-ce7cec491ee9.png)

To result in this:
![go_project_tree](https://cloud.githubusercontent.com/assets/1229385/4110544/e87b563a-31f3-11e4-866c-6b689ba149a2.png)
