### PR TITLE
Enable remaining failing tests

### DIFF
--- a/test/ro/redeul/google/go/inspection/fix/AddImportFixTest.java
+++ b/test/ro/redeul/google/go/inspection/fix/AddImportFixTest.java
@@ -3,6 +3,7 @@ package ro.redeul.google.go.inspection.fix;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
+import org.junit.Ignore;
 import ro.redeul.google.go.GoEditorAwareTestCase;
 import ro.redeul.google.go.lang.psi.GoFile;
 
@@ -11,9 +12,8 @@ public class AddImportFixTest extends GoEditorAwareTestCase {
     public void testOneExistingImport() throws Exception{ doTest(); }
     public void testMultipleExistingImport() throws Exception{ doTest(); }
 
-/*  TODO FIX TEST
     @Ignore("not ready yet")
-    public void testDotImport() throws Exception{ doTest(); }*/
+    public void testDotImport() throws Exception{ doTest(); }
 
     @Override
     protected void invoke(Project project, Editor editor, GoFile file) {

--- a/test/uk/co/cwspencer/gdb/messages/TestGdbMiMessageConverter.java
+++ b/test/uk/co/cwspencer/gdb/messages/TestGdbMiMessageConverter.java
@@ -1,6 +1,7 @@
 package uk.co.cwspencer.gdb.messages;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.co.cwspencer.gdb.gdbmi.GdbMiParser2;
 import uk.co.cwspencer.gdb.gdbmi.GdbMiRecord;
@@ -17,7 +18,8 @@ public class TestGdbMiMessageConverter
 	/**
 	 * Verifies the correct conversion of a 'connected' message.
 	 */
-	@Test(expected = AssertionError.class) //TODO FIX TEST
+	@Test
+	@Ignore("not ready yet")
 	public void testConnectedEvent() throws UnsupportedEncodingException
 	{
 		// Parse the message
@@ -87,7 +89,8 @@ public class TestGdbMiMessageConverter
 	/**
 	 * Verifies the correct conversion of a 'stopped' message.
 	 */
-	@Test(expected = AssertionError.class) // TODO FIX TEST
+	@Test
+	@Ignore("not ready yet")
 	public void testStoppedEvent() throws UnsupportedEncodingException
 	{
 		// Parse the message
@@ -259,7 +262,8 @@ public class TestGdbMiMessageConverter
 	/**
 	 * Verifies the correct conversion of a breakpoint message.
 	 */
-	@Test(expected = AssertionError.class) // TODO FIX TEST
+	@Test
+	@Ignore("not ready yet")
 	public void testBreakpoint() throws UnsupportedEncodingException
 	{
 		// Parse the message


### PR DESCRIPTION
These are basically the tests that are failing right now and are marked as ignored. 
However they will fail in TravisCI and thus break the future contributions to the plugin so they are disabled in the current `master`.
As such I've enabled them here so we can keep a track of them.
## Possible contributors

If you are looking to contribute to the plugin, you might want to pick up these tests and solve one of them. You'd have my eternal gratitude.
Thank you.
## **Please DO NOT merge this until everything is fixed.**
