### PR TITLE
fix #498, inspection can find shadowed during return error.

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -519,6 +519,12 @@
                          implementationClass="ro.redeul.google.go.inspection.ConstantExpressionsInConstDeclarationsInspection"/>
         <localInspection groupName="Google Go" language="Google Go"
                          enabledByDefault="true"
+                         shortName="ShadowedDuringReturn"
+                         displayName="Highlights shadowed during return error"
+                         level="ERROR"
+                         implementationClass="ro.redeul.google.go.inspection.ShadowedDuringReturnInspection"/>
+        <localInspection groupName="Google Go" language="Google Go"
+                         enabledByDefault="true"
                          shortName="MismatchedTypes"
                          displayName="Highlights mismatched types"
                          level="ERROR"

--- a/src/ro/redeul/google/go/GoBundle.properties
+++ b/src/ro/redeul/google/go/GoBundle.properties
@@ -84,6 +84,7 @@ error.duplicate.argument=Duplicate argument {0}
 error.redeclared.in.block={0} redeclared in this block
 error.output.variadic=Cannot use ... in output argument list
 error.variadic.not.the.last=Can only use ... as final argument in list
+error.shadowed.during.return=Varibles {0} shadowed during return
 error.too.many.arguments.to.return=Too many arguments to return
 error.not.enough.arguments.to.return=Not enough arguments to return
 error.too.many.arguments.in.call=Too many arguments in call to {0}

--- a/src/ro/redeul/google/go/inspection/ShadowedDuringReturnInspection.java
+++ b/src/ro/redeul/google/go/inspection/ShadowedDuringReturnInspection.java
@@ -1,0 +1,149 @@
+package ro.redeul.google.go.inspection;
+
+import com.intellij.psi.impl.DebugUtil;
+import org.jetbrains.annotations.NotNull;
+import ro.redeul.google.go.GoBundle;
+import ro.redeul.google.go.lang.psi.GoFile;
+import ro.redeul.google.go.lang.psi.declarations.GoVarDeclaration;
+import ro.redeul.google.go.lang.psi.expressions.literals.GoLiteralFunction;
+import ro.redeul.google.go.lang.psi.expressions.literals.GoLiteralIdentifier;
+import ro.redeul.google.go.lang.psi.statements.GoBlockStatement;
+import ro.redeul.google.go.lang.psi.statements.GoReturnStatement;
+import ro.redeul.google.go.lang.psi.statements.GoShortVarDeclaration;
+import ro.redeul.google.go.lang.psi.toplevel.GoFunctionDeclaration;
+import ro.redeul.google.go.lang.psi.toplevel.GoMethodDeclaration;
+import ro.redeul.google.go.lang.psi.visitors.GoRecursiveElementVisitor;
+
+import java.util.*;
+
+import static ro.redeul.google.go.lang.psi.utils.GoFunctionDeclarationUtils.*;
+
+
+public class ShadowedDuringReturnInspection extends AbstractWholeGoFileInspection {
+    @Override
+    protected void doCheckFile(@NotNull GoFile file, @NotNull final InspectionResult result) {
+
+        new GoRecursiveElementVisitor() {
+            @Override
+            public void visitFunctionDeclaration(GoFunctionDeclaration declaration) {
+                visitElement(declaration);
+                checkFunction(result, declaration);
+            }
+
+            @Override
+            public void visitMethodDeclaration(GoMethodDeclaration declaration) {
+                visitElement(declaration);
+                checkFunction(result, declaration);
+            }
+
+            @Override
+            public void visitFunctionLiteral(GoLiteralFunction literal) {
+                visitElement(literal);
+                checkFunction(result, literal);
+            }
+        }.visitFile(file);
+    }
+
+    public static void checkFunction(InspectionResult result, GoFunctionDeclaration function) {
+        checkShadowedDuringReturn(result, function);
+    }
+
+    private static void checkShadowedDuringReturn(InspectionResult result, GoFunctionDeclaration function) {
+        // function have return parameters can cause shadowed during return
+        if (!hasResult(function)){
+            return;
+        }
+
+        // return parameters must have name can cause shadowed during return
+        if (!IsResultNamed(function)){
+            return;
+        }
+
+        new ReturnVisitor(result, function).visitFunctionDeclaration(function);
+    }
+
+    /**
+     * Recursively look for VarDeclaration can cuase shadowed during return,
+     * Recursively look for GoReturnStatement which can cuase shadowed during return,
+     * 1.VarDeclaration must in direct parent blockStat childrens.
+     * 2.VarDeclaration can not in topLevel block of function.
+     * 3.VarDeclaration must appear before that GoReturnStatement.
+     * 4.VarDeclaration Identifier must equal some function ResultParameterNames.
+     */
+    private static class ReturnVisitor extends GoRecursiveElementVisitor {
+        private final InspectionResult result;
+        private GoFunctionDeclaration functionDeclaration;
+        private HashSet<GoVarDeclaration> currentShadowedVarDeclarationSet = new HashSet<GoVarDeclaration>();
+        private Stack<HashSet<GoVarDeclaration>> currentBlockVarDeclarationStack = new Stack<HashSet<GoVarDeclaration>>();
+        private boolean isInFunctionBlock = true;
+
+        public ReturnVisitor(InspectionResult result, GoFunctionDeclaration declaration) {
+            this.result = result;
+            this.functionDeclaration = declaration;
+        }
+
+        @Override
+        public void visitFunctionLiteral(GoLiteralFunction literal) {
+            // stop the recursion here
+        }
+
+        @Override
+        public void visitBlockStatement(GoBlockStatement statement) {
+            boolean oldIsInFunctionBlock = isInFunctionBlock;
+            isInFunctionBlock = functionDeclaration.getBlock()==statement;
+            currentBlockVarDeclarationStack.push(new HashSet<GoVarDeclaration>());
+            super.visitBlockStatement(statement);
+            HashSet<GoVarDeclaration> currentblockStack = currentBlockVarDeclarationStack.pop();
+            currentShadowedVarDeclarationSet.removeAll(currentblockStack);
+            isInFunctionBlock = oldIsInFunctionBlock;
+        }
+
+        @Override
+        public void visitVarDeclaration(GoVarDeclaration declaration) {
+            if (isInFunctionBlock){
+                return;
+            }
+            currentShadowedVarDeclarationSet.add(declaration);
+            currentBlockVarDeclarationStack.peek().add(declaration);
+        }
+
+        public void visitShortVarDeclaration(GoShortVarDeclaration declaration) {
+            visitVarDeclaration(declaration);
+        }
+
+        @Override
+        public void visitReturnStatement(GoReturnStatement statement) {
+            // return statement do not have any expressions can cause shadowed during return
+            if (statement.getExpressions().length>0) {
+                return;
+            }
+            List<String> varDeclarationNames = getShadowedVarDeclarationNames();
+            ArrayList<String> shadowedResultNames = new ArrayList<String>();
+            for(String resultName: getResultParameterNames(functionDeclaration)){
+                if (varDeclarationNames.contains(resultName)){
+                    shadowedResultNames.add(resultName);
+                }
+            }
+
+            if (shadowedResultNames.size()>0){
+                result.addProblem(statement, GoBundle.message("error.shadowed.during.return", stringJoin(shadowedResultNames) ));
+            }
+        }
+
+        private List<String> getShadowedVarDeclarationNames(){
+            ArrayList<String> output = new ArrayList<String>();
+            for(GoVarDeclaration varDeclaration: currentShadowedVarDeclarationSet){
+                for(GoLiteralIdentifier ids : varDeclaration.getIdentifiers()){
+                    output.add(ids.getCanonicalName());
+                }
+            }
+            return output;
+        }
+
+        private String stringJoin(List<String> input){
+            String output = Arrays.toString(input.toArray());
+            return output.substring(1,output.length()-1);
+        }
+
+    }
+}

--- a/src/ro/redeul/google/go/lang/psi/impl/statements/GoBlockStatementImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/statements/GoBlockStatementImpl.java
@@ -9,6 +9,7 @@ import ro.redeul.google.go.lang.psi.impl.GoPsiElementBase;
 import ro.redeul.google.go.lang.psi.patterns.GoElementPatterns;
 import ro.redeul.google.go.lang.psi.statements.GoBlockStatement;
 import ro.redeul.google.go.lang.psi.statements.GoStatement;
+import ro.redeul.google.go.lang.psi.visitors.GoElementVisitor;
 
 public class GoBlockStatementImpl extends GoPsiElementBase implements GoBlockStatement {
     public GoBlockStatementImpl(@NotNull ASTNode node) {
@@ -37,5 +38,10 @@ public class GoBlockStatementImpl extends GoPsiElementBase implements GoBlockSta
         }
 
         return true;
+    }
+
+    @Override
+    public void accept(GoElementVisitor visitor) {
+        visitor.visitBlockStatement(this);
     }
 }

--- a/src/ro/redeul/google/go/lang/psi/utils/GoFunctionDeclarationUtils.java
+++ b/src/ro/redeul/google/go/lang/psi/utils/GoFunctionDeclarationUtils.java
@@ -1,0 +1,65 @@
+package ro.redeul.google.go.lang.psi.utils;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import ro.redeul.google.go.lang.lexer.GoTokenTypes;
+import ro.redeul.google.go.lang.psi.GoPsiElement;
+import ro.redeul.google.go.lang.psi.expressions.GoPrimaryExpression;
+import ro.redeul.google.go.lang.psi.expressions.literals.GoLiteralIdentifier;
+import ro.redeul.google.go.lang.psi.expressions.primary.GoBuiltinCallExpression;
+import ro.redeul.google.go.lang.psi.expressions.primary.GoCallOrConvExpression;
+import ro.redeul.google.go.lang.psi.expressions.primary.GoLiteralExpression;
+import ro.redeul.google.go.lang.psi.expressions.primary.GoSelectorExpression;
+import ro.redeul.google.go.lang.psi.toplevel.GoFunctionDeclaration;
+import ro.redeul.google.go.lang.psi.toplevel.GoFunctionParameter;
+import ro.redeul.google.go.util.GoUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static ro.redeul.google.go.lang.psi.utils.GoIdentifierUtils.getFunctionDeclaration;
+import static ro.redeul.google.go.lang.psi.utils.GoPsiUtils.*;
+
+public class GoFunctionDeclarationUtils {
+    public static boolean IsResultNamed(GoFunctionDeclaration declaration){
+        for (GoFunctionParameter resParam : declaration.getResults()) {
+            if (resParam.getIdentifiers().length > 0){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static int GetResultCount(GoFunctionDeclaration declaration){
+        int returnCount = 0;
+        for (GoFunctionParameter resParam : declaration.getResults()) {
+            returnCount += Math.max(resParam.getIdentifiers().length, 1);
+        }
+        return returnCount;
+    }
+
+    public static boolean hasResult(GoFunctionDeclaration function) {
+        return function.getResults().length > 0;
+    }
+
+    public static boolean hasBody(GoFunctionDeclaration function) {
+        return function.getBlock() != null;
+    }
+
+    public static List<String> getResultParameterNames(GoFunctionDeclaration function){
+        return getParameterNames(function.getResults());
+    }
+    private static List<String> getParameterNames(GoFunctionParameter[] parameters) {
+        List<String> parameterNames = new ArrayList<String>();
+        for (GoFunctionParameter fp : parameters) {
+            for (GoLiteralIdentifier id : fp.getIdentifiers()) {
+                if (!id.isBlank()) {
+                    parameterNames.add(id.getText());
+                }
+            }
+        }
+        return parameterNames;
+    }
+}

--- a/src/ro/redeul/google/go/lang/psi/visitors/GoElementVisitor.java
+++ b/src/ro/redeul/google/go/lang/psi/visitors/GoElementVisitor.java
@@ -220,6 +220,10 @@ public class GoElementVisitor  {
         visitElement(statement);
     }
 
+    public void visitBlockStatement(GoBlockStatement statement) {
+        visitElement(statement);
+    }
+
     public void visitBreakStatement(GoBreakStatement statement) {
         visitElement(statement);
     }

--- a/test/ro/redeul/google/go/inspection/ShadowedDuringReturnInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/ShadowedDuringReturnInspectionTest.java
@@ -1,0 +1,7 @@
+package ro.redeul.google.go.inspection;
+
+public class ShadowedDuringReturnInspectionTest extends GoInspectionTestCase {
+    public void testShadowedDuringReturn() throws Exception {
+        doTest();
+    }
+}

--- a/testdata/inspection/shadowedDuringReturn/shadowedDuringReturn.go
+++ b/testdata/inspection/shadowedDuringReturn/shadowedDuringReturn.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+}
+
+func bad1()(err1 error){
+	if true{
+		err1:=fmt.Errorf("123")
+		if err1!=nil{
+			/*begin*/return/*end.Varibles err1 shadowed during return*/
+		}
+	}
+	return
+}
+
+func bad2()(err2 error){
+	if true{
+		err2:="123"
+		if true {
+			if err2 != "" {
+				/*begin*/return/*end.Varibles err2 shadowed during return*/
+			}
+		}
+	}
+	return
+}
+
+func bad3()(err3 error){
+	if true{
+		if true {
+			if err3 != nil {
+				return
+			}
+		}
+		err3:="123"
+		if err3 != "" {
+			/*begin*/return/*end.Varibles err3 shadowed during return*/
+		}
+	}
+	return
+}
+
+func bad4()(err4,v4 int){
+	if true{
+		if true {
+			if err4 != nil {
+				return
+			}
+		}
+		err4:="123"
+		v4:="abc"
+		if err4 != "" && v4!="" {
+			/*begin*/return/*end.Varibles err4, v4 shadowed during return*/
+		}
+	}
+	return
+}
+
+func good1()(err error){
+	if true{
+		err:=fmt.Errorf("123")
+	}
+	return
+}
+
+
+func good2()(err error){
+	if true{
+		if true{
+			return
+		}
+		fmt.Println(err)
+		err:="123"
+		fmt.Println(err)
+	}
+	return
+}


### PR DESCRIPTION
fix #498, inspection can find shadowed during return error.

Add ShadowedDuringReturnInspection class to find shadowed during return compiler error.

All test passed.
