### PR TITLE
Return full go binary path instead of "go" for standard SDKs

### DIFF
--- a/src/ro/redeul/google/go/sdk/GoSdkUtil.java
+++ b/src/ro/redeul/google/go/sdk/GoSdkUtil.java
@@ -935,7 +935,7 @@ public class GoSdkUtil {
                 return null;
             }
 
-            return sdkData.GO_EXEC;
+            return sdkData.GO_BIN_PATH;
         } else if (sdk.getSdkAdditionalData() instanceof GoAppEngineSdkData) {
             GoAppEngineSdkData sdkData = (GoAppEngineSdkData) sdk.getSdkAdditionalData();
             if (sdkData == null) {


### PR DESCRIPTION
This change fixes problems with running gofmt on my machine.

As a side note, I've never used the Go App Engine SDK and I'm curious to know if that has a different "go" binary. If it does, I'll go ahead and modify my changes in bd3fce4a9ca9582d6d57960bdf860f3eb8c85c29 to use this method instead of just always assuming `GO_BIN_PATH` is usable.
