### PR TITLE
v1.0.0 Override previous plugin version

### DIFF
--- a/.idea/copyright/apache.xml
+++ b/.idea/copyright/apache.xml
@@ -1,8 +1,9 @@
 <component name="CopyrightManager">
   <copyright>
+    <option name="notice" value="Copyright 2013-&amp;#36;today.year Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="keyword" value="Copyright" />
     <option name="allowReplaceKeyword" value="Copyright" />
     <option name="myName" value="apache" />
-    <option name="notice" value="Copyright 2013-&amp;#36;today.year Sergey Ignatov, Alexander Zolotov, Mihai Toader&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
     <option name="myLocal" value="true" />
   </copyright>
 </component>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader
+  ~ Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,14 +15,25 @@
   -->
 
 <idea-plugin version="2">
-  <id>com.goide</id>
-  <name>Go</name>
+  <id>ro.redeul.google.go</id>
+  <name>Go language (golang.org) support plugin</name>
   <version>1.0</version>
-  <vendor>Oh ltd.</vendor>
+  <vendor url="https://github.com/go-lang-plugin-org/go-lang-idea-plugin"/>
+  <category>Custom Languages</category>
 
-  <description><![CDATA[]]></description>
+  <description>
+    <![CDATA[<h2>Support for Go programming language.</h2>
+    ]]>
+  </description>
 
-  <change-notes><![CDATA[]]></change-notes>
+  <change-notes>
+    <![CDATA[
+    <h3>1.0.0 changes:</h3>
+        <ul>
+            <li>[improvement] Fully reworked insternals</li>
+        </ul>
+    ]]>
+  </change-notes>
 
   <idea-version since-build="138.2210"/>
   <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
As it's difficult to jump versions when one of the plugin version needs to be disabled and another to be enabled I've added some of the things there.
Also, I've updated the copyright profile to add me as well, hope that's ok.

@ignatov the one major problem I've had in doing this PR was to remove all the artificial differences created in the `.xml` files by IDEA. Is there any way that I need to setup my environment so that I don't bump into this anymore? Thanks.
