### PR TITLE
Use full go binary path for commands

### DIFF
--- a/src/ro/redeul/google/go/components/EditorTweakingComponent.java
+++ b/src/ro/redeul/google/go/components/EditorTweakingComponent.java
@@ -1,5 +1,6 @@
 package ro.redeul.google.go.components;
 
+import com.intellij.execution.CantRunException;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
@@ -15,6 +16,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import org.jetbrains.annotations.NotNull;
 import ro.redeul.google.go.GoFileType;
+import ro.redeul.google.go.config.sdk.GoSdkData;
 import ro.redeul.google.go.ide.GoProjectSettings;
 import ro.redeul.google.go.ide.ui.GoToolWindow;
 import ro.redeul.google.go.sdk.GoSdkUtil;
@@ -129,13 +131,19 @@ public class EditorTweakingComponent extends FileDocumentManagerAdapter {
             return;
         }
 
+        final GoSdkData sdkData = (GoSdkData)sdk.getSdkAdditionalData();
+        if (sdkData == null) {
+            return;
+        }
+        final String goExecName = sdkData.GO_BIN_PATH;
+
         String[] goEnv = GoSdkUtil.getGoEnv(sdk, projectDir);
         if (goEnv == null) {
             return;
         }
 
         try {
-            String[] command = {"go", "fmt", fileName};
+            String[] command = {sdkData.GO_BIN_PATH, "fmt", fileName};
 
             Runtime rt = Runtime.getRuntime();
             Process proc = rt.exec(command, goEnv);

--- a/src/ro/redeul/google/go/ide/GoModuleBuilder.java
+++ b/src/ro/redeul/google/go/ide/GoModuleBuilder.java
@@ -69,7 +69,7 @@ public class GoModuleBuilder extends JavaModuleBuilder implements SourcePathsBui
             if ( sdkData == null ) {
                 throw new CantRunException("No Go Sdk defined for this project");
             }
-            final String goExecName = sdkData.GO_EXEC;
+            final String goExecName = sdkData.GO_BIN_PATH;
             final String projectDir = module.getProject().getBasePath();
             if (projectDir == null) {
                 throw new CantRunException("Could not retrieve the project directory");

--- a/src/ro/redeul/google/go/ide/actions/GoDebugEnv.java
+++ b/src/ro/redeul/google/go/ide/actions/GoDebugEnv.java
@@ -33,7 +33,7 @@ public class GoDebugEnv extends GoCommonDebugAction {
             return;
         }
 
-        String goExecName = sdkData.GO_EXEC;
+        String goExecName = sdkData.GO_BIN_PATH;
 
         String projectDir = project.getBasePath();
 

--- a/src/ro/redeul/google/go/ide/actions/GoDebugSDK.java
+++ b/src/ro/redeul/google/go/ide/actions/GoDebugSDK.java
@@ -32,7 +32,7 @@ public class GoDebugSDK extends GoCommonDebugAction {
             return;
         }
 
-        String goExecName = sdkData.GO_EXEC;
+        String goExecName = sdkData.GO_BIN_PATH;
 
         String projectDir = project.getBasePath();
 
@@ -51,7 +51,7 @@ public class GoDebugSDK extends GoCommonDebugAction {
 
             toolWindow.printNormalMessage(String.format("%s -> %s%n", "Project dir", projectDir));
             toolWindow.printNormalMessage(String.format("%s -> %s%n", "GO_GOROOT_PATH", sdkData.GO_GOROOT_PATH));
-            toolWindow.printNormalMessage(String.format("%s -> %s%n", "GO_BIN_PATH", sdkData.GO_EXEC));
+            toolWindow.printNormalMessage(String.format("%s -> %s%n", "GO_BIN_PATH", sdkData.GO_BIN_PATH));
             toolWindow.printNormalMessage(String.format("%s -> %s%n", "GO_GOPATH_PATH", sdkData.GO_GOPATH_PATH));
             toolWindow.printNormalMessage(String.format("%s -> %s%n", "TARGET_OS", sdkData.TARGET_OS));
             toolWindow.printNormalMessage(String.format("%s -> %s%n", "TARGET_ARCH", sdkData.TARGET_ARCH));

--- a/src/ro/redeul/google/go/runner/GoCommandLineState.java
+++ b/src/ro/redeul/google/go/runner/GoCommandLineState.java
@@ -61,7 +61,7 @@ class GoCommandLineState extends CommandLineState {
             throw new CantRunException("Could not retrieve the project directory");
         }
 
-        String goExecName = sdkData.GO_EXEC;
+        String goExecName = sdkData.GO_BIN_PATH;
         String workingDir = testConfiguration.workingDir;
 
         GoProjectSettings.GoProjectSettingsBean settings = GoProjectSettings.getInstance(project).getState();

--- a/src/ro/redeul/google/go/runner/GoRunProfileState.java
+++ b/src/ro/redeul/google/go/runner/GoRunProfileState.java
@@ -49,7 +49,7 @@ public class GoRunProfileState extends CommandLineState {
             throw new CantRunException("No Go Sdk defined for this project");
         }
 
-        String goExecName = sdkData.GO_EXEC;
+        String goExecName = sdkData.GO_BIN_PATH;
 
         String projectDir = m_project.getBasePath();
 

--- a/src/ro/redeul/google/go/runner/beforeRunTasks/GoVetRunner.java
+++ b/src/ro/redeul/google/go/runner/beforeRunTasks/GoVetRunner.java
@@ -55,7 +55,7 @@ public class GoVetRunner extends Task.Backgroundable {
             LOG.error("No Go Sdk defined for this project");
         }
 
-        String goExecName = sdkData.GO_EXEC;
+        String goExecName = sdkData.GO_BIN_PATH;
         String projectDir = myProject.getBasePath();
 
         try {

--- a/src/uk/co/cwspencer/ideagdb/run/GoDebugProfileState.java
+++ b/src/uk/co/cwspencer/ideagdb/run/GoDebugProfileState.java
@@ -63,7 +63,7 @@ public class GoDebugProfileState implements RunProfileState {
             throw new CantRunException("No Go Sdk defined for this project");
         }
 
-        String goExecName = sdkData.GO_EXEC;
+        String goExecName = sdkData.GO_BIN_PATH;
 
         String projectDir = project.getBasePath();
 


### PR DESCRIPTION
This change updates places that use sdkData.GO_EXEC (or just "go") instead sdkData.GO_BIN_PATH for commands. This makes it so that "go" commands will actually use the tools given by the current SDK instead of whatever's first found in the user's PATH
