### PR TITLE
Add support for importing from paths with dots

### DIFF
--- a/src/ro/redeul/google/go/imports/AutoImportHighlightingPass.java
+++ b/src/ro/redeul/google/go/imports/AutoImportHighlightingPass.java
@@ -26,6 +26,7 @@ import ro.redeul.google.go.lang.psi.expressions.primary.GoSelectorExpression;
 import ro.redeul.google.go.lang.psi.toplevel.GoImportDeclaration;
 import ro.redeul.google.go.lang.psi.toplevel.GoImportDeclarations;
 import ro.redeul.google.go.lang.psi.types.GoPsiTypeName;
+import ro.redeul.google.go.lang.psi.utils.GoPsiUtils;
 import ro.redeul.google.go.lang.stubs.GoNamesCache;
 import ro.redeul.google.go.options.GoSettings;
 
@@ -145,12 +146,14 @@ public class AutoImportHighlightingPass extends TextEditorHighlightingPass {
                                                  String expectedName) {
         List<String> packageFiles = new ArrayList<String>();
         for (String p : allPackages) {
-            if (expectedName.equals(p) || p.endsWith(
+            String importPath = GoPsiUtils.findRealImportPathValue(p);
+            if (expectedName.equals(p) || importPath.endsWith(
                 "/" + expectedName)) {
                 packageFiles.add(p);
             }
         }
-        return packageFiles;
+        packageFiles.sort(null);
+        return  packageFiles;
     }
 
     private RangeHighlighter[] getAllHighlighters(Project project) {

--- a/src/ro/redeul/google/go/inspection/InvalidPackageNameInspection.java
+++ b/src/ro/redeul/google/go/inspection/InvalidPackageNameInspection.java
@@ -11,6 +11,7 @@ import ro.redeul.google.go.inspection.fix.ChangePackageNameFix;
 import ro.redeul.google.go.inspection.fix.RepackageFileFix;
 import ro.redeul.google.go.lang.psi.GoFile;
 import ro.redeul.google.go.lang.psi.toplevel.GoPackageDeclaration;
+import ro.redeul.google.go.lang.psi.utils.GoPsiUtils;
 
 public class InvalidPackageNameInspection
     extends AbstractWholeGoFileInspection {
@@ -52,6 +53,8 @@ public class InvalidPackageNameInspection
         }
 
         String targetPackageName = virtualFile.getParent().getName();
+        // We are only interested in the package name without any "."
+        targetPackageName = GoPsiUtils.findRealImportPathValue(targetPackageName);
 
         if (virtualFile.getNameWithoutExtension().endsWith("_test") ) {
             packageName = packageName.replaceAll("_test$", "");

--- a/src/ro/redeul/google/go/lang/completion/GoCompletionContributor.java
+++ b/src/ro/redeul/google/go/lang/completion/GoCompletionContributor.java
@@ -458,6 +458,11 @@ public class GoCompletionContributor extends CompletionContributor {
             if (visibleName.contains("/")) {
                 visibleName = visibleName.substring(visibleName.lastIndexOf('/') + 1);
             }
+            // Exclude any package names containing "." as these
+            // will be included in the values list for the corresponding
+            // package name without the "."
+            if (visibleName.contains("."))
+                continue;
             if (!importedPackages.contains(visibleName)) {
                 List<String> packages = packageMap.get(visibleName);
                 if (packages == null) {

--- a/src/ro/redeul/google/go/lang/psi/impl/GoFileImpl.java
+++ b/src/ro/redeul/google/go/lang/psi/impl/GoFileImpl.java
@@ -25,6 +25,7 @@ import ro.redeul.google.go.lang.psi.declarations.GoConstDeclarations;
 import ro.redeul.google.go.lang.psi.declarations.GoVarDeclarations;
 import ro.redeul.google.go.lang.psi.processors.GoResolveStates;
 import ro.redeul.google.go.lang.psi.toplevel.*;
+import ro.redeul.google.go.lang.psi.utils.GoPsiUtils;
 import ro.redeul.google.go.lang.psi.visitors.GoElementVisitor;
 import ro.redeul.google.go.lang.psi.visitors.GoElementVisitorWithData;
 import ro.redeul.google.go.lang.stubs.GoNamesCache;
@@ -90,7 +91,8 @@ public class GoFileImpl extends PsiFileBase implements GoFile {
         if (path == null || path.equals(""))
             path = getPackageName();
 
-        if (path != null && !isApplicationPart() && !path.endsWith(getPackageName()) && !path.toLowerCase().endsWith(getPackageName())) {
+        String pathCheck = GoPsiUtils.findRealImportPathValue(path);
+        if (path != null && !isApplicationPart() && !pathCheck.endsWith(getPackageName()) && !pathCheck.toLowerCase().endsWith(getPackageName())) {
             path = path + "/" + getPackageName();
         }
 

--- a/src/ro/redeul/google/go/lang/psi/processors/ImportedPackagesCollectorProcessor.java
+++ b/src/ro/redeul/google/go/lang/psi/processors/ImportedPackagesCollectorProcessor.java
@@ -8,6 +8,9 @@ import ro.redeul.google.go.lang.psi.GoPackageReference;
 import ro.redeul.google.go.lang.psi.expressions.literals.GoLiteralString;
 import ro.redeul.google.go.lang.psi.toplevel.GoImportDeclaration;
 
+import static ro.redeul.google.go.lang.psi.utils.GoPsiUtils.findDefaultPackageName;
+import static ro.redeul.google.go.lang.psi.utils.GoPsiUtils.isDotImport;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,9 +49,16 @@ public class ImportedPackagesCollectorProcessor extends BaseScopeProcessor {
             GoPackageReference packageReference = importSpec.getPackageReference();
 
             if (packageReference == null) {
+                // If there is no package reference but the import path contains
+                // a ".', treat it like a package reference were specfied.
                 GoLiteralString importPath = importSpec.getImportPath();
-                if (importPath != null)
-                    packageImports.add(importPath.getValue());
+                if (importPath != null) {
+                    String path = importPath.getValue();
+                    if (isDotImport(path)) {
+                        path = findDefaultPackageName(path);
+                    }
+                    packageImports.add(path);
+                }
                 continue;
             }
 

--- a/src/ro/redeul/google/go/lang/psi/utils/GoPsiUtils.java
+++ b/src/ro/redeul/google/go/lang/psi/utils/GoPsiUtils.java
@@ -263,9 +263,30 @@ public class GoPsiUtils {
     }
 
     public static String findDefaultPackageName(String importPath) {
-        return importPath != null
-            ? importPath.replaceAll("(?:[^/]+/)+", "")
-            : null;
+        if ( importPath == null ) {
+            return null;
+        }
+        // Ensure any part of the package name after a "." is stripped.
+        String realPath = findRealImportPathValue(importPath);
+        return realPath.replaceAll("(?:[^/]+/)+", "");
+    }
+
+    private static final Pattern dotImport = Pattern.compile("[^/]+.+\\.[^/]+");
+
+    public static boolean isDotImport(String importPath) {
+        return importPath != null && dotImport.matcher(importPath).matches();
+    }
+
+    /**
+     * For import paths containing ".", strips out the "." and
+     * following text, as this is ignored by Go.
+     * eg github.com/foo/bar.v1 -> github.com/foo/bar
+     * @param importPath
+     * @return importPath wih the dotted text removed.
+     */
+    public static String findRealImportPathValue(String importPath) {
+        return isDotImport(importPath)
+                ? importPath.replaceAll("\\.[^\\.]+$", ""): importPath;
     }
 
     public static boolean isNodeOfType(PsiElement node, TokenSet tokenSet) {

--- a/test/ro/redeul/google/go/inspection/ImportUnusedInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/ImportUnusedInspectionTest.java
@@ -4,6 +4,7 @@ public class ImportUnusedInspectionTest extends GoInspectionTestCase {
 
     public void testSimple() throws Exception{ doTest(); }
     public void testOnlyOneImport() throws Exception{ doTest(); }
+    public void testDotImport() throws Exception{ doTest(); }
     public void testBlankImport() throws Exception{ doTest(); }
     public void testMixedCaseImport() throws Exception{ doTest(); }
     public void testCgo() throws Exception{ doTest(); }

--- a/test/ro/redeul/google/go/inspection/fix/AddImportFixTest.java
+++ b/test/ro/redeul/google/go/inspection/fix/AddImportFixTest.java
@@ -10,6 +10,7 @@ public class AddImportFixTest extends GoEditorAwareTestCase {
     public void testSimple() throws Exception{ doTest(); }
     public void testOneExistingImport() throws Exception{ doTest(); }
     public void testMultipleExistingImport() throws Exception{ doTest(); }
+    public void testDotImport() throws Exception{ doTest(); }
 
     @Override
     protected void invoke(Project project, Editor editor, GoFile file) {

--- a/testdata/inspection/importPath/dotImport.go
+++ b/testdata/inspection/importPath/dotImport.go
@@ -1,0 +1,5 @@
+package main
+
+import (
+	"fmt.v1"
+)

--- a/testdata/inspection/importUnused/dotImport.go
+++ b/testdata/inspection/importUnused/dotImport.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+    "fmt"
+    "gongo.v1"
+    /*begin*/"io"/*end.Unused import "io"|RemoveImportFix*/
+)
+
+func main() {
+    var x gongo.MyType = 10
+    fmt.Printf("Hello world!")
+}


### PR DESCRIPTION
When Go sees an import path like this:
"github.com/foo/bar.v1"

the bit after the "." is ignored and the real value of the import path used by the compiler is
"github.com/foo/bar"

even though the path on disk has the ".v1" bit in the directory.

The pull request adds support to import path processing and associated inspections and intentions to allow code with dotted import paths to be handled properly. The approach used is to treat the import statement as if a package reference were specified. The package reference is set to the part of the package name before the dot. Thus the above example is treated as if it were written like this:

bar "github.com/foo/bar.v1"

Other changes include allowing the auto completion pop up to work properly if more than one dotted package with the same root exists etc.

Unit tests pass and I added a couple of additional tests also.
