### PR TITLE
Add support for ant build.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ src/icons/go-logo-black.png
 src/icons/logo-153x55.png
 idea-IC
 idea-IC-*
+.directory
+.idea/libraries/
+build.properties
+build_test/

--- a/build-distribution.xml
+++ b/build-distribution.xml
@@ -1,6 +1,8 @@
 <project name="Idea Google Go language scripted build file" default="assemble"
          basedir=".">
 
+    <property file="build.properties" />
+
     <!-- set global properties for this build -->
     <property name="work" location="build"/>
     <property name="dist" location="dist"/>

--- a/build-package.xml
+++ b/build-package.xml
@@ -1,5 +1,7 @@
 <project name="Idea Google Go language scripted build file" default="package" basedir=".">
 
+    <property file="build.properties" />
+
     <!-- set global properties for this build -->
     <property name="src" location="src"/>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -1,5 +1,7 @@
 <project name="Idea Google Go language scripted test file" default="test" basedir=".">
 
+    <property file="build.properties" />
+
     <!-- set global properties for this build -->
     <property name="build.compiler" value="modern"/>
 


### PR DESCRIPTION
So that different Intellij locations can be easily used between developers, I added a build directive to the ant xml files:
<property file="build.properties" />
Thus the default build properties can be overridden by each developer in their local branches.
.gitignore is also updated.
