### PR TITLE
add a inspection testsuite to test on Go sdk.

### DIFF
--- a/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
+++ b/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
@@ -85,7 +85,7 @@ public abstract class GoInspectionTestCase
 //        removeContentRoots();
         super.tearDown();
     }
-    private void doTestWithOneFile(PsiFile file) throws Exception {
+    protected void doTestWithOneFile(PsiFile file) throws Exception {
         Document document = myFixture.getDocument(file);
         List<String> data = readInput(document.getText());
 

--- a/test/ro/redeul/google/go/inspection/GoSDKInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/GoSDKInspectionTest.java
@@ -1,0 +1,91 @@
+package ro.redeul.google.go.inspection;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ex.ProblemDescriptorImpl;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.Processor;
+import org.junit.Assert;
+import ro.redeul.google.go.lang.psi.GoFile;
+import ro.redeul.google.go.sdk.GoSdkUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by bronze1man on 14-10-24.
+ * Test every files and every inspections on go sdk to find more bugs
+ * Most used for finding false error inspection.
+ * TODO make this test possible in Travis CI
+ */
+public class GoSDKInspectionTest extends GoInspectionTestCase{
+    public void testNothing() throws Exception{
+    }
+    /* TODO FIX ME
+    public void testTime() throws Exception{
+        doTestInPackage("time");
+    }
+    */
+    protected void doTestInPackage(String subPath) throws Exception{
+        final ArrayList<PsiFile> list = new ArrayList<PsiFile>();
+        String FolderPath =  GetGoSdkRootPath()+"/"+subPath;
+        final String DataPath = GetGoSdkRootPath();
+        myFixture.setTestDataPath(DataPath);
+        FileUtil.visitFiles(new File(FolderPath), new Processor<File>() {
+            @Override
+            public boolean process(File file) {
+                String path = file.getPath();
+                String ext = FileUtil.getExtension(path);
+                if (!ext.equals("go")) {
+                    return true;
+                }
+                PsiFile psi = myFixture.configureByFile(FileUtil.getRelativePath(DataPath, path,'/'));
+                list.add(psi);
+                return true;
+            }
+        });
+        StringBuilder sb = new StringBuilder();
+        for(PsiFile file:list){
+            Document document = myFixture.getDocument(file);
+            InspectionResult result = new InspectionResult(getProject());
+            detectProblems((GoFile)file, result);
+            List<ProblemDescriptor> problems = result.getProblems();
+            for (ProblemDescriptor pd : problems) {
+                TextRange range;
+                if (pd instanceof ProblemDescriptorImpl) {
+                    range = ((ProblemDescriptorImpl) pd).getTextRange();
+                } else {
+                    int start = pd.getStartElement().getTextOffset();
+                    int end = pd.getEndElement()
+                            .getTextOffset() + pd.getEndElement()
+                            .getTextLength();
+                    range = new TextRange(start, end);
+                }
+                String text = document.getText(range);
+
+                sb.append(file.getVirtualFile().getName())
+                        .append(":").append(pd.getLineNumber()).append(" ")
+                        .append(text
+                                        .replaceAll("\"?.*(, )?/\\*begin\\*/([^\\*/]*)/\\*end\\.[^\\*/]*\\*/(\\\\n)?\"?", "$2")
+                        ).append(" => ").append(pd.getDescriptionTemplate()).append("\n");
+            }
+        }
+        Assert.assertEquals("", sb.toString());
+    }
+    protected String GetGoSdkRootPath(){
+        return "/usr/local/Cellar/go/1.3/libexec/src/pkg";
+    }
+    protected void detectProblems(GoFile file, InspectionResult result)
+            throws IllegalAccessException, InstantiationException {
+        new ConstantExpressionsInConstDeclarationsInspection().doCheckFile(file,result);
+        new ConstDeclarationInspection().doCheckFile(file,result);
+        new FmtUsageInspection().doCheckFile(file,result);
+        new FunctionDuplicateArgumentInspection().doCheckFile(file,result);
+        new FunctionCallInspection().doCheckFile(file,result);
+        new RedeclareInspection().doCheckFile(file, result);
+        new ShadowedDuringReturnInspection().doCheckFile(file,result);
+    }
+}


### PR DESCRIPTION
We can use this kind of test suite to find false error inspection.
If you want to run this test case ,you need to config your go root path in GetGoSdkRootPath .
This test cases is fail,and it is not running.

Follow is test on time package with #895 pull request:
It seems RedeclareInspection has some bugs.

```
format.go:464 y => No new variables on left side of :=
format.go:517 hr => No new variables on left side of :=
format.go:579 zone => No new variables on left side of :=
format_test.go:181 t => Expression type mismatch, the expected type is *testing.T
format_test.go:247 t => Expression type mismatch, the expected type is *testing.T
sleep_test.go:19 100 * Millisecond => Constant expression expected
sleep_test.go:150 100 * Millisecond => Constant expression expected
sleep_test.go:329 25 * Millisecond => Constant expression expected
sleep_test.go:92 b => Expression type mismatch, the expected type is *testing.B
sleep_test.go:110 b => Expression type mismatch, the expected type is *testing.B
sleep_test.go:118 b => Expression type mismatch, the expected type is *testing.B
sleep_test.go:130 wg.Done => Expression type mismatch, the expected type is func()
sleep_test.go:126 b => Expression type mismatch, the expected type is *testing.B
sleep_test.go:137 b => Expression type mismatch, the expected type is *testing.B
sleep_test.go:213 t => Expression type mismatch, the expected type is *testing.T
sleep_test.go:352 big => Expression type mismatch, the expected type is Duration
sleep_test.go:359 neg => Expression type mismatch, the expected type is Duration
time.go:452 1000 * Nanosecond => Constant expression expected
time.go:453 1000 * Microsecond => Constant expression expected
time.go:454 1000 * Millisecond => Constant expression expected
time.go:455 60 * Second => Constant expression expected
time.go:456 60 * Minute => Constant expression expected
time.go:501 buf[:w] => Expression type mismatch, the expected type is []byte
time.go:502 buf[:w] => Expression type mismatch, the expected type is []byte
time.go:507 buf[:w] => Expression type mismatch, the expected type is []byte
time.go:510 buf[:w] => Expression type mismatch, the expected type is []byte
time.go:517 buf[:w] => Expression type mismatch, the expected type is []byte
time.go:525 buf[:w] => Expression type mismatch, the expected type is []byte
time.go:1169 d1 => No new variables on left side of :=
zoneinfo_windows.go:46 h => Expression type mismatch, the expected type is syscall.Handle
zoneinfo_windows.go:53 h => Expression type mismatch, the expected type is syscall.Handle
zoneinfo_windows.go:85 zones => Expression type mismatch, the expected type is syscall.Handle
zoneinfo_windows.go:161 i => Expression type mismatch, the expected type is *syscall.Timezoneinformation
zoneinfo_windows.go:244 &usPacific => Expression type mismatch, the expected type is *syscall.Timezoneinformation
zoneinfo_windows.go:248 &aus => Expression type mismatch, the expected type is *syscall.Timezoneinformation
zoneinfo_windows.go:257 &i => Expression type mismatch, the expected type is *syscall.Timezoneinformation
zoneinfo_windows_test.go:28 t => Expression type mismatch, the expected type is *testing.T
zoneinfo_windows_test.go:34 t => Expression type mismatch, the expected type is *testing.T

```
