### PR TITLE
Add library support to the plugin

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -715,6 +715,8 @@
 
         <xdebugger.breakpointType implementation="uk.co.cwspencer.ideagdb.debug.breakpoints.GdbBreakpointType"/>
 
+        <library.type id="go.library.type" implementation="ro.redeul.google.go.library.GoLibraryType"/>
+
     </extensions>
 
 </idea-plugin>

--- a/src/ro/redeul/google/go/GoBundle.properties
+++ b/src/ro/redeul/google/go/GoBundle.properties
@@ -185,6 +185,8 @@ go.error.report.message=<html>Error Submitting Feedback: {0}<br>\
   Consider creating an issue at \
   <a href="https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues">Github Issue Tracker</a></html>
 go.error.report.action=&Report on Github
+go.new.package.file.chooser.title=New Go Package Files
+go.new.package.file.chooser.description=Select the directory in which the Go package files are located
 
 fix.add.import.choose.package.path=Choose package path
 fix.add.import.text=import "{0}"

--- a/src/ro/redeul/google/go/components/GoSdkParsingHelper.java
+++ b/src/ro/redeul/google/go/components/GoSdkParsingHelper.java
@@ -117,21 +117,6 @@ public class GoSdkParsingHelper implements ApplicationComponent {
         return relativePath;
     }
 
-    private String getPackageImportPathFromProject(ProjectFileIndex projectIndex, VirtualFile virtualFile) {
-
-        VirtualFile contentRoot = projectIndex.getContentRootForFile(virtualFile);
-        if ( contentRoot == null ) {
-            return "";
-        }
-
-        String relativePath = VfsUtil.getRelativePath(virtualFile, contentRoot.getParent(), '/');
-        if ( relativePath == null ) {
-            return "";
-        }
-
-        return "";
-    }
-
     private Map<String, String> findPackageMappings(Sdk ownerSdk) {
         Map<String, String> result = new HashMap<String, String>();
 

--- a/src/ro/redeul/google/go/library/GoLibrary.java
+++ b/src/ro/redeul/google/go/library/GoLibrary.java
@@ -1,0 +1,13 @@
+package ro.redeul.google.go.library;
+
+import com.intellij.openapi.roots.libraries.LibraryKind;
+
+/**
+ * @author Florin Patan
+ */
+public interface GoLibrary {
+    String GO_LIBRARY_TYPE_ID = "Go";
+    String GO_LIBRARY_CATEGORY_NAME = "Go";
+    String GO_LIBRARY_KIND_ID = "Go";
+    LibraryKind KIND = LibraryKind.create(GO_LIBRARY_KIND_ID);
+}

--- a/src/ro/redeul/google/go/library/GoLibraryProperties.java
+++ b/src/ro/redeul/google/go/library/GoLibraryProperties.java
@@ -1,0 +1,31 @@
+package ro.redeul.google.go.library;
+
+import com.intellij.openapi.roots.libraries.LibraryProperties;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+/**
+ * @author Florin Patan
+ */
+public class GoLibraryProperties extends LibraryProperties {
+    private Object comparable = new Object();
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public Object getState() {
+        return null;
+    }
+
+    @Override
+    public void loadState(Object o) {
+    }
+}

--- a/src/ro/redeul/google/go/library/GoLibraryType.java
+++ b/src/ro/redeul/google/go/library/GoLibraryType.java
@@ -1,0 +1,98 @@
+package ro.redeul.google.go.library;
+
+import com.intellij.openapi.fileChooser.FileChooser;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.libraries.LibraryType;
+import com.intellij.openapi.roots.libraries.NewLibraryConfiguration;
+import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
+import com.intellij.openapi.roots.libraries.ui.LibraryEditorComponent;
+import com.intellij.openapi.roots.libraries.ui.LibraryPropertiesEditor;
+import com.intellij.openapi.roots.ui.configuration.libraryEditor.LibraryEditor;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import ro.redeul.google.go.GoBundle;
+import ro.redeul.google.go.GoFileType;
+import ro.redeul.google.go.GoIcons;
+
+import javax.swing.*;
+import java.util.List;
+
+/**
+ * @author Florin Patan
+ */
+public class GoLibraryType extends LibraryType<GoLibraryProperties> implements GoLibrary {
+    private static final PersistentLibraryKind<GoLibraryProperties> LIBRARY_KIND =
+            new PersistentLibraryKind<GoLibraryProperties>(GO_LIBRARY_KIND_ID) {
+                @NotNull
+                @Override
+                public GoLibraryProperties createDefaultProperties() {
+                    return new GoLibraryProperties();
+                }
+            };
+
+    protected GoLibraryType() {
+        super(LIBRARY_KIND);
+    }
+
+
+    @NotNull
+    @Override
+    public String getCreateActionName() {
+        return "New Go package";
+    }
+
+    @Override
+    public NewLibraryConfiguration createNewLibrary(@NotNull JComponent jComponent, @Nullable VirtualFile virtualFile,
+                                                    @NotNull Project project) {
+        final FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createAllButJarContentsDescriptor();
+        descriptor.setTitle(GoBundle.message("go.new.package.file.chooser.title"));
+        descriptor.setDescription(GoBundle.message("go.new.package.file.chooser.description"));
+        final VirtualFile[] files = FileChooser.chooseFiles(descriptor, project, virtualFile);
+
+        if (files.length == 0) {
+            return null;
+        }
+        return new NewLibraryConfiguration("Go package", this, new GoLibraryProperties()) {
+            @Override
+            public void addRoots(@NotNull LibraryEditor editor) {
+                for (VirtualFile file : files) {
+                    editor.addRoot(file, OrderRootType.CLASSES);
+                }
+            }
+        };
+    }
+
+    @Override
+    public Icon getIcon() {
+        return GoIcons.GO_ICON_16x16;
+    }
+
+    @Override
+    public LibraryPropertiesEditor createPropertiesEditor(@NotNull LibraryEditorComponent<GoLibraryProperties>
+                                                                  libraryPropertiesLibraryEditorComponent) {
+
+        return null;
+    }
+
+    @Override
+    public GoLibraryProperties detect(@NotNull List<VirtualFile> classesRoots) {
+        for (VirtualFile vf : classesRoots) {
+            if (!vf.isDirectory())
+                return null;
+
+            for(VirtualFile file : vf.getChildren()) {
+                String fileExtension = file.getExtension();
+                if (fileExtension != null)
+                    if (fileExtension.equals(GoFileType.DEFAULT_EXTENSION))
+                        return new GoLibraryProperties();
+            }
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
~~This does the following:~~
- ~~ensures that only files terminating with `.go` will be used in the parsing process~~
- ~~allows files from `OrderRootType.SOURCES` to be parsed, not from `OrderRootType.CLASSES`~~
- ~~remove the unused function from the file, thus a small cleanup~~
- ~~adds library support to the plugin~~

~~According to the [IntelliJ sources](https://github.com/JetBrains/intellij-community/blob/master/platform/projectModel-api/src/com/intellij/openapi/roots/OrderRootType.java#L57), `OrderRootType.SOURCES` should be the place where the source files are found, thus the `.go` files, while `OrderRootType.CLASSES` is the place where the classes are found, thus the `.a` files.
As we currently don't parse `.a` files, we should change this to allow a more native behavior. Also it has the nice side effect that we can support again creating an IntelliJ project inside the GOPATH and still use the GOPATH as it is.
I'm also pending clarification on this one on Gitter, to be sure I'm not wrong.~~

This adds library support to the plugin ~~and thus fixes everything~~.
