### PR TITLE
[WIP]fix #993

### DIFF
--- a/src/ro/redeul/google/go/lang/packages/GoPackages.java
+++ b/src/ro/redeul/google/go/lang/packages/GoPackages.java
@@ -155,7 +155,7 @@ public class GoPackages extends AbstractProjectComponent {
         if ( sourcePackage != null && targetPackage != null && !sourcePackage.equals(targetPackage) ) {
             GoPackage builtin = GoPackages.getInstance(source.getProject()).getBuiltinPackage();
 
-            if ( !builtin.equals(targetPackage))
+            if ( builtin!=null && !builtin.equals(targetPackage))
                 return targetPackage;
         }
 

--- a/test/ro/redeul/google/go/inspection/FunctionCallInspectionTest.java
+++ b/test/ro/redeul/google/go/inspection/FunctionCallInspectionTest.java
@@ -51,4 +51,8 @@ public class FunctionCallInspectionTest extends GoInspectionTestCase {
 
     @Ignore("failing test")
     public void testIssue686() throws Exception{ doTest(); }
+
+    public void testIssue993() throws Exception{
+        doTestWithDirectory(false);
+    }
 }

--- a/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
+++ b/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
@@ -56,12 +56,14 @@ public abstract class GoInspectionTestCase
 
     protected void doTest() throws Exception {
         addPackageBuiltin();
-        doTestWithOneFile((GoFile)myFixture.configureByFile(getTestName(true) + ".go"));
+        doTestWithOneFile((GoFile) myFixture.configureByFile(getTestName(true) + ".go"));
     }
 
-    protected void doTestWithDirectory() throws Exception {
+    protected void doTestWithDirectory(boolean isAddBuiltinPackage) throws Exception {
         final File folder = new File(getTestDataPath(), getTestName(true));
-        addPackageBuiltin();
+        if (isAddBuiltinPackage) {
+            addPackageBuiltin();
+        }
         List<File> files = new ArrayList<File>();
         FileUtil.collectMatchedFiles(folder, Pattern.compile(".*\\.go$"), files);
         List<String> fileNames = ContainerUtil.map(files, new Function<File, String>() {
@@ -74,6 +76,10 @@ public abstract class GoInspectionTestCase
         for (PsiFile psi : psiFiles) {
             doTestWithOneFile((GoFile)psi);
         }
+    }
+
+    protected void doTestWithDirectory() throws Exception {
+        doTestWithDirectory(true);
     }
 
     private void doTestWithOneFile(GoFile file) throws Exception {

--- a/testdata/inspection/functionCall/issue993/p1/p1.go
+++ b/testdata/inspection/functionCall/issue993/p1/p1.go
@@ -1,0 +1,7 @@
+package p1
+
+type TSturct struct{}
+
+func (t TSturct) Good2() {
+
+}

--- a/testdata/inspection/functionCall/issue993/p2/p2.go
+++ b/testdata/inspection/functionCall/issue993/p2/p2.go
@@ -1,0 +1,10 @@
+package p2
+
+import (
+	"issue993/p1"
+)
+
+func test1() {
+	t := p1.TSturct{}
+	t.Good2()
+}


### PR DESCRIPTION
Add a test case and fix #993
This NPE happened because GoPackages.getTargetPackageIfDifferent do not handle builtin package not exist case.
This PR is conflict with #1001 , please first merge one of them, then I will rebase another one.
