### PR TITLE
Fix NPE when IDEA is closing and the action is invoked for the unsaved file

### DIFF
--- a/src/ro/redeul/google/go/components/EditorTweakingComponent.java
+++ b/src/ro/redeul/google/go/components/EditorTweakingComponent.java
@@ -60,6 +60,9 @@ public class EditorTweakingComponent extends FileDocumentManagerAdapter {
             ApplicationManager.getApplication().invokeLater(new Runnable() {
                 @Override
                 public void run() {
+                    if (p.isDisposed()) {
+                        return;
+                    }
                     ProcessFileWithGoImports(p, file);
                 }
             });
@@ -67,6 +70,9 @@ public class EditorTweakingComponent extends FileDocumentManagerAdapter {
             ApplicationManager.getApplication().invokeLater(new Runnable() {
                 @Override
                 public void run() {
+                    if (p.isDisposed()) {
+                        return;
+                    }
                     ProcessFileWithGoFmt(p, file);
                 }
             });


### PR DESCRIPTION
I came across this by mistake.
It happens when you close IDEA on a previously backgrounded save action. It's a really hard one to replicate but at least the fix is easy :)
