### PR TITLE
fix a bug in GoInspectionTestCase. two ignore test cases passed.

### DIFF
--- a/test/ro/redeul/google/go/inspection/FunctionCallInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/FunctionCallInspectionTest.java
@@ -42,6 +42,5 @@ public class FunctionCallInspectionTest extends GoInspectionTestCase {
     @Ignore("failing test")
     public void testInterface() throws Exception{ doTest(); }
 
-    @Ignore("failing test")
     public void testIssue875() throws Exception{ doTestWithDirectory(); }
 }

--- a/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
+++ b/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
@@ -93,7 +93,7 @@ public abstract class GoInspectionTestCase
         List<String> data = readInput(file.getText());
 
         String expected = data.get(1).trim();
-        Assert.assertEquals("fail at " + file.getVirtualFile().getPath(), expected, processFile(data.get(0).trim()));
+        Assert.assertEquals("fail at " + file.getVirtualFile().getPath(), expected, processFile(data.get(0).trim(),(GoFile)file));
     }
 
     private List<String> readInput(String content) throws IOException {
@@ -118,10 +118,10 @@ public abstract class GoInspectionTestCase
         return data;
     }
 
-    protected String processFile(String fileText)
+    protected String processFile(String fileText,GoFile file)
             throws InstantiationException, IllegalAccessException, IOException {
 
-        GoFile file = (GoFile) myFixture.configureByText(GoFileType.INSTANCE, fileText);
+        //GoFile file = (GoFile) myFixture.configureByText(GoFileType.INSTANCE, fileText);
         Document document = myFixture.getDocument(file);
         InspectionResult result = new InspectionResult(getProject());
         detectProblems(file, result);

--- a/test/ro/redeul/google/go/inspection/RedeclareInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/RedeclareInspectionTest.java
@@ -19,7 +19,6 @@ public class RedeclareInspectionTest extends GoInspectionTestCase {
 
     public void testInit() throws Exception{ doTest(); }
 
-    @Ignore("broken by the new resolver")
     public void testMultiFiles() throws Exception{ doTestWithDirectory(); }
 
     @Ignore("failing test")


### PR DESCRIPTION
All tests passed.

@mtoader , Is there a reason to remove gofile argument passed into GoInspectionTestCase.processFile()? I may need to consider it too.
