### PR TITLE
Remove error message that couldn't be displayed anyway [fixes #955]

### DIFF
--- a/src/ro/redeul/google/go/ide/GoGlobalConfigurableForm.java
+++ b/src/ro/redeul/google/go/ide/GoGlobalConfigurableForm.java
@@ -60,7 +60,6 @@ public class GoGlobalConfigurableForm {
         sdkList.addAll(GoSdkUtil.getSdkOfType(GoAppEngineSdkType.getInstance(), jdkTable));
 
         if (sdkList.size() == 0) {
-            Messages.showErrorDialog("No GO or GO AppEngine SDK could be identified. Please create one first (by creating a project).", "Error on Google Go Plugin");
             return;
         }
 


### PR DESCRIPTION
@zolotov or @ignatov if you guys have a better idea, please let me know. Thanks.

@mtoader I leave this up to you but I'd rather have one of the guys having a look on this one, maybe we can have a better solution for it.

The full error that happens otherwise is:

``` java

[   6636]  ERROR - ellij.openapi.ui.DialogWrapper - Dialog must be init in EDT only: Thread[ApplicationImpl pooled thread 4,4,main] 
java.lang.Throwable
    at com.intellij.openapi.diagnostic.Logger.error(Logger.java:115)
    at com.intellij.openapi.ui.DialogWrapper.init(DialogWrapper.java:1165)
    at com.intellij.openapi.ui.Messages$MessageDialog._init(Messages.java:1391)
    at com.intellij.openapi.ui.Messages$MessageDialog.<init>(Messages.java:1358)
    at com.intellij.openapi.ui.Messages.showDialog(Messages.java:278)
    at com.intellij.openapi.ui.Messages.showDialog(Messages.java:291)
    at com.intellij.openapi.ui.Messages.showDialog(Messages.java:302)
    at com.intellij.openapi.ui.Messages.showErrorDialog(Messages.java:739)
    at ro.redeul.google.go.ide.GoGlobalConfigurableForm.populateFromSDKs(GoGlobalConfigurableForm.java:63)
    at ro.redeul.google.go.ide.GoGlobalConfigurableForm.<init>(GoGlobalConfigurableForm.java:53)
    at ro.redeul.google.go.ide.GoGlobalConfigurable.createComponent(GoGlobalConfigurable.java:47)
    at com.intellij.openapi.options.ex.ConfigurableWrapper.createComponent(ConfigurableWrapper.java:162)
    at com.intellij.openapi.options.newEditor.OptionsEditor$Simple.<init>(OptionsEditor.java:1052)
    at com.intellij.openapi.options.newEditor.OptionsEditor.initConfigurable(OptionsEditor.java:507)
    at com.intellij.openapi.options.newEditor.OptionsEditor.access$1900(OptionsEditor.java:67)
    at com.intellij.openapi.options.newEditor.OptionsEditor$9$1$1.run(OptionsEditor.java:476)
    at com.intellij.openapi.application.impl.ApplicationImpl.runEdtSafeAction(ApplicationImpl.java:1090)
    at com.intellij.openapi.options.newEditor.OptionsEditor$9$1.run(OptionsEditor.java:469)
    at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:905)
    at com.intellij.openapi.options.newEditor.OptionsEditor$9.run(OptionsEditor.java:466)
    at com.intellij.openapi.application.impl.ApplicationImpl$8.run(ApplicationImpl.java:405)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
    at org.jetbrains.ide.PooledThreadExecutor$1$1.run(PooledThreadExecutor.java:56)
[   6641]  ERROR - ellij.openapi.ui.DialogWrapper - IntelliJ IDEA (Community Edition) IC-139.SNAPSHOT  Build #IC-139.SNAPSHOT 
[   6641]  ERROR - ellij.openapi.ui.DialogWrapper - JDK: 1.8.0_25 
[   6641]  ERROR - ellij.openapi.ui.DialogWrapper - VM: Java HotSpot(TM) 64-Bit Server VM 
[   6641]  ERROR - ellij.openapi.ui.DialogWrapper - Vendor: Oracle Corporation 
[   6641]  ERROR - ellij.openapi.ui.DialogWrapper - OS: Linux 
[   6641]  ERROR - ellij.openapi.ui.DialogWrapper - Last Action: ShowSettings 
[   6663]  ERROR - plication.impl.ApplicationImpl - The DialogWrapper can be used only on event dispatch thread. 
java.lang.IllegalStateException: The DialogWrapper can be used only on event dispatch thread.
    at com.intellij.openapi.ui.DialogWrapper.ensureEventDispatchThread(DialogWrapper.java:1998)
    at com.intellij.openapi.ui.DialogWrapper.showAndGetOk(DialogWrapper.java:1553)
    at com.intellij.openapi.ui.DialogWrapper.show(DialogWrapper.java:1536)
    at com.intellij.openapi.ui.Messages$MessageDialog.show(Messages.java:1478)
    at com.intellij.openapi.ui.Messages.showDialog(Messages.java:279)
    at com.intellij.openapi.ui.Messages.showDialog(Messages.java:291)
    at com.intellij.openapi.ui.Messages.showDialog(Messages.java:302)
    at com.intellij.openapi.ui.Messages.showErrorDialog(Messages.java:739)
    at ro.redeul.google.go.ide.GoGlobalConfigurableForm.populateFromSDKs(GoGlobalConfigurableForm.java:63)
    at ro.redeul.google.go.ide.GoGlobalConfigurableForm.<init>(GoGlobalConfigurableForm.java:53)
    at ro.redeul.google.go.ide.GoGlobalConfigurable.createComponent(GoGlobalConfigurable.java:47)
    at com.intellij.openapi.options.ex.ConfigurableWrapper.createComponent(ConfigurableWrapper.java:162)
    at com.intellij.openapi.options.newEditor.OptionsEditor$Simple.<init>(OptionsEditor.java:1052)
    at com.intellij.openapi.options.newEditor.OptionsEditor.initConfigurable(OptionsEditor.java:507)
    at com.intellij.openapi.options.newEditor.OptionsEditor.access$1900(OptionsEditor.java:67)
    at com.intellij.openapi.options.newEditor.OptionsEditor$9$1$1.run(OptionsEditor.java:476)
    at com.intellij.openapi.application.impl.ApplicationImpl.runEdtSafeAction(ApplicationImpl.java:1090)
    at com.intellij.openapi.options.newEditor.OptionsEditor$9$1.run(OptionsEditor.java:469)
    at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:905)
    at com.intellij.openapi.options.newEditor.OptionsEditor$9.run(OptionsEditor.java:466)
    at com.intellij.openapi.application.impl.ApplicationImpl$8.run(ApplicationImpl.java:405)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
    at org.jetbrains.ide.PooledThreadExecutor$1$1.run(PooledThreadExecutor.java:56)

```
