### PR TITLE
add a test case for #599 Symbols from *_test.go files in the same package should be shared.

### DIFF
--- a/test/ro/redeul/google/go/inspection/UnresolvedSymbolsTest.java
+++ b/test/ro/redeul/google/go/inspection/UnresolvedSymbolsTest.java
@@ -82,4 +82,9 @@ public class UnresolvedSymbolsTest extends GoInspectionTestCase {
     public void testError() throws Exception {
         doTest();
     }
+
+    @Ignore("failing test")
+    public void testGoTestFiles() throws Exception{
+        doTestWithDirectory();
+    }
 }

--- a/testdata/inspection/unresolvedSymbols/goTestFiles/goTestFiles_test.go
+++ b/testdata/inspection/unresolvedSymbols/goTestFiles/goTestFiles_test.go
@@ -1,0 +1,3 @@
+package goTestFiles
+
+type T1 int

--- a/testdata/inspection/unresolvedSymbols/goTestFiles/tt_test.go
+++ b/testdata/inspection/unresolvedSymbols/goTestFiles/tt_test.go
@@ -1,0 +1,6 @@
+package goTestFiles
+
+
+func good1(){
+	_ = T1(1)
+}


### PR DESCRIPTION
This is a test case for #599
