### PR TITLE
fix #494, Struct identifiers must be prefixed with the package name if hey are not defined in current package

### DIFF
--- a/src/ro/redeul/google/go/lang/psi/resolve/references/GoPsiReference.java
+++ b/src/ro/redeul/google/go/lang/psi/resolve/references/GoPsiReference.java
@@ -107,7 +107,7 @@ public abstract class GoPsiReference<
     }
 
     private boolean matchesPackageName(String currentPackageName, String targetQualifiedName, String elementName) {
-        if (targetQualifiedName.contains(".")) {
+        if (!currentPackageName.equals("")) {
             elementName = currentPackageName + "." + elementName;
         }
 


### PR DESCRIPTION
fix #494 
I spent at least 6 hours to read relative code and a lot of stack traces to find the reason of the bug. 
And change one line, bug fixed.

I do not know how to add a test which relative to two package,So I do not add a test to this pr.
master branch seems fail to some test.I found a good commit to add this pr to pass all tests.
All test passed.
