### PR TITLE
Add project level settings to allow running go fmt or goimports on save.

### DIFF
--- a/src/ro/redeul/google/go/components/EditorTweakingComponent.java
+++ b/src/ro/redeul/google/go/components/EditorTweakingComponent.java
@@ -1,5 +1,7 @@
 package ro.redeul.google.go.components;
 
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.editor.Document;
@@ -7,58 +9,153 @@ import com.intellij.openapi.editor.DocumentRunnable;
 import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.text.CharArrayUtil;
 import org.jetbrains.annotations.NotNull;
 import ro.redeul.google.go.GoFileType;
+import ro.redeul.google.go.ide.GoProjectSettings;
+import ro.redeul.google.go.ide.ui.GoToolWindow;
+import ro.redeul.google.go.sdk.GoSdkUtil;
 
 /**
  * @author Mihai Claudiu Toader <mtoader@gmail.com>
  *         Date: Sep 7, 2010
  */
 public class EditorTweakingComponent extends FileDocumentManagerAdapter {
-
     @Override
     public void beforeDocumentSaving(@NotNull final Document document) {
 
         if (!document.isWritable())
             return;
 
-        VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+        final Project[] projects = ProjectManager.getInstance().getOpenProjects();
+        if (projects.length == 0) {
+            return;
+        }
+
+        final VirtualFile file = FileDocumentManager.getInstance().getFile(document);
         if (file == null || file.getFileType() != GoFileType.INSTANCE) {
             return;
         }
 
-        final EditorSettingsExternalizable settings =
-            EditorSettingsExternalizable.getInstance();
+        Project project = null;
+        for (Project possibleProject : projects) {
+            if (ProjectRootManager.getInstance(possibleProject).getFileIndex().getSourceRootForFile(file) != null) {
+               project = possibleProject;
+                break;
+            }
+        }
 
-        if (settings != null && settings.isEnsureNewLineAtEOF()) {
+        if (project == null) {
             return;
         }
 
-        final int lines = document.getLineCount();
-        if (lines > 0) {
-            final int start = document.getLineStartOffset(lines - 1);
-            final int end = document.getLineEndOffset(lines - 1);
-            if (start != end) {
-                ApplicationManager.getApplication().runWriteAction(
-                    new DocumentRunnable(document, null) {
-                        public void run() {
-                            CommandProcessor.getInstance().runUndoTransparentAction(
-                                new Runnable() {
-                                    public void run() {
-                                        CharSequence content = document.getCharsSequence();
-                                        if (CharArrayUtil.containsOnlyWhiteSpaces(
-                                            content.subSequence(start, end))) {
-                                            document.deleteString(start, end);
-                                        } else {
-                                            document.insertString(end, "\n");
-                                        }
-                                    }
-                                });
-                        }
-                    });
+        GoProjectSettings.GoProjectSettingsBean settings = GoProjectSettings.getInstance(project).getState();
+
+        final Project p = project;
+        if (settings.goimportsOnSave) {
+            ApplicationManager.getApplication().invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    ProcessFileWithGoImports(p, file);
+                }
+            });
+        } else if (settings.goFmtOnSave) {
+            ApplicationManager.getApplication().invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    ProcessFileWithGoFmt(p, file);
+                }
+            });
+        }
+    }
+
+    private void ProcessFileWithGoImports(Project project, VirtualFile file) {
+        GoToolWindow toolWindow = GoToolWindow.getInstance(project);
+        toolWindow.setTitle("goimports (file)");
+
+        String fileName = file.getCanonicalPath();
+
+        String projectDir = project.getBasePath();
+        if (projectDir == null) {
+            return;
+        }
+
+        Sdk sdk = GoSdkUtil.getProjectSdk(project);
+        if (sdk == null) {
+            return;
+        }
+
+        String[] goEnv = GoSdkUtil.getGoEnv(sdk, projectDir);
+        if (goEnv == null) {
+            return;
+        }
+
+        try {
+            String[] command = {"goimports", "-w", fileName};
+
+            Runtime rt = Runtime.getRuntime();
+            Process proc = rt.exec(command, goEnv);
+            OSProcessHandler handler = new OSProcessHandler(proc, null);
+            toolWindow.attachConsoleViewToProcess(handler);
+            toolWindow.printNormalMessage(String.format("%s%n", StringUtil.join(command, " ")));
+            handler.startNotify();
+
+            if (proc.waitFor() == 0) {
+                VirtualFileManager.getInstance().syncRefresh();
+                file.refresh(false, false);
             }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Messages.showErrorDialog("Error while processing goimports command.", "Error on goimports");
+        }
+    }
+
+    private void ProcessFileWithGoFmt(Project project, VirtualFile file) {
+        GoToolWindow toolWindow = GoToolWindow.getInstance(project);
+        toolWindow.setTitle("go fmt (file)");
+
+        String fileName = file.getCanonicalPath();
+
+        String projectDir = project.getBasePath();
+        if (projectDir == null) {
+            return;
+        }
+
+        Sdk sdk = GoSdkUtil.getProjectSdk(project);
+        if (sdk == null) {
+            return;
+        }
+
+        String[] goEnv = GoSdkUtil.getGoEnv(sdk, projectDir);
+        if (goEnv == null) {
+            return;
+        }
+
+        try {
+            String[] command = {"gofmt", "-w", fileName};
+
+            Runtime rt = Runtime.getRuntime();
+            Process proc = rt.exec(command, goEnv);
+            OSProcessHandler handler = new OSProcessHandler(proc, null);
+            toolWindow.attachConsoleViewToProcess(handler);
+            toolWindow.printNormalMessage(String.format("%s%n", StringUtil.join(command, " ")));
+            handler.startNotify();
+
+            if (proc.waitFor() == 0) {
+                VirtualFileManager.getInstance().syncRefresh();
+                file.refresh(false, false);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Messages.showErrorDialog("Error while processing go fmt command.", "Error on go fmt");
         }
     }
 }

--- a/src/ro/redeul/google/go/ide/GoConfigurableForm.form
+++ b/src/ro/redeul/google/go/ide/GoConfigurableForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="ro.redeul.google.go.ide.GoConfigurableForm">
-  <grid id="27dc6" binding="componentPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="componentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="583" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <vspacer id="86d62">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="4d48" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -82,6 +82,45 @@
           </component>
         </children>
       </grid>
+      <grid id="86c93" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <clientProperties>
+          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
+        </clientProperties>
+        <border type="etched" title="On Save"/>
+        <children>
+          <component id="b4182" class="javax.swing.JRadioButton" binding="doNothingOnSave" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Do nothing"/>
+            </properties>
+          </component>
+          <component id="e870d" class="javax.swing.JRadioButton" binding="goFmtOnSave" default-binding="true">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text value="go fmt"/>
+            </properties>
+          </component>
+          <component id="2b7c8" class="javax.swing.JRadioButton" binding="goimportsOnSave" default-binding="true">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="goimports"/>
+              <toolTipText value="Requires the goimports binary exist in the path"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
   <buttonGroups>
@@ -89,6 +128,11 @@
       <member id="2c44c"/>
       <member id="9472f"/>
       <member id="4da6"/>
+    </group>
+    <group name="ONSAVE">
+      <member id="b4182"/>
+      <member id="e870d"/>
+      <member id="2b7c8"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/ro/redeul/google/go/ide/GoConfigurableForm.java
+++ b/src/ro/redeul/google/go/ide/GoConfigurableForm.java
@@ -20,6 +20,9 @@ public class GoConfigurableForm {
     private JRadioButton radioGOPATHproject;
     private JRadioButton enablePrependSysGoPath;
     private JRadioButton enableAppendSysGoPath;
+    private JRadioButton doNothingOnSave;
+    private JRadioButton goFmtOnSave;
+    private JRadioButton goimportsOnSave;
 
     public void enableShowHide(){
         componentPanel.addComponentListener(new ComponentAdapter() {
@@ -41,11 +44,6 @@ public class GoConfigurableForm {
 
     public boolean isModified(GoProjectSettings.GoProjectSettingsBean settingsBean,
                               GoSettings goSettings) {
-
-        //if (goSettings.OPTIMIZE_IMPORTS_ON_THE_FLY != enableOnTheFlyImportOptimization.isSelected()) {
-        //    return true;
-        //}
-
         if ( settingsBean.enableOptimizeImports != enableImportsOptimizer.isSelected() ) {
             return true;
         }
@@ -58,21 +56,37 @@ public class GoConfigurableForm {
             return true;
         }
 
+        if ( settingsBean.goFmtOnSave != goFmtOnSave.isSelected() ) {
+            return true;
+        }
+
+        if ( settingsBean.goimportsOnSave != goimportsOnSave.isSelected() ) {
+            return true;
+        }
+
         return false;
     }
 
     public void apply(GoProjectSettings.GoProjectSettingsBean settingsBean) {
-        settingsBean.enableOptimizeImports = enableImportsOptimizer.isSelected();
-        //goSettings.OPTIMIZE_IMPORTS_ON_THE_FLY = enableOnTheFlyImportOptimization.isSelected();
         settingsBean.appendSysGoPath = enableAppendSysGoPath.isSelected();
         settingsBean.prependSysGoPath = enablePrependSysGoPath.isSelected();
+
+        settingsBean.enableOptimizeImports = enableImportsOptimizer.isSelected();
+
+        settingsBean.goFmtOnSave = goFmtOnSave.isSelected();
+        settingsBean.goimportsOnSave = goimportsOnSave.isSelected();
     }
 
     public void reset(GoProjectSettings.GoProjectSettingsBean settingsBean, GoSettings goSettings) {
-        //enableOnTheFlyImportOptimization.setSelected(goSettings.OPTIMIZE_IMPORTS_ON_THE_FLY);
-        enableImportsOptimizer.setSelected(settingsBean.enableOptimizeImports);
+        radioGOPATHproject.setSelected(!settingsBean.appendSysGoPath && !settingsBean.prependSysGoPath);
         enableAppendSysGoPath.setSelected(settingsBean.appendSysGoPath);
         enablePrependSysGoPath.setSelected(settingsBean.prependSysGoPath);
+
+        enableImportsOptimizer.setSelected(settingsBean.enableOptimizeImports);
+
+        doNothingOnSave.setSelected(!settingsBean.goFmtOnSave && !settingsBean.goimportsOnSave);
+        goFmtOnSave.setSelected(settingsBean.goFmtOnSave);
+        goimportsOnSave.setSelected(settingsBean.goimportsOnSave);
     }
 
 }

--- a/src/ro/redeul/google/go/ide/GoProjectSettings.java
+++ b/src/ro/redeul/google/go/ide/GoProjectSettings.java
@@ -18,6 +18,8 @@ public class GoProjectSettings implements PersistentStateComponent<GoProjectSett
         public boolean enableOptimizeImports = false;
         public boolean prependSysGoPath = false;
         public boolean appendSysGoPath = true;
+        public boolean goFmtOnSave = true;
+        public boolean goimportsOnSave = false;
     }
 
     private GoProjectSettingsBean bean;


### PR DESCRIPTION
The goimports option may be an easy replacement for the import optimizations option.  It does require that goimports already exists in the system path.  This isn't normally a problem if the system path includes $GOPATH/bin and one runs the following command.

```
go get code.google.com/p/go.tools/cmd/goimports
```

The already existing code that ensured the file ended with a line feed has been removed because both gofmt and goimports will do that for you.

This pull request changes the project settings dialog to look like this:
![go_settings](https://cloud.githubusercontent.com/assets/1229385/4177366/c320c7f2-363b-11e4-809c-88abcc3acbe7.png)

The default setting is to run go fmt on save.
