### PR TITLE
add test case for #858,#864,#865,doTestWithDirectory can test all file in directory.

### DIFF
--- a/test/ro/redeul/google/go/inspection/RedeclareInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/RedeclareInspectionTest.java
@@ -5,4 +5,7 @@ public class RedeclareInspectionTest extends GoInspectionTestCase {
 
     public void testIssue861() throws Exception{ doTest(); }
 
+    /* TODO FIX TEST
+    public void testGH864() throws Exception{ doTest(); }
+    */
 }

--- a/test/ro/redeul/google/go/inspection/UnresolvedSymbolsTest.java
+++ b/test/ro/redeul/google/go/inspection/UnresolvedSymbolsTest.java
@@ -49,4 +49,12 @@ public class UnresolvedSymbolsTest extends GoInspectionTestCase {
         doTest();
     }
 
+    /* TODO FIX TEST
+    public void testGH865() throws Exception {
+        doTest();
+    }
+    public void testGH858() throws Exception {
+        doTestWithDirectory();
+    }
+    */
 }

--- a/test/ro/redeul/google/go/inspection/UnusedVariableInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/UnusedVariableInspectionTest.java
@@ -57,5 +57,9 @@ public class UnusedVariableInspectionTest extends GoInspectionTestCase {
     public void testIssue438() throws Exception {
         doTestWithDirectory();
     }
+    public void testGH865() throws Exception {
+        doTest();
+    }
     */
+
 }

--- a/testdata/inspection/redeclare/GH864.go
+++ b/testdata/inspection/redeclare/GH864.go
@@ -1,0 +1,15 @@
+package main
+
+func main() {
+	if err := doSomething(); err != nil {
+	}
+	if err := doSomething(); err != nil { // Case 1: err variable claimed to be not new
+	}
+	err := doSomething() // Case 2: err variable claimed to be not new
+	if err == nil {
+	}
+}
+
+func doSomething() error {
+	return nil
+}

--- a/testdata/inspection/unresolvedSymbols/GH858/p1/p1.go
+++ b/testdata/inspection/unresolvedSymbols/GH858/p1/p1.go
@@ -1,0 +1,5 @@
+package p1
+
+import "GH858/p3"
+
+var ErrorLog *p3.P1

--- a/testdata/inspection/unresolvedSymbols/GH858/p2/p2.go
+++ b/testdata/inspection/unresolvedSymbols/GH858/p2/p2.go
@@ -1,0 +1,9 @@
+package p2
+
+import (
+	"GH858/p1"
+)
+
+func f2() {
+	p1.ErrorLog.F1()
+}

--- a/testdata/inspection/unresolvedSymbols/GH858/p3/p3.go
+++ b/testdata/inspection/unresolvedSymbols/GH858/p3/p3.go
@@ -1,0 +1,7 @@
+package p3
+
+type P1 int
+
+func (p *P1) F1() {
+
+}

--- a/testdata/inspection/unresolvedSymbols/GH865.go
+++ b/testdata/inspection/unresolvedSymbols/GH865.go
@@ -1,0 +1,16 @@
+package main
+
+type Foo struct {
+	Things []string
+}
+
+func main() {
+	foo := doSomething()  // foo marked as Unused
+	for _, v := range (*foo).Things { // foo marked as Unresolved
+		_ = v
+	}
+}
+
+func doSomething() *Foo {
+	return &Foo{}
+}

--- a/testdata/inspection/unusedVariable/GH865.go
+++ b/testdata/inspection/unusedVariable/GH865.go
@@ -1,0 +1,16 @@
+package main
+
+type Foo struct {
+	Things []string
+}
+
+func main() {
+	foo := doSomething()  // foo marked as Unused
+	for _, v := range (*foo).Things { // foo marked as Unresolved
+		_ = v
+	}
+}
+
+func doSomething() *Foo {
+	return &Foo{}
+}


### PR DESCRIPTION
Add not running test cases for #858,#864,#865.
I had ran all of them,they are all fail right now.
Fix a bug in GoInspectionTestCase.doTestWithDirectory.
