### PR TITLE
find redeclare in mulit files.

### DIFF
--- a/test/ro/redeul/google/go/inspection/RedeclareInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/RedeclareInspectionTest.java
@@ -16,4 +16,6 @@ public class RedeclareInspectionTest extends GoInspectionTestCase {
     public void testSelect() throws Exception{ doTest(); }
 
     public void testInit() throws Exception{ doTest(); }
+
+    public void testMulitFiles() throws Exception{ doTestWithDirectory(); }
 }

--- a/testdata/inspection/redeclare/mulitFiles/fa.go
+++ b/testdata/inspection/redeclare/mulitFiles/fa.go
@@ -1,0 +1,26 @@
+package mulitFiles
+
+var /*begin*/bad1/*end.Redeclare in this block*/ = 1
+
+var /*begin*/Bad2/*end.Redeclare in this block*/ = 1
+
+var /*begin*/Bad3/*end.Redeclare in this block*/ = 1
+
+var /*begin*/Bad4/*end.Redeclare in this block*/ = 1
+
+var /*begin*/Bad5/*end.Redeclare in this block*/ = 1
+
+
+var good1 = 1
+
+func good3(){
+	a:=0
+	_=a
+}
+
+type good5 struct{
+}
+
+func (g good5)/*begin*/bad6/*end.Redeclare in this block*/(){
+
+}

--- a/testdata/inspection/redeclare/mulitFiles/fb.go
+++ b/testdata/inspection/redeclare/mulitFiles/fb.go
@@ -1,0 +1,25 @@
+package mulitFiles
+
+func /*begin*/bad1/*end.Redeclare in this block*/(){}
+
+var /*begin*/Bad2/*end.Redeclare in this block*/ = 1
+
+type /*begin*/Bad3/*end.Redeclare in this block*/ struct{
+
+}
+
+type /*begin*/Bad4/*end.Redeclare in this block*/ interface{
+}
+
+const /*begin*/Bad5/*end.Redeclare in this block*/ = 1
+
+var good2=1
+
+func good4(){
+	a:=0
+	_=a
+}
+
+func (g good5)/*begin*/bad6/*end.Redeclare in this block*/(){
+
+}


### PR DESCRIPTION
RedeclareInspection can find redeclare in multiple files.

some tests failed, and it seems not related to RedeclareInspection.I will see whether it works on ci.

```
junit.framework.AssertionFailedError: /xxx/xxx/work/go-lang-idea-plugin/testdata/psi/resolve/calls/ConversionToLocallyImportedType/test/test.go (No such file or directory)
    at ro.redeul.google.go.GoFileBasedPsiTestCase.parseFile(GoFileBasedPsiTestCase.java:167)
    at ro.redeul.google.go.GoFileBasedPsiTestCase$4.process(GoFileBasedPsiTestCase.java:132)
    at ro.redeul.google.go.GoFileBasedPsiTestCase$4.process(GoFileBasedPsiTestCase.java:129)
    at com.intellij.util.FilteringProcessor.process(FilteringProcessor.java:35)
    at com.intellij.openapi.vfs.VfsUtilCore.processFilesRecursively(VfsUtilCore.java:552)
    at ro.redeul.google.go.GoFileBasedPsiTestCase.doDirectoryTest(GoFileBasedPsiTestCase.java:119)
    at ro.redeul.google.go.GoFileBasedPsiTestCase.doTest(GoFileBasedPsiTestCase.java:59)
    at ro.redeul.google.go.resolve.GoResolveCallsTest.testConversionToLocallyImportedType(GoResolveCallsTest.java:85)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at com.intellij.testFramework.UsefulTestCase.access$001(UsefulTestCase.java:84)
    at com.intellij.testFramework.UsefulTestCase$2.run(UsefulTestCase.java:301)
    at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:938)
    at com.intellij.testFramework.PlatformTestCase$6.run(PlatformTestCase.java:713)
    at com.intellij.testFramework.PlatformTestCase.invokeTestRunnable(PlatformTestCase.java:729)
    at com.intellij.testFramework.UsefulTestCase.runTest(UsefulTestCase.java:317)
    at com.intellij.testFramework.PlatformTestCase$5.run(PlatformTestCase.java:639)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:199)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:715)
    at java.awt.EventQueue.access$400(EventQueue.java:82)
    at java.awt.EventQueue$2.run(EventQueue.java:676)
    at java.awt.EventQueue$2.run(EventQueue.java:674)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:86)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:685)
    at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:746)
    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:576)
    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:383)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:296)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:211)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:201)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:196)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:188)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)
```

I just update my java to 8
