### PR TITLE
Fix goimports and go fmt calling (fixes #792)

### DIFF
--- a/src/ro/redeul/google/go/components/EditorTweakingComponent.java
+++ b/src/ro/redeul/google/go/components/EditorTweakingComponent.java
@@ -94,7 +94,7 @@ public class EditorTweakingComponent extends FileDocumentManagerAdapter {
         }
 
         try {
-            String[] command = {"goimports", "-w", fileName};
+            String[] command = {GoSdkUtil.getGoImportsExec(), "-w", fileName};
 
             Runtime rt = Runtime.getRuntime();
             Process proc = rt.exec(command, goEnv);
@@ -135,7 +135,7 @@ public class EditorTweakingComponent extends FileDocumentManagerAdapter {
         }
 
         try {
-            String[] command = {"gofmt", "-w", fileName};
+            String[] command = {"go", "fmt", fileName};
 
             Runtime rt = Runtime.getRuntime();
             Process proc = rt.exec(command, goEnv);

--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -1095,4 +1095,13 @@ public class GoSdkUtil {
 
         return computeGoCommand(goExecName, goArgs);
     }
+
+    public static String getGoImportsExec() {
+        String execPath = GoSdkUtil.getGoPath() + File.separator + "bin" + File.separator + "goimports";
+        if (isHostOsWindows()) {
+            execPath += ".exe";
+        }
+
+        return execPath;
+    }
 }


### PR DESCRIPTION
It remains to solve the issue of setting the GOPATH for creating new projects as currently in the dialog there's no way to do it, hence things won't work properly. Also, new projects should be able to be created inside the GOPATH properly. But that's another PR.
