### PR TITLE
Add go1.4 support

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -32,6 +32,9 @@
         <option name="FORMATTER_TAGS_ENABLED" value="true" />
         <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
         <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
+        <JavaCodeStyleSettings>
+          <option name="LEGACY_SETTING_USE_FQ_CLASS_NAMES_IN_JAVADOC_IMPORTED" value="true" />
+        </JavaCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -32,9 +32,6 @@
         <option name="FORMATTER_TAGS_ENABLED" value="true" />
         <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
         <option name="BLOCK_COMMENT_AT_FIRST_COLUMN" value="false" />
-        <JavaCodeStyleSettings>
-          <option name="LEGACY_SETTING_USE_FQ_CLASS_NAMES_IN_JAVADOC_IMPORTED" value="true" />
-        </JavaCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/.idea/dictionaries/ignatov.xml
+++ b/.idea/dictionaries/ignatov.xml
@@ -2,6 +2,7 @@
   <dictionary name="ignatov">
     <words>
       <w>variadic</w>
+      <w>zolotov</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/inspectionProfiles/idea_default.xml
+++ b/.idea/inspectionProfiles/idea_default.xml
@@ -251,7 +251,6 @@
       <option name="m_ignoreLoopsWithoutConditions" value="false" />
     </inspection_tool>
     <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FunctionWithInconsistentReturnsJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GemInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Geronimo" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="GlassFish" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -563,13 +562,7 @@
     <inspection_tool class="PyUnboundLocalVariableInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnnecessaryBackslashInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnreachableCodeInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="ignoredIdentifiers">
-        <value>
-          <list size="0" />
-        </value>
-      </option>
-    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreTupleUnpacking" value="true" />
       <option name="ignoreLambdaParameters" value="true" />

--- a/.idea/inspectionProfiles/idea_default.xml
+++ b/.idea/inspectionProfiles/idea_default.xml
@@ -251,6 +251,7 @@
       <option name="m_ignoreLoopsWithoutConditions" value="false" />
     </inspection_tool>
     <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="FunctionWithInconsistentReturnsJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GemInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Geronimo" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="GlassFish" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -562,7 +563,13 @@
     <inspection_tool class="PyUnboundLocalVariableInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnnecessaryBackslashInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnreachableCodeInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoredIdentifiers">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
     <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreTupleUnpacking" value="true" />
       <option name="ignoreLambdaParameters" value="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,10 +3,8 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="ProjectKey">
-    <option name="state" value="git@github.com:go-lang-plugin-org/go-lang-idea-plugin.git" />
-  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA sdk" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
+

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,8 +3,10 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
+  <component name="ProjectKey">
+    <option name="state" value="git@github.com:go-lang-plugin-org/go-lang-idea-plugin.git" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="IDEA sdk" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
-

--- a/.idea/runConfigurations/All_in_intellij_go.xml
+++ b/.idea/runConfigurations/All_in_intellij_go.xml
@@ -18,10 +18,16 @@
     </option>
     <envs />
     <patterns />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="" />
+      <option name="TRANSPORT" value="0" />
+      <option name="LOCAL" value="true" />
+    </RunnerSettings>
     <RunnerSettings RunnerId="Profile ">
       <option name="myExternalizedOptions" value="&#10;additional-options2=onexit\=snapshot&#10;" />
     </RunnerSettings>
     <RunnerSettings RunnerId="Run" />
+    <ConfigurationWrapper RunnerId="Debug" />
     <ConfigurationWrapper RunnerId="Run" />
     <method />
   </configuration>

--- a/gen/com/goide/GoTypes.java
+++ b/gen/com/goide/GoTypes.java
@@ -101,6 +101,7 @@ public interface GoTypes {
   IElementType TYPE_ASSERTION_EXPR = new GoCompositeElementType("TYPE_ASSERTION_EXPR");
   IElementType TYPE_CASE_CLAUSE = new GoCompositeElementType("TYPE_CASE_CLAUSE");
   IElementType TYPE_DECLARATION = new GoCompositeElementType("TYPE_DECLARATION");
+  IElementType TYPE_GUARD = new GoCompositeElementType("TYPE_GUARD");
   IElementType TYPE_LIST = new GoCompositeElementType("TYPE_LIST");
   IElementType TYPE_REFERENCE_EXPRESSION = new GoCompositeElementType("TYPE_REFERENCE_EXPRESSION");
   IElementType TYPE_SPEC = GoStubElementTypeFactory.factory("TYPE_SPEC");
@@ -470,6 +471,9 @@ public interface GoTypes {
       }
       else if (type == TYPE_DECLARATION) {
         return new GoTypeDeclarationImpl(node);
+      }
+      else if (type == TYPE_GUARD) {
+        return new GoTypeGuardImpl(node);
       }
       else if (type == TYPE_LIST) {
         return new GoTypeListImpl(node);

--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -1915,7 +1915,7 @@ public class GoParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // FieldName & ':' | ElementIndex
+  // FieldName &':' | ElementIndex
   public static boolean Key(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "Key")) return false;
     boolean r;
@@ -1926,7 +1926,7 @@ public class GoParser implements PsiParser {
     return r;
   }
 
-  // FieldName & ':'
+  // FieldName &':'
   private static boolean Key_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "Key_0")) return false;
     boolean r;
@@ -1937,7 +1937,7 @@ public class GoParser implements PsiParser {
     return r;
   }
 
-  // & ':'
+  // &':'
   private static boolean Key_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "Key_0_1")) return false;
     boolean r;

--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -493,12 +493,13 @@ public class GoParser implements PsiParser {
   // Statements '}'
   private static boolean Block_1_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "Block_1_1")) return false;
-    boolean r;
-    Marker m = enter_section_(b);
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, null);
     r = Statements(b, l + 1);
+    p = r; // pin = 1
     r = r && consumeToken(b, RBRACE);
-    exit_section_(b, m, null, r);
-    return r;
+    exit_section_(b, l, m, null, r, p, null);
+    return r || p;
   }
 
   /* ********************************************************** */

--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -289,6 +289,9 @@ public class GoParser implements PsiParser {
     else if (t == TYPE_DECLARATION) {
       r = TypeDeclaration(b, 0);
     }
+    else if (t == TYPE_GUARD) {
+      r = TypeGuard(b, 0);
+    }
     else if (t == TYPE_LIST) {
       r = TypeList(b, 0);
     }
@@ -3255,6 +3258,21 @@ public class GoParser implements PsiParser {
   }
 
   /* ********************************************************** */
+  // '(' 'type' ')'
+  public static boolean TypeGuard(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "TypeGuard")) return false;
+    if (!nextTokenIs(b, LPAREN)) return false;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, null);
+    r = consumeToken(b, LPAREN);
+    r = r && consumeToken(b, TYPE_);
+    p = r; // pin = 2
+    r = r && consumeToken(b, RPAREN);
+    exit_section_(b, l, m, TYPE_GUARD, r, p, null);
+    return r || p;
+  }
+
+  /* ********************************************************** */
   // Type ( ',' Type )*
   public static boolean TypeList(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "TypeList")) return false;
@@ -3466,20 +3484,17 @@ public class GoParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // [ VarDefinition ':=' ] Expression '.' '(' 'type' ')'
+  // [ VarDefinition ':=' ] Expression '.' TypeGuard
   public static boolean TypeSwitchGuard(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "TypeSwitchGuard")) return false;
-    boolean r, p;
+    boolean r;
     Marker m = enter_section_(b, l, _NONE_, "<type switch guard>");
     r = TypeSwitchGuard_0(b, l + 1);
     r = r && Expression(b, l + 1, -1);
     r = r && consumeToken(b, DOT);
-    r = r && consumeToken(b, LPAREN);
-    r = r && consumeToken(b, TYPE_);
-    p = r; // pin = 5
-    r = r && consumeToken(b, RPAREN);
-    exit_section_(b, l, m, TYPE_SWITCH_GUARD, r, p, null);
-    return r || p;
+    r = r && TypeGuard(b, l + 1);
+    exit_section_(b, l, m, TYPE_SWITCH_GUARD, r, false, null);
+    return r;
   }
 
   // [ VarDefinition ':=' ]

--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -1218,19 +1218,19 @@ public class GoParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // Expression (',' (Expression | &')'))*
+  // ExpressionWithRecover (',' (ExpressionWithRecover | &')'))*
   static boolean ExpressionList(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "ExpressionList")) return false;
     boolean r, p;
     Marker m = enter_section_(b, l, _NONE_, null);
-    r = Expression(b, l + 1, -1);
+    r = ExpressionWithRecover(b, l + 1);
     p = r; // pin = 1
     r = r && ExpressionList_1(b, l + 1);
     exit_section_(b, l, m, null, r, p, null);
     return r || p;
   }
 
-  // (',' (Expression | &')'))*
+  // (',' (ExpressionWithRecover | &')'))*
   private static boolean ExpressionList_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "ExpressionList_1")) return false;
     int c = current_position_(b);
@@ -1242,7 +1242,7 @@ public class GoParser implements PsiParser {
     return true;
   }
 
-  // ',' (Expression | &')')
+  // ',' (ExpressionWithRecover | &')')
   private static boolean ExpressionList_1_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "ExpressionList_1_0")) return false;
     boolean r, p;
@@ -1254,12 +1254,12 @@ public class GoParser implements PsiParser {
     return r || p;
   }
 
-  // Expression | &')'
+  // ExpressionWithRecover | &')'
   private static boolean ExpressionList_1_0_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "ExpressionList_1_0_1")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = Expression(b, l + 1, -1);
+    r = ExpressionWithRecover(b, l + 1);
     if (!r) r = ExpressionList_1_0_1_1(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
@@ -1272,6 +1272,106 @@ public class GoParser implements PsiParser {
     Marker m = enter_section_(b, l, _AND_, null);
     r = consumeToken(b, RPAREN);
     exit_section_(b, l, m, null, r, false, null);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '<NL>' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | ']' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var)
+  static boolean ExpressionListRecover(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "ExpressionListRecover")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NOT_, null);
+    r = !ExpressionListRecover_0(b, l + 1);
+    exit_section_(b, l, m, null, r, false, null);
+    return r;
+  }
+
+  // '!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '<NL>' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | ']' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var
+  private static boolean ExpressionListRecover_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "ExpressionListRecover_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, NOT);
+    if (!r) r = consumeToken(b, NOT_EQ);
+    if (!r) r = consumeToken(b, REMAINDER);
+    if (!r) r = consumeToken(b, REMAINDER_ASSIGN);
+    if (!r) r = consumeToken(b, COND_AND);
+    if (!r) r = consumeToken(b, BIT_AND);
+    if (!r) r = consumeToken(b, BIT_AND_ASSIGN);
+    if (!r) r = consumeToken(b, BIT_CLEAR);
+    if (!r) r = consumeToken(b, BIT_CLEAR_ASSIGN);
+    if (!r) r = consumeToken(b, LPAREN);
+    if (!r) r = consumeToken(b, RPAREN);
+    if (!r) r = consumeToken(b, MUL);
+    if (!r) r = consumeToken(b, MUL_ASSIGN);
+    if (!r) r = consumeToken(b, PLUS);
+    if (!r) r = consumeToken(b, PLUS_PLUS);
+    if (!r) r = consumeToken(b, PLUS_ASSIGN);
+    if (!r) r = consumeToken(b, COMMA);
+    if (!r) r = consumeToken(b, MINUS);
+    if (!r) r = consumeToken(b, MINUS_MINUS);
+    if (!r) r = consumeToken(b, MINUS_ASSIGN);
+    if (!r) r = consumeToken(b, DOT);
+    if (!r) r = consumeToken(b, TRIPLE_DOT);
+    if (!r) r = consumeToken(b, QUOTIENT);
+    if (!r) r = consumeToken(b, QUOTIENT_ASSIGN);
+    if (!r) r = consumeToken(b, COLON);
+    if (!r) r = consumeToken(b, SEMICOLON);
+    if (!r) r = consumeToken(b, LESS);
+    if (!r) r = consumeToken(b, SEND_CHANNEL);
+    if (!r) r = consumeToken(b, SHIFT_LEFT);
+    if (!r) r = consumeToken(b, SHIFT_LEFT_ASSIGN);
+    if (!r) r = consumeToken(b, LESS_OR_EQUAL);
+    if (!r) r = consumeToken(b, SEMICOLON_SYNTHETIC);
+    if (!r) r = consumeToken(b, ASSIGN);
+    if (!r) r = consumeToken(b, EQ);
+    if (!r) r = consumeToken(b, GREATER);
+    if (!r) r = consumeToken(b, GREATER_OR_EQUAL);
+    if (!r) r = consumeToken(b, SHIFT_RIGHT);
+    if (!r) r = consumeToken(b, SHIFT_RIGHT_ASSIGN);
+    if (!r) r = consumeToken(b, LBRACK);
+    if (!r) r = consumeToken(b, RBRACK);
+    if (!r) r = consumeToken(b, BIT_XOR);
+    if (!r) r = consumeToken(b, BIT_XOR_ASSIGN);
+    if (!r) r = consumeToken(b, TYPE_);
+    if (!r) r = consumeToken(b, LBRACE);
+    if (!r) r = consumeToken(b, BIT_OR);
+    if (!r) r = consumeToken(b, BIT_OR_ASSIGN);
+    if (!r) r = consumeToken(b, COND_OR);
+    if (!r) r = consumeToken(b, RBRACE);
+    if (!r) r = consumeToken(b, BREAK);
+    if (!r) r = consumeToken(b, CASE);
+    if (!r) r = consumeToken(b, CHAN);
+    if (!r) r = consumeToken(b, CHAR);
+    if (!r) r = consumeToken(b, CONST);
+    if (!r) r = consumeToken(b, CONTINUE);
+    if (!r) r = consumeToken(b, DECIMALI);
+    if (!r) r = consumeToken(b, DEFAULT);
+    if (!r) r = consumeToken(b, DEFER);
+    if (!r) r = consumeToken(b, ELSE);
+    if (!r) r = consumeToken(b, FALLTHROUGH);
+    if (!r) r = consumeToken(b, FLOAT);
+    if (!r) r = consumeToken(b, FLOATI);
+    if (!r) r = consumeToken(b, FOR);
+    if (!r) r = consumeToken(b, FUNC);
+    if (!r) r = consumeToken(b, GO);
+    if (!r) r = consumeToken(b, GOTO);
+    if (!r) r = consumeToken(b, HEX);
+    if (!r) r = consumeToken(b, IDENTIFIER);
+    if (!r) r = consumeToken(b, IF);
+    if (!r) r = consumeToken(b, IMAGINARY);
+    if (!r) r = consumeToken(b, INT);
+    if (!r) r = consumeToken(b, INTERFACE);
+    if (!r) r = consumeToken(b, MAP);
+    if (!r) r = consumeToken(b, OCT);
+    if (!r) r = consumeToken(b, RETURN);
+    if (!r) r = consumeToken(b, RUNE);
+    if (!r) r = consumeToken(b, SELECT);
+    if (!r) r = consumeToken(b, STRING);
+    if (!r) r = consumeToken(b, STRUCT);
+    if (!r) r = consumeToken(b, SWITCH);
+    if (!r) r = consumeToken(b, VAR);
+    exit_section_(b, m, null, r);
     return r;
   }
 
@@ -1306,6 +1406,17 @@ public class GoParser implements PsiParser {
     r = Expression(b, l + 1, -1);
     r = r && exitMode(b, l + 1, "NO_EMPTY_LITERAL");
     exit_section_(b, m, null, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // Expression
+  static boolean ExpressionWithRecover(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "ExpressionWithRecover")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NONE_, null);
+    r = Expression(b, l + 1, -1);
+    exit_section_(b, l, m, null, r, false, ExpressionListRecover_parser_);
     return r;
   }
 
@@ -4272,6 +4383,11 @@ public class GoParser implements PsiParser {
     return r || p;
   }
 
+  final static Parser ExpressionListRecover_parser_ = new Parser() {
+    public boolean parse(PsiBuilder b, int l) {
+      return ExpressionListRecover(b, l + 1);
+    }
+  };
   final static Parser StatementRecover_parser_ = new Parser() {
     public boolean parse(PsiBuilder b, int l) {
       return StatementRecover(b, l + 1);

--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -383,13 +383,14 @@ public class GoParser implements PsiParser {
   public static boolean ArgumentList(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "ArgumentList")) return false;
     if (!nextTokenIs(b, LPAREN)) return false;
-    boolean r;
-    Marker m = enter_section_(b);
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, null);
     r = consumeToken(b, LPAREN);
-    r = r && ArgumentList_1(b, l + 1);
-    r = r && consumeToken(b, RPAREN);
-    exit_section_(b, m, ARGUMENT_LIST, r);
-    return r;
+    p = r; // pin = 1
+    r = r && report_error_(b, ArgumentList_1(b, l + 1));
+    r = p && consumeToken(b, RPAREN) && r;
+    exit_section_(b, l, m, ARGUMENT_LIST, r, p, null);
+    return r || p;
   }
 
   // [ ExpressionList '...'? ]

--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -3023,7 +3023,7 @@ public class GoParser implements PsiParser {
   }
 
   /* ********************************************************** */
-  // !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '<NL>' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | ']' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var)
+  // !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var)
   static boolean StatementRecover(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "StatementRecover")) return false;
     boolean r;
@@ -3033,7 +3033,7 @@ public class GoParser implements PsiParser {
     return r;
   }
 
-  // '!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '<NL>' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | ']' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var
+  // '!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var
   private static boolean StatementRecover_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "StatementRecover_0")) return false;
     boolean r;
@@ -3048,7 +3048,6 @@ public class GoParser implements PsiParser {
     if (!r) r = consumeToken(b, BIT_CLEAR);
     if (!r) r = consumeToken(b, BIT_CLEAR_ASSIGN);
     if (!r) r = consumeToken(b, LPAREN);
-    if (!r) r = consumeToken(b, RPAREN);
     if (!r) r = consumeToken(b, MUL);
     if (!r) r = consumeToken(b, MUL_ASSIGN);
     if (!r) r = consumeToken(b, PLUS);
@@ -3069,7 +3068,6 @@ public class GoParser implements PsiParser {
     if (!r) r = consumeToken(b, SHIFT_LEFT);
     if (!r) r = consumeToken(b, SHIFT_LEFT_ASSIGN);
     if (!r) r = consumeToken(b, LESS_OR_EQUAL);
-    if (!r) r = consumeToken(b, SEMICOLON_SYNTHETIC);
     if (!r) r = consumeToken(b, ASSIGN);
     if (!r) r = consumeToken(b, EQ);
     if (!r) r = consumeToken(b, GREATER);
@@ -3077,7 +3075,6 @@ public class GoParser implements PsiParser {
     if (!r) r = consumeToken(b, SHIFT_RIGHT);
     if (!r) r = consumeToken(b, SHIFT_RIGHT_ASSIGN);
     if (!r) r = consumeToken(b, LBRACK);
-    if (!r) r = consumeToken(b, RBRACK);
     if (!r) r = consumeToken(b, BIT_XOR);
     if (!r) r = consumeToken(b, BIT_XOR_ASSIGN);
     if (!r) r = consumeToken(b, TYPE_);

--- a/gen/com/goide/psi/GoArgumentList.java
+++ b/gen/com/goide/psi/GoArgumentList.java
@@ -13,7 +13,7 @@ public interface GoArgumentList extends GoCompositeElement {
   @NotNull
   PsiElement getLparen();
 
-  @NotNull
+  @Nullable
   PsiElement getRparen();
 
   @Nullable

--- a/gen/com/goide/psi/GoBuiltinCallExpr.java
+++ b/gen/com/goide/psi/GoBuiltinCallExpr.java
@@ -19,7 +19,7 @@ public interface GoBuiltinCallExpr extends GoExpression {
   @NotNull
   PsiElement getLparen();
 
-  @NotNull
+  @Nullable
   PsiElement getRparen();
 
 }

--- a/gen/com/goide/psi/GoFieldName.java
+++ b/gen/com/goide/psi/GoFieldName.java
@@ -4,10 +4,14 @@ package com.goide.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.goide.psi.impl.GoFieldNameReference;
 
 public interface GoFieldName extends GoCompositeElement {
 
   @NotNull
   PsiElement getIdentifier();
+
+  @NotNull
+  GoFieldNameReference getReference();
 
 }

--- a/gen/com/goide/psi/GoMapType.java
+++ b/gen/com/goide/psi/GoMapType.java
@@ -19,4 +19,10 @@ public interface GoMapType extends GoType {
   @NotNull
   PsiElement getMap();
 
+  @Nullable
+  GoType getKeyType();
+
+  @Nullable
+  GoType getValueType();
+
 }

--- a/gen/com/goide/psi/GoTypeGuard.java
+++ b/gen/com/goide/psi/GoTypeGuard.java
@@ -1,0 +1,19 @@
+// This is a generated file. Not intended for manual editing.
+package com.goide.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface GoTypeGuard extends GoCompositeElement {
+
+  @NotNull
+  PsiElement getLparen();
+
+  @Nullable
+  PsiElement getRparen();
+
+  @NotNull
+  PsiElement getType();
+
+}

--- a/gen/com/goide/psi/GoTypeSwitchGuard.java
+++ b/gen/com/goide/psi/GoTypeSwitchGuard.java
@@ -10,20 +10,14 @@ public interface GoTypeSwitchGuard extends GoCompositeElement {
   @NotNull
   GoExpression getExpression();
 
+  @NotNull
+  GoTypeGuard getTypeGuard();
+
   @Nullable
   GoVarDefinition getVarDefinition();
 
   @NotNull
   PsiElement getDot();
-
-  @NotNull
-  PsiElement getLparen();
-
-  @Nullable
-  PsiElement getRparen();
-
-  @NotNull
-  PsiElement getType();
 
   @Nullable
   PsiElement getVarAssign();

--- a/gen/com/goide/psi/GoVisitor.java
+++ b/gen/com/goide/psi/GoVisitor.java
@@ -368,6 +368,10 @@ public class GoVisitor extends PsiElementVisitor {
     visitTopLevelDeclaration(o);
   }
 
+  public void visitTypeGuard(@NotNull GoTypeGuard o) {
+    visitCompositeElement(o);
+  }
+
   public void visitTypeList(@NotNull GoTypeList o) {
     visitType(o);
   }

--- a/gen/com/goide/psi/impl/GoArgumentListImpl.java
+++ b/gen/com/goide/psi/impl/GoArgumentListImpl.java
@@ -34,9 +34,9 @@ public class GoArgumentListImpl extends GoCompositeElementImpl implements GoArgu
   }
 
   @Override
-  @NotNull
+  @Nullable
   public PsiElement getRparen() {
-    return findNotNullChildByType(RPAREN);
+    return findChildByType(RPAREN);
   }
 
   @Override

--- a/gen/com/goide/psi/impl/GoBuiltinCallExprImpl.java
+++ b/gen/com/goide/psi/impl/GoBuiltinCallExprImpl.java
@@ -46,9 +46,9 @@ public class GoBuiltinCallExprImpl extends GoExpressionImpl implements GoBuiltin
   }
 
   @Override
-  @NotNull
+  @Nullable
   public PsiElement getRparen() {
-    return findNotNullChildByType(RPAREN);
+    return findChildByType(RPAREN);
   }
 
 }

--- a/gen/com/goide/psi/impl/GoFieldNameImpl.java
+++ b/gen/com/goide/psi/impl/GoFieldNameImpl.java
@@ -27,4 +27,9 @@ public class GoFieldNameImpl extends GoCompositeElementImpl implements GoFieldNa
     return findNotNullChildByType(IDENTIFIER);
   }
 
+  @NotNull
+  public GoFieldNameReference getReference() {
+    return GoPsiImplUtil.getReference(this);
+  }
+
 }

--- a/gen/com/goide/psi/impl/GoMapTypeImpl.java
+++ b/gen/com/goide/psi/impl/GoMapTypeImpl.java
@@ -45,4 +45,18 @@ public class GoMapTypeImpl extends GoTypeImpl implements GoMapType {
     return findNotNullChildByType(MAP);
   }
 
+  @Override
+  @Nullable
+  public GoType getKeyType() {
+    List<GoType> p1 = getTypeList();
+    return p1.size() < 1 ? null : p1.get(0);
+  }
+
+  @Override
+  @Nullable
+  public GoType getValueType() {
+    List<GoType> p1 = getTypeList();
+    return p1.size() < 2 ? null : p1.get(1);
+  }
+
 }

--- a/gen/com/goide/psi/impl/GoTypeGuardImpl.java
+++ b/gen/com/goide/psi/impl/GoTypeGuardImpl.java
@@ -1,0 +1,42 @@
+// This is a generated file. Not intended for manual editing.
+package com.goide.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static com.goide.GoTypes.*;
+import com.goide.psi.*;
+
+public class GoTypeGuardImpl extends GoCompositeElementImpl implements GoTypeGuard {
+
+  public GoTypeGuardImpl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof GoVisitor) ((GoVisitor)visitor).visitTypeGuard(this);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getLparen() {
+    return findNotNullChildByType(LPAREN);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getRparen() {
+    return findChildByType(RPAREN);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getType() {
+    return findNotNullChildByType(TYPE_);
+  }
+
+}

--- a/gen/com/goide/psi/impl/GoTypeSwitchGuardImpl.java
+++ b/gen/com/goide/psi/impl/GoTypeSwitchGuardImpl.java
@@ -28,6 +28,12 @@ public class GoTypeSwitchGuardImpl extends GoCompositeElementImpl implements GoT
   }
 
   @Override
+  @NotNull
+  public GoTypeGuard getTypeGuard() {
+    return findNotNullChildByClass(GoTypeGuard.class);
+  }
+
+  @Override
   @Nullable
   public GoVarDefinition getVarDefinition() {
     return findChildByClass(GoVarDefinition.class);
@@ -37,24 +43,6 @@ public class GoTypeSwitchGuardImpl extends GoCompositeElementImpl implements GoT
   @NotNull
   public PsiElement getDot() {
     return findNotNullChildByType(DOT);
-  }
-
-  @Override
-  @NotNull
-  public PsiElement getLparen() {
-    return findNotNullChildByType(LPAREN);
-  }
-
-  @Override
-  @Nullable
-  public PsiElement getRparen() {
-    return findChildByType(RPAREN);
-  }
-
-  @Override
-  @NotNull
-  public PsiElement getType() {
-    return findNotNullChildByType(TYPE_);
   }
 
   @Override

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -166,7 +166,13 @@ MethodSpec ::= TypeName &(!'(') | identifier Signature {
   methods=[getGoType getName]
 }
 
-MapType ::= map '[' Type ']' Type {pin=1}
+MapType ::= map '[' Type ']' Type {
+  pin=1
+  methods = [
+    keyType="Type[0]"
+    valueType="Type[1]"
+  ]
+}
 ChannelType ::= ChanTypePrefix Type {pin=1}
 private ChanTypePrefix ::= chan '<-'? | '<-' chan {pin(".*")=1}
 
@@ -283,8 +289,10 @@ LiteralTypeExpr ::=
 LiteralValue ::= <<isModeOff "NO_EMPTY_LITERAL">> '{' '}' | '{' ElementList '}' // todo: not a smart solution
 private ElementList  ::= Element ( ',' Element? )*
 Element ::= [ Key ':' ] Value
-Key ::= FieldName & ':' | ElementIndex
-FieldName ::= identifier
+Key ::= FieldName &':' | ElementIndex
+FieldName ::= identifier {
+  methods=[getReference]
+}
 ElementIndex ::= Expression
 Value ::= Expression | LiteralValue
 

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -176,7 +176,7 @@ MapType ::= map '[' Type ']' Type {
 ChannelType ::= ChanTypePrefix Type {pin=1}
 private ChanTypePrefix ::= chan '<-'? | '<-' chan {pin(".*")=1}
 
-Block ::= '{' ('}' | Statements '}') {pin=1 methods=[processDeclarations]}
+Block ::= '{' ('}' | Statements '}') {pin(".*")=1 methods=[processDeclarations]}
 private Statements ::= StatementWithSemi* {pin=1}
 
 private StatementWithSemi ::= Statement (semi|&'}') { pin=1 recoverWhile=StatementRecover }

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -224,7 +224,9 @@ ConstDefinition ::= identifier {
   stubClass="com.goide.stubs.GoConstDefinitionStub"
 }
 
-private ExpressionList ::= Expression (',' (Expression | &')'))* {pin(".*")=1}
+private ExpressionList ::= ExpressionWithRecover (',' (ExpressionWithRecover | &')'))* {pin(".*")=1}
+private ExpressionWithRecover ::= Expression {recoverWhile=ExpressionListRecover}
+private ExpressionListRecover ::= !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '<NL>' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | ']' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var)
 
 TypeDeclaration ::= 'type' ( TypeSpec | '(' TypeSpecs? ')' ) {pin(".*")=1}
 private TypeSpecs ::= TypeSpec (semi TypeSpec)* semi? {pin=1}

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -319,7 +319,7 @@ AddExpr ::= Expression add_op Expression
 MulExpr ::= Expression mul_op Expression
 ParenthesesExpr ::= '(' Expression ')'
 
-BuiltinCallExpr ::= ReferenceExpression <<isBuiltin>> '(' [ BuiltinArgs ','? ] ')'
+BuiltinCallExpr ::= ReferenceExpression <<isBuiltin>> '(' [ BuiltinArgs ','? ] ')' {pin=3}
 BuiltinArgs ::= Type [ ',' ExpressionList '...'? ] | ExpressionList '...'?
 
 private MaxGroup ::=
@@ -350,7 +350,7 @@ private IndexExprBody ::= Expression
 private SliceExprBody ::= (Expression? ':' Expression ':' Expression) | (Expression? ':' Expression?)
 TypeAssertionExpr ::= Expression '.' '(' &(!'type') Type ')'
 CallExpr ::= Expression ArgumentList
-ArgumentList ::= '(' [ ExpressionList '...'? ] ')' {pin=0}
+ArgumentList ::= '(' [ ExpressionList '...'? ] ')' {pin=1}
 ConversionExpr ::= &ConversionPredicate Type ConversionTail
 private ConversionPredicate ::= ConversionStart | '(' ConversionStart
 private ConversionTail ::= '(' Expression ','? ')' {pin=1}

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -177,7 +177,7 @@ ChannelType ::= ChanTypePrefix Type {pin=1}
 private ChanTypePrefix ::= chan '<-'? | '<-' chan {pin(".*")=1}
 
 Block ::= '{' ('}' | Statements '}') {pin(".*")=1 methods=[processDeclarations]}
-private Statements ::= StatementWithSemi* {pin=1}
+private Statements ::= StatementWithSemi*
 
 private StatementWithSemi ::= Statement (semi|&'}') { pin=1 recoverWhile=StatementRecover }
 Statement ::=
@@ -199,7 +199,7 @@ Statement ::=
   | ForStatement
   | DeferStatement {methods=[processDeclarations]}
 
-private StatementRecover ::= !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '<NL>' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | ']' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var)
+private StatementRecover ::= !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '&^' | '&^=' | '(' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<-' | '<<' | '<<=' | '<=' | '=' | '==' | '>' | '>=' | '>>' | '>>=' | '[' | '^' | '^=' | 'type' | '{' | '|' | '|=' | '||' | '}' | break | case | chan | char | const | continue | decimali | default | defer | else | fallthrough | float | floati | for | func | go | goto | hex | identifier | if | imaginary | int | interface | map | oct | return | rune | select | string | struct | switch | var)
 
 SimpleStatement ::=
     AssignmentStatement

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -367,7 +367,8 @@ private SimpleStatementOpt ::= [SimpleStatement ';'?] // todo: remove ?
 ExprCaseClause ::= ExprSwitchCase ':' Statements?
 ExprSwitchCase ::= case ExpressionList | default {pin(".*")=1}
 left TypeSwitchStatement ::= (TypeSwitchGuard | SimpleStatement ';'? TypeSwitchGuard) '{' ( TypeCaseClause )* '}' {pin=1 extends=SwitchStatement}
-TypeSwitchGuard ::= [ VarDefinition ':=' ] Expression '.' '(' 'type' ')' {pin=5}
+TypeSwitchGuard ::= [ VarDefinition ':=' ] Expression '.' TypeGuard
+TypeGuard ::= '(' 'type' ')' {pin=2}
 TypeCaseClause ::= TypeSwitchCase ':' Statements?
 TypeSwitchCase ::= case TypeList | default {pin(".*")=1}
 TypeList ::= Type ( ',' Type )* {extends=Type}

--- a/jps-plugin/src/com/goide/jps/model/JpsGoSdkType.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoSdkType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.goide.jps.model;
 
 import com.intellij.execution.configurations.PathEnvironmentVariableUtil;

--- a/jps-plugin/src/com/goide/jps/model/JpsGoSdkType.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoSdkType.java
@@ -15,10 +15,12 @@ import java.io.File;
 public class JpsGoSdkType extends JpsSdkType<JpsDummyElement> implements JpsElementTypeWithDefaultProperties<JpsDummyElement> {
   public static final JpsGoSdkType INSTANCE = new JpsGoSdkType();
 
+  private static final String goExecName = SystemInfo.isWindows ? "go.exe" : "go";
+
   @NotNull
   public static File getGoExecutableFile(@NotNull String sdkHome) {
-    File fromSdkPath = getExecutable(new File(sdkHome, "bin").getAbsolutePath(), "go");
-    File fromEnvironment = PathEnvironmentVariableUtil.findInPath("go");
+    File fromSdkPath = getExecutable(new File(sdkHome, "bin").getAbsolutePath(), goExecName);
+    File fromEnvironment = PathEnvironmentVariableUtil.findInPath(goExecName);
     return fromSdkPath.canExecute() || fromEnvironment == null ? fromSdkPath : fromEnvironment;
   }
 

--- a/jps-plugin/tests/com/goide/jps/GoBuilderTest.java
+++ b/jps-plugin/tests/com/goide/jps/GoBuilderTest.java
@@ -17,7 +17,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class GoBuilderTest extends JpsBuildTestCase {
-  public static final String GO_LINUX_SDK_PATH = "/usr/lib/go";
+  public static final String GO_LINUX_SDK_PATH = "/usr/local/go";
+  public static final String GO_LINUX_SDK_PATH_ALTERNATIVE = "/usr/lib/go";
   public static final String GO_MAC_SDK_PATH = "/usr/local/go";
 
   public void testSimple() throws Exception {
@@ -72,7 +73,12 @@ public class GoBuilderTest extends JpsBuildTestCase {
 
   @NotNull
   private static String getGoSdkPath() {
-    if (SystemInfo.isLinux) return GO_LINUX_SDK_PATH;
+    if (SystemInfo.isLinux) {
+      if ((new File(GO_LINUX_SDK_PATH)).exists()) {
+        return GO_LINUX_SDK_PATH;
+      }
+      return GO_LINUX_SDK_PATH_ALTERNATIVE;
+    }
     if (SystemInfo.isMac) return GO_MAC_SDK_PATH;
     throw new RuntimeException("Only mac & linux supported");
   }

--- a/jps-plugin/tests/com/goide/jps/GoBuilderTest.java
+++ b/jps-plugin/tests/com/goide/jps/GoBuilderTest.java
@@ -1,3 +1,20 @@
+
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.goide.jps;
 
 import com.goide.jps.model.JpsGoSdkType;

--- a/resources/liveTemplates/go.xml
+++ b/resources/liveTemplates/go.xml
@@ -147,7 +147,7 @@
     <variable alwaysStopAt='true' defaultValue='' expression='complete()' name='KEY_TYPE'/>
     <variable alwaysStopAt='true' defaultValue='' expression='complete()' name='VALUE_TYPE'/>
     <context>
-      <option name='GO' value='true'/>
+      <option name='GO_TYPE' value='true'/>
     </context>
   </template>
   <template description='Variable declaration :=' name=':' toReformat='true' toShortenFQNames='true'

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -136,6 +136,8 @@
 
     <checkinHandlerFactory implementation="com.goide.actions.fmt.GoFmtCheckinFactory" order="last"/>
 
+    <editorNotificationProvider implementation="com.goide.inspections.SetupSDKNotificationProvider"/>
+    
     <lang.inspectionSuppressor language="go" implementationClass="com.goide.inspections.suppression.GoInspectionSuppressor"/>
     
     <localInspection language="go" displayName="Unresolved reference inspection"

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -65,6 +65,7 @@
     <liveTemplateContext implementation="com.goide.template.GoLiveTemplateContextType$GoEverywhereContextType"/>
     <liveTemplateContext implementation="com.goide.template.GoLiveTemplateContextType$GoFileContextType"/>
     <liveTemplateContext implementation="com.goide.template.GoLiveTemplateContextType$GoBlockContextType"/>
+    <liveTemplateContext implementation="com.goide.template.GoLiveTemplateContextType$GoTypeContextType"/>
     <liveTemplateMacro implementation="com.goide.template.DirectoryNameMacro"/>
 
     <lang.elementManipulator forClass="com.goide.psi.GoImportString"

--- a/src/com/goide/completion/BracesInsertHandler.java
+++ b/src/com/goide/completion/BracesInsertHandler.java
@@ -30,7 +30,19 @@ import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 
-public class AddBracesInsertHandler implements InsertHandler<LookupElement> {
+public class BracesInsertHandler implements InsertHandler<LookupElement> {
+  public static final BracesInsertHandler ONE_LINER = new BracesInsertHandler(true);
+  
+  private final boolean myOneLine;
+
+  public BracesInsertHandler(boolean oneLine) {
+    myOneLine = oneLine;
+  }
+
+  public BracesInsertHandler() {
+    this(false);
+  }
+
   @Override
   public void handleInsert(InsertionContext context, LookupElement item) {
     final Editor editor = context.getEditor();
@@ -38,7 +50,7 @@ public class AddBracesInsertHandler implements InsertHandler<LookupElement> {
     int offset = skipWhiteSpaces(editor.getCaretModel().getOffset(), documentText);
     if (documentText.charAt(offset) != '{') {
       Project project = context.getProject();
-      Template template = TemplateManager.getInstance(project).createTemplate("braces", "go", " {\n$END$\n}");
+      Template template = TemplateManager.getInstance(project).createTemplate("braces", "go", myOneLine ? "{$END$}" : " {\n$END$\n}");
       template.setToReformat(true);
       TemplateManager.getInstance(project).startTemplate(editor, template);
     }

--- a/src/com/goide/completion/GoKeywordCompletionContributor.java
+++ b/src/com/goide/completion/GoKeywordCompletionContributor.java
@@ -35,7 +35,7 @@ import static com.intellij.patterns.PlatformPatterns.psiFile;
 import static com.intellij.patterns.StandardPatterns.*;
 
 public class GoKeywordCompletionContributor extends CompletionContributor {
-  private static final AddBracesInsertHandler ADD_BRACES_INSERT_HANDLER = new AddBracesInsertHandler();
+  private static final BracesInsertHandler ADD_BRACES_INSERT_HANDLER = new BracesInsertHandler();
   private static final InsertHandler<LookupElement> ADD_BRACKETS_INSERT_HANDLER = new AddBracketsInsertHandler();
 
   public GoKeywordCompletionContributor() {

--- a/src/com/goide/completion/GoKeywordCompletionContributor.java
+++ b/src/com/goide/completion/GoKeywordCompletionContributor.java
@@ -52,7 +52,7 @@ public class GoKeywordCompletionContributor extends CompletionContributor {
     extend(CompletionType.BASIC, insideBlockPattern(GoTypes.IDENTIFIER),
            new GoKeywordCompletionProvider(GoCompletionUtil.KEYWORD_PRIORITY, ADD_BRACES_INSERT_HANDLER, "select"));
     extend(CompletionType.BASIC, typeDeclaration(),
-           new GoKeywordCompletionProvider(GoCompletionUtil.KEYWORD_PRIORITY, new AddBracesInsertHandler(),
+           new GoKeywordCompletionProvider(GoCompletionUtil.KEYWORD_PRIORITY, ADD_BRACES_INSERT_HANDLER,
                                            "interface", "struct"));
     extend(CompletionType.BASIC, insideForStatement(GoTypes.IDENTIFIER),
            new GoKeywordCompletionProvider(GoCompletionUtil.CONTEXT_KEYWORD_PRIORITY, EMPTY_INSERT_HANDLER, "break", "continue"));

--- a/src/com/goide/inspections/GoNoNewVariablesInspection.java
+++ b/src/com/goide/inspections/GoNoNewVariablesInspection.java
@@ -19,6 +19,7 @@ package com.goide.inspections;
 import com.goide.psi.GoShortVarDeclaration;
 import com.goide.psi.GoVarDefinition;
 import com.goide.psi.GoVisitor;
+import com.goide.psi.impl.GoPsiImplUtil;
 import com.intellij.codeInspection.LocalInspectionToolSession;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.util.TextRange;
@@ -49,6 +50,7 @@ public class GoNoNewVariablesInspection extends GoInspectionBase {
         int end = last.getStartOffsetInParent() + last.getTextLength();
 
         for (GoVarDefinition def : list) {
+          if (GoPsiImplUtil.isBlank(def)) continue;
           PsiReference reference = def.getReference();
           PsiElement resolve = reference != null ? reference.resolve() : null;
           if (resolve == null) return;

--- a/src/com/goide/inspections/SetupSDKNotificationProvider.java
+++ b/src/com/goide/inspections/SetupSDKNotificationProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.GoFileType;
+import com.goide.GoLanguage;
+import com.intellij.ProjectTopics;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectBundle;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ModuleRootAdapter;
+import com.intellij.openapi.roots.ModuleRootEvent;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.roots.ui.configuration.ProjectSettingsService;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.ui.EditorNotificationPanel;
+import com.intellij.ui.EditorNotifications;
+import org.jetbrains.annotations.NotNull;
+
+// todo: extract the common one
+public class SetupSDKNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> {
+  private static final Key<EditorNotificationPanel> KEY = Key.create("Setup Go SDK");
+
+  private final Project myProject;
+
+  public SetupSDKNotificationProvider(Project project, final EditorNotifications notifications) {
+    myProject = project;
+    myProject.getMessageBus().connect(project).subscribe(ProjectTopics.PROJECT_ROOTS, new ModuleRootAdapter() {
+      @Override
+      public void rootsChanged(ModuleRootEvent event) {
+        notifications.updateAllNotifications();
+      }
+    });
+  }
+
+  @NotNull
+  @Override
+  public Key<EditorNotificationPanel> getKey() {
+    return KEY;
+  }
+
+  @Override
+  public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor fileEditor) {
+    if (file.getFileType() != GoFileType.INSTANCE) return null;
+
+    PsiFile psiFile = PsiManager.getInstance(myProject).findFile(file);
+    if (psiFile == null) return null;
+
+    if (psiFile.getLanguage() != GoLanguage.INSTANCE) return null;
+
+    Module module = ModuleUtilCore.findModuleForPsiElement(psiFile);
+    if (module == null) return null;
+
+    Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+    if (sdk != null) return null;
+
+    return createPanel(myProject, psiFile);
+  }
+
+  @NotNull
+  private static EditorNotificationPanel createPanel(@NotNull final Project project, @NotNull final PsiFile file) {
+    EditorNotificationPanel panel = new EditorNotificationPanel();
+    panel.setText(ProjectBundle.message("project.sdk.not.defined"));
+    panel.createActionLabel(ProjectBundle.message("project.sdk.setup"), new Runnable() {
+      @Override
+      public void run() {
+        Sdk projectSdk = ProjectSettingsService.getInstance(project).chooseAndSetSdk();
+        if (projectSdk == null) return;
+        ApplicationManager.getApplication().runWriteAction(new Runnable() {
+          @Override
+          public void run() {
+            Module module = ModuleUtilCore.findModuleForPsiElement(file);
+            if (module != null) {
+              ModuleRootModificationUtil.setSdkInherited(module);
+            }
+          }
+        });
+      }
+    });
+    return panel;
+  }
+}

--- a/src/com/goide/inspections/unresolved/GoUnusedFunctionInspection.java
+++ b/src/com/goide/inspections/unresolved/GoUnusedFunctionInspection.java
@@ -43,6 +43,7 @@ public class GoUnusedFunctionInspection extends GoInspectionBase {
         GoFile file = o.getContainingFile();
         String name = o.getName();
         if ("main".equals(file.getPackageName()) && "main".equals(name)) return;
+        if ("init".equals(name)) return;
         if (GoTestFinder.isTestFile(file) && name != null && (name.startsWith("Test") || name.startsWith("Benchmark"))) return;
         Query<PsiReference> search = ReferencesSearch.search(o, o.getUseScope());
         if (search.findFirst() == null) {

--- a/src/com/goide/inspections/unresolved/GoUnusedVariableInspection.java
+++ b/src/com/goide/inspections/unresolved/GoUnusedVariableInspection.java
@@ -38,7 +38,7 @@ public class GoUnusedVariableInspection extends GoInspectionBase {
       @Override
       public void visitVarDefinition(@NotNull GoVarDefinition o) {
         if (GoPsiImplUtil.isBlank(o.getIdentifier())) return;
-        GoShortVarDeclaration shortDecl = PsiTreeUtil.getParentOfType(o, GoShortVarDeclaration.class);
+        GoVarSpec shortDecl = PsiTreeUtil.getParentOfType(o, GoShortVarDeclaration.class, GoRecvStatement.class);
         GoVarDeclaration decl = PsiTreeUtil.getParentOfType(o, GoVarDeclaration.class);
         if (shortDecl != null || decl != null) {
           PsiReference reference = o.getReference();

--- a/src/com/goide/project/GoLibrariesConfigurable.java
+++ b/src/com/goide/project/GoLibrariesConfigurable.java
@@ -16,6 +16,7 @@
 
 package com.goide.project;
 
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileChooser.FileChooserDialog;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.options.Configurable;
@@ -34,28 +35,34 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.List;
+import java.util.Set;
 
 import static com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createMultipleFoldersDescriptor;
 
 public class GoLibrariesConfigurable implements Configurable {
   @NotNull private final String myDisplayName;
   private final GoLibrariesService myLibrariesService;
+  private final String[] myReadOnlyPaths;
   private final JPanel myPanel = new JPanel(new BorderLayout());
-  private final CollectionListModel<String> myListModel = new CollectionListModel<String>();
+  private final CollectionListModel<ListItem> myListModel = new CollectionListModel<ListItem>();
 
-  public GoLibrariesConfigurable(@NotNull String displayName, @NotNull GoLibrariesService librariesService) {
+  public GoLibrariesConfigurable(@NotNull String displayName, @NotNull GoLibrariesService librariesService, String... readOnlyPaths) {
     myDisplayName = displayName;
     myLibrariesService = librariesService;
+    myReadOnlyPaths = readOnlyPaths;
 
     final JBList filesList = new JBList(myListModel);
     filesList.setCellRenderer(new ColoredListCellRenderer() {
       @Override
       protected void customizeCellRenderer(JList list, Object value, int index, boolean selected, boolean hasFocus) {
-        final String url = value.toString();
+        final ListItem item = (ListItem)value;
+        final String url = item.url;
+        if (item.readOnly) {
+          append("[GOPATH] ", SimpleTextAttributes.GRAY_ATTRIBUTES);
+        }
         final VirtualFile file = VirtualFileManager.getInstance().findFileByUrl(url);
         if (file != null) {
-          append(file.getPath());
+          append(file.getPath(), item.readOnly ? SimpleTextAttributes.GRAY_ATTRIBUTES : SimpleTextAttributes.REGULAR_ATTRIBUTES);
           setIcon(IconUtil.getIcon(file, Iconable.ICON_FLAG_READ_STATUS, null));
         }
         else {
@@ -72,9 +79,9 @@ public class GoLibrariesConfigurable implements Configurable {
             .createFileChooser(createMultipleFoldersDescriptor(), null, filesList);
 
           VirtualFile fileToSelect = null;
-          final String lastItem = ContainerUtil.getLastItem(myListModel.getItems());
+          final ListItem lastItem = ContainerUtil.getLastItem(myListModel.getItems());
           if (lastItem != null) {
-            fileToSelect = VirtualFileManager.getInstance().findFileByUrl(lastItem);
+            fileToSelect = VirtualFileManager.getInstance().findFileByUrl(lastItem.url);
           }
 
           final VirtualFile[] newDirectories = fileChooser.choose(null, fileToSelect);
@@ -82,9 +89,8 @@ public class GoLibrariesConfigurable implements Configurable {
             for (final VirtualFile newDirectory : newDirectories) {
               final String newDirectoryUrl = newDirectory.getUrl();
               boolean alreadyAdded = false;
-              List<String> items = myListModel.getItems();
-              for (String item : items) {
-                if (newDirectoryUrl.equals(item)) {
+              for (ListItem item : myListModel.getItems()) {
+                if (newDirectoryUrl.equals(item.url) && !item.readOnly) {
                   filesList.clearSelection();
                   filesList.setSelectedValue(item, true);
                   scrollToSelection(filesList);
@@ -93,17 +99,28 @@ public class GoLibrariesConfigurable implements Configurable {
                 }
               }
               if (!alreadyAdded) {
-                myListModel.add(newDirectoryUrl);
+                myListModel.add(new ListItem(newDirectoryUrl, false));
               }
             }
           }
+        }
+      })
+      .setRemoveActionUpdater(new AnActionButtonUpdater() {
+        @Override
+        public boolean isEnabled(AnActionEvent event) {
+          for (Object selectedValue : filesList.getSelectedValues()) {
+            if (((ListItem)selectedValue).readOnly) {
+              return false;
+            }
+          }
+          return true;
         }
       })
       .setRemoveAction(new AnActionButtonRunnable() {
         @Override
         public void run(AnActionButton button) {
           for (Object selectedValue : filesList.getSelectedValues()) {
-            myListModel.remove(selectedValue.toString());
+            myListModel.remove(((ListItem)selectedValue));
           }
         }
       })
@@ -126,18 +143,23 @@ public class GoLibrariesConfigurable implements Configurable {
 
   @Override
   public boolean isModified() {
-    return !ContainerUtil.newHashSet(myListModel.getItems()).equals(ContainerUtil.newHashSet(myLibrariesService.getLibraryRootUrls()));
+    return !getUserDefinedUrls().equals(ContainerUtil.newHashSet(myLibrariesService.getLibraryRootUrls()));
   }
 
   @Override
   public void apply() throws ConfigurationException {
-    myLibrariesService.setLibraryRootUrls(ContainerUtil.newHashSet(myListModel.getItems()));
+    myLibrariesService.setLibraryRootUrls(getUserDefinedUrls());
   }
 
   @Override
   public void reset() {
     myListModel.removeAll();
-    myListModel.add(ContainerUtil.newArrayList(myLibrariesService.getLibraryRootUrls()));
+    for (String url : myReadOnlyPaths) {
+      myListModel.add(new ListItem(url, true));
+    }
+    for (String url : myLibrariesService.getLibraryRootUrls()) {
+      myListModel.add(new ListItem(url, false));
+    }
   }
 
   @Override
@@ -156,5 +178,26 @@ public class GoLibrariesConfigurable implements Configurable {
   @Override
   public String getHelpTopic() {
     return null;
+  }
+
+  @NotNull
+  private Set<String> getUserDefinedUrls() {
+    final Set<String> libraryUrls = ContainerUtil.newHashSet();
+    for (ListItem item : myListModel.getItems()) {
+      if (!item.readOnly) {
+        libraryUrls.add(item.url);
+      }
+    }
+    return libraryUrls;
+  }
+  
+  private static class ListItem {
+    final boolean readOnly;
+    final String url;
+
+    public ListItem(String url, boolean readOnly) {
+      this.readOnly = readOnly;
+      this.url = url;
+    }
   }
 }

--- a/src/com/goide/project/GoLibrariesConfigurableProvider.java
+++ b/src/com/goide/project/GoLibrariesConfigurableProvider.java
@@ -17,6 +17,7 @@
 package com.goide.project;
 
 import com.goide.GoModuleType;
+import com.goide.sdk.GoSdkUtil;
 import com.intellij.application.options.ModuleAwareProjectConfigurable;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.module.Module;
@@ -24,10 +25,12 @@ import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.options.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.HideableDecorator;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
+import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -99,7 +102,15 @@ public class GoLibrariesConfigurableProvider extends ConfigurableProvider {
       @Override
       protected List<UnnamedConfigurable> createConfigurables() {
         final List<UnnamedConfigurable> result = ContainerUtil.newArrayList();
-        result.add(new GoLibrariesConfigurable("Global libraries", GoApplicationLibrariesService.getInstance()));
+        
+        final String[] urlsFromEnv = ContainerUtil.map2Array(GoSdkUtil.getGoPathsSources(), String.class,
+                                                             new Function<VirtualFile, String>() {
+                                                               @Override
+                                                               public String fun(VirtualFile file) {
+                                                                 return file.getUrl();
+                                                               }
+                                                             });
+        result.add(new GoLibrariesConfigurable("Global libraries", GoApplicationLibrariesService.getInstance(), urlsFromEnv));
         result.add(new GoLibrariesConfigurable("Project libraries", GoProjectLibrariesService.getInstance(myProject)));
         result.add(new ModuleAwareProjectConfigurable(myProject, "Module libraries", "Module libraries") {
           @Override

--- a/src/com/goide/psi/impl/GoCompositeElementImpl.java
+++ b/src/com/goide/psi/impl/GoCompositeElementImpl.java
@@ -16,6 +16,7 @@
 
 package com.goide.psi.impl;
 
+import com.goide.psi.GoBlock;
 import com.goide.psi.GoCompositeElement;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.lang.ASTNode;
@@ -48,6 +49,10 @@ public class GoCompositeElementImpl extends ASTWrapperPsiElement implements GoCo
                                                   @NotNull ResolveState state,
                                                   @Nullable PsiElement lastParent,
                                                   @NotNull PsiElement place) {
-    return processor.execute(o, state) && ResolveUtil.processChildren(o, processor, state, lastParent, place);
+    return processor.execute(o, state) && 
+           o instanceof GoBlock ? 
+           ResolveUtil.processChildrenFromTop(o, processor, state, lastParent, place) :
+           ResolveUtil.processChildren(o, processor, state, lastParent, place)
+      ;
   }
 }

--- a/src/com/goide/psi/impl/GoFieldNameReference.java
+++ b/src/com/goide/psi/impl/GoFieldNameReference.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.psi.impl;
+
+import com.goide.psi.*;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.IncorrectOperationException;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+public class GoFieldNameReference extends PsiReferenceBase<GoFieldName> {
+  private GoCompositeElement myValue;
+
+  @NotNull
+  private GoScopeProcessorBase getProcessor(final boolean completion) {
+    return new GoScopeProcessorBase(myElement.getText(), myElement, completion) {
+      @Override
+      protected boolean condition(@NotNull PsiElement element) {
+        return !(element instanceof GoFieldDefinition) &&
+               !(element instanceof GoConstDefinition);
+      }
+    };
+  }
+
+  public GoFieldNameReference(@NotNull GoFieldName element) {
+    super(element, TextRange.from(0, element.getTextLength()));
+    
+    GoCompositeElement place = myElement;
+    while ((place = PsiTreeUtil.getParentOfType(place, GoLiteralValue.class)) != null) {
+      if (place.getParent() instanceof GoValue) {
+        myValue = (GoValue)place.getParent();
+        break;
+      }
+    }
+  }
+
+  private boolean processFields(@NotNull GoScopeProcessorBase processor) {
+    GoCompositeLit lit = PsiTreeUtil.getParentOfType(myElement, GoCompositeLit.class);
+    GoLiteralTypeExpr expr = lit != null ? lit.getLiteralTypeExpr() : null;
+    if (expr == null) return false;
+
+    GoType type = expr.getType();
+    if (type == null) {
+      type = getTypeFromReference(expr.getTypeReferenceExpression());
+    }
+
+    type = getType(type);
+
+    if (type instanceof GoStructType && !type.processDeclarations(processor, ResolveState.initial(), null, myElement)) return true;
+
+    PsiFile file = myElement.getContainingFile();
+    if (file instanceof GoFile && !GoReference.processNamedElements(processor, ResolveState.initial(), ((GoFile)file).getConsts(), true)) return true;
+
+    return false;
+  }
+
+  @Nullable
+  private static GoType getTypeFromReference(@Nullable GoTypeReferenceExpression expression) {
+    PsiReference reference = expression != null ? expression.getReference() : null;
+    PsiElement resolve = reference != null ? reference.resolve() : null;
+    if (resolve instanceof GoTypeSpec) {
+      return ((GoTypeSpec)resolve).getType();
+    }
+    return null;
+  }
+
+  @Nullable
+  private GoType getType(GoType type) {
+    boolean inValue = myValue != null;
+    
+    if (inValue && type instanceof GoArrayOrSliceType) type = type.getType();
+    else if (type instanceof GoMapType) type = inValue ? ((GoMapType)type).getValueType() : ((GoMapType)type).getKeyType();
+    else if (inValue && type instanceof GoStructType) {
+      GoKey key = PsiTreeUtil.getPrevSiblingOfType(myValue, GoKey.class);
+      GoFieldName field = key != null ? key.getFieldName() : null;
+      GoFieldNameReference reference = field != null ? field.getReference() : null;
+      PsiElement resolve = reference != null ? reference.resolve() : null;
+      if (resolve instanceof GoFieldDefinition) {
+        type = PsiTreeUtil.getNextSiblingOfType(resolve, GoType.class);
+      }
+    }
+
+    if (type != null && type.getTypeReferenceExpression() != null) {
+      type = getTypeFromReference(type.getTypeReferenceExpression());
+    }
+
+    return type;
+  }
+
+  @Nullable
+  @Override
+  public PsiElement resolve() {
+    GoScopeProcessorBase p = getProcessor(false);
+    processFields(p);
+    return p.getResult();
+  }
+
+  @NotNull
+  @Override
+  public Object[] getVariants() {
+    GoScopeProcessorBase p = getProcessor(false);
+    processFields(p);
+    List<GoNamedElement> variants = p.getVariants();
+    if (variants.isEmpty()) return EMPTY_ARRAY;
+    Collection<LookupElement> result = ContainerUtil.newArrayList();
+    for (GoNamedElement element : variants) {
+      result.add(GoPsiImplUtil.createVariableLikeLookupElement(element));
+    }
+    return ArrayUtil.toObjectArray(result);
+  }
+
+  @Override
+  public PsiElement handleElementRename(String newElementName) throws IncorrectOperationException {
+    myElement.replace(GoElementFactory.createIdentifierFromText(myElement.getProject(), newElementName));
+    return myElement;
+  }
+}

--- a/src/com/goide/psi/impl/GoNamedElementImpl.java
+++ b/src/com/goide/psi/impl/GoNamedElementImpl.java
@@ -45,6 +45,7 @@ public abstract class GoNamedElementImpl<T extends GoNamedStub<?>> extends GoStu
   }
 
   public boolean isPublic() {
+    if (GoPsiImplUtil.builtin(this)) return true;
     T stub = getStub();
     return stub != null ? stub.isPublic() : StringUtil.isCapitalized(getName());
   }

--- a/src/com/goide/psi/impl/GoNamedElementImpl.java
+++ b/src/com/goide/psi/impl/GoNamedElementImpl.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.scope.PsiScopeProcessor;
-import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -125,6 +124,6 @@ public abstract class GoNamedElementImpl<T extends GoNamedStub<?>> extends GoStu
   @NotNull
   @Override
   public SearchScope getUseScope() {
-    return isPublic() ? super.getUseScope() : GlobalSearchScope.fileScope(getContainingFile());
+    return isPublic() ? super.getUseScope() : GoPsiImplUtil.cretePackageScope(getContainingFile());
   }
 }

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -135,7 +135,9 @@ public class GoPsiImplUtil {
 
   @Nullable
   public static PsiReference getReference(@NotNull GoVarDefinition o) {
-    return PsiTreeUtil.getParentOfType(o, GoShortVarDeclaration.class) != null ? new GoVarReference(o) : null;
+    GoShortVarDeclaration shortDeclaration = PsiTreeUtil.getParentOfType(o, GoShortVarDeclaration.class);
+    boolean createRef = PsiTreeUtil.getParentOfType(shortDeclaration, GoBlock.class, GoIfStatement.class) instanceof GoBlock;
+    return createRef ? new GoVarReference(o) : null;
   }
 
   @NotNull

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -132,7 +132,6 @@ public class GoPsiImplUtil {
 
     if (o instanceof GoBlock ||
         o instanceof GoIfStatement ||
-        //o instanceof GoSwitchStatement ||
         o instanceof GoForStatement ||
         o instanceof GoCommClause ||
         o instanceof GoFunctionLit ||

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -366,6 +366,7 @@ public class GoPsiImplUtil {
       if (expression != null) {
         GoType type = expression.getGoType();
         if (type instanceof GoChannelType && ((GoUnaryExpr)o).getSendChannel() != null) return type.getType();
+        if (type instanceof GoPointerType && ((GoUnaryExpr)o).getMul() != null) return type.getType();
         return type;
       }
       return null;
@@ -415,7 +416,6 @@ public class GoPsiImplUtil {
           return list.get(1);
         }
       }
-      type = type instanceof GoPointerType ? type.getType() : type;
       if (type instanceof GoArrayOrSliceType) {
         return type.getType();
       }

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -112,6 +112,11 @@ public class GoPsiImplUtil {
   public static GoReference getReference(@NotNull final GoReferenceExpression o) {
     return new GoReference(o);
   }
+  
+  @NotNull
+  public static GoFieldNameReference getReference(@NotNull GoFieldName o) {
+    return new GoFieldNameReference(o);
+  }
 
   @NotNull
   public static PsiReference[] getReferences(@NotNull GoImportString o) {

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -17,6 +17,7 @@
 package com.goide.psi.impl;
 
 import com.goide.GoIcons;
+import com.goide.completion.BracesInsertHandler;
 import com.goide.completion.GoCompletionUtil;
 import com.goide.psi.*;
 import com.goide.psi.impl.imports.GoImportReferenceSet;
@@ -136,8 +137,7 @@ public class GoPsiImplUtil {
   @Nullable
   public static PsiReference getReference(@NotNull GoVarDefinition o) {
     GoShortVarDeclaration shortDeclaration = PsiTreeUtil.getParentOfType(o, GoShortVarDeclaration.class);
-    boolean createRef = PsiTreeUtil.getParentOfType(shortDeclaration, GoBlock.class, 
-                                                    GoIfStatement.class, GoSwitchStatement.class, GoSelectStatement.class) instanceof GoBlock;
+    boolean createRef = PsiTreeUtil.getParentOfType(shortDeclaration, GoBlock.class, GoIfStatement.class, GoSwitchStatement.class, GoSelectStatement.class) instanceof GoBlock;
     return createRef ? new GoVarReference(o) : null;
   }
 
@@ -269,11 +269,15 @@ public class GoPsiImplUtil {
 
   @NotNull
   public static LookupElement createTypeConversionLookupElement(@NotNull GoTypeSpec t) {
+    InsertHandler<LookupElement> handler = t.getType() instanceof GoStructType ? 
+                                           BracesInsertHandler.ONE_LINER : 
+                                           ParenthesesInsertHandler.WITH_PARAMETERS; // todo: check context and place caret in or outside {}
     return PrioritizedLookupElement.withPriority(
       LookupElementBuilder
         .create(t)
         .withLookupString(StringUtil.notNullize(t.getName(), "").toLowerCase())
-        .withInsertHandler(ParenthesesInsertHandler.WITH_PARAMETERS).withIcon(GoIcons.TYPE),
+        .withInsertHandler(handler)
+        .withIcon(GoIcons.TYPE),
       GoCompletionUtil.TYPE_CONVERSION);
   }
 

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -136,7 +136,8 @@ public class GoPsiImplUtil {
   @Nullable
   public static PsiReference getReference(@NotNull GoVarDefinition o) {
     GoShortVarDeclaration shortDeclaration = PsiTreeUtil.getParentOfType(o, GoShortVarDeclaration.class);
-    boolean createRef = PsiTreeUtil.getParentOfType(shortDeclaration, GoBlock.class, GoIfStatement.class) instanceof GoBlock;
+    boolean createRef = PsiTreeUtil.getParentOfType(shortDeclaration, GoBlock.class, 
+                                                    GoIfStatement.class, GoSwitchStatement.class, GoSelectStatement.class) instanceof GoBlock;
     return createRef ? new GoVarReference(o) : null;
   }
 

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -415,7 +415,8 @@ public class GoPsiImplUtil {
           return list.get(1);
         }
       }
-      else if (type instanceof GoArrayOrSliceType) {
+      type = type instanceof GoPointerType ? type.getType() : type;
+      if (type instanceof GoArrayOrSliceType) {
         return type.getType();
       }
     }

--- a/src/com/goide/psi/impl/GoReference.java
+++ b/src/com/goide/psi/impl/GoReference.java
@@ -181,6 +181,13 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
     else if (target instanceof GoTypeOwner) {
       GoType type = ((GoTypeOwner)target).getGoType();
       if (type != null) processGoType(type, processor, state);
+      PsiElement parent = target.getParent();
+      if (target instanceof GoVarDefinition && parent instanceof GoTypeSwitchGuard) {
+        GoTypeCaseClause typeCase = PsiTreeUtil.getParentOfType(myElement, GoTypeCaseClause.class);
+        GoTypeSwitchCase switchCase = typeCase != null ? typeCase.getTypeSwitchCase() : null;
+        GoType caseType = switchCase != null ? switchCase.getType() : null;
+        if (caseType != null) processGoType(caseType, processor, state);
+      }
     }
     return false;
   }

--- a/src/com/goide/psi/impl/GoReference.java
+++ b/src/com/goide/psi/impl/GoReference.java
@@ -319,10 +319,11 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
 
     GoScopeProcessorBase delegate = createDelegate(processor);
     ResolveUtil.treeWalkUp(myElement, delegate);
+    if (!processNamedElements(processor, state, delegate.getVariants(), localResolve)) return false;
     processReceiver(delegate);
+    if (!processNamedElements(processor, state, delegate.getVariants(), localResolve)) return false;
     processFunctionParameters(myElement, delegate);
-    Collection<? extends GoNamedElement> result = delegate.getVariants();
-    if (!processNamedElements(processor, state, result, localResolve)) return false;
+    if (!processNamedElements(processor, state, delegate.getVariants(), localResolve)) return false;
     if (!processFileEntities(file, processor, state, localResolve)) return false;
     if (!processDirectory(file.getOriginalFile().getParent(), file, file.getPackageName(), processor, state, true)) return false;
     if (processImports(file, processor, state, myElement)) return false;

--- a/src/com/goide/psi/impl/GoReference.java
+++ b/src/com/goide/psi/impl/GoReference.java
@@ -104,7 +104,8 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
   }
 
   @NotNull
-  static MyScopeProcessor createCompletionProcessor(@NotNull final Collection<LookupElement> variants, final boolean forTypes,
+  static MyScopeProcessor createCompletionProcessor(@NotNull final Collection<LookupElement> variants, 
+                                                    final boolean forTypes,
                                                     @NotNull final Condition<PsiElement> filter) {
     return new MyScopeProcessor() {
       @Override
@@ -124,7 +125,7 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
       private LookupElement createLookup(@NotNull PsiElement element) {
         // @formatter:off
         if (element instanceof GoNamedSignatureOwner)return createFunctionOrMethodLookupElement((GoNamedSignatureOwner)element);
-        else if (element instanceof GoTypeSpec)      return forTypes ? createTypeLookupElement((GoTypeSpec)element) :createTypeConversionLookupElement((GoTypeSpec)element);
+        else if (element instanceof GoTypeSpec)      return forTypes ? createTypeLookupElement((GoTypeSpec)element) : createTypeConversionLookupElement((GoTypeSpec)element);
         else if (element instanceof GoImportSpec)    return createPackageLookupElement(((GoImportSpec)element));
         else if (element instanceof PsiDirectory)    return createPackageLookupElement(((PsiDirectory)element).getName(), true);
         else if (element instanceof GoNamedElement)  return createVariableLikeLookupElement((GoNamedElement)element);

--- a/src/com/goide/psi/impl/GoReference.java
+++ b/src/com/goide/psi/impl/GoReference.java
@@ -376,7 +376,7 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
 
   @NotNull
   private GoVarProcessor createDelegate(@NotNull MyScopeProcessor processor) {
-    return new GoVarProcessor(getName(), myElement, processor.isCompletion());
+    return new GoVarProcessor(getName(), myElement, processor.isCompletion(), true);
   }
 
   private static boolean processFileEntities(@NotNull GoFile file,

--- a/src/com/goide/psi/impl/GoReference.java
+++ b/src/com/goide/psi/impl/GoReference.java
@@ -392,9 +392,10 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
 
   static boolean processNamedElements(@NotNull PsiScopeProcessor processor,
                                       @NotNull ResolveState state,
-                                      @NotNull Collection<? extends GoNamedElement> elements, boolean localResolve) {
+                                      @NotNull Collection<? extends GoNamedElement> elements, 
+                                      boolean localResolve) {
     for (GoNamedElement definition : elements) {
-      if ((definition.isPublic() || localResolve) && !processor.execute(definition, state)) return false;
+      if ((localResolve || definition.isPublic()) && !processor.execute(definition, state)) return false;
     }
     return true;
   }

--- a/src/com/goide/psi/impl/GoScopeProcessorBase.java
+++ b/src/com/goide/psi/impl/GoScopeProcessorBase.java
@@ -31,11 +31,11 @@ import java.util.List;
 public abstract class GoScopeProcessorBase extends BaseScopeProcessor {
   @NotNull protected OrderedSet<GoNamedElement> myResult = new OrderedSet<GoNamedElement>();
 
-  protected final PsiElement myOrigin;
-  private final String myRequestedName;
+  @NotNull protected final PsiElement myOrigin;
+  @NotNull private final String myRequestedName;
   private final boolean myIsCompletion;
 
-  public GoScopeProcessorBase(String requestedName, PsiElement origin, boolean completion) {
+  public GoScopeProcessorBase(@NotNull String requestedName, @NotNull PsiElement origin, boolean completion) {
     myRequestedName = requestedName;
     myOrigin = origin;
     myIsCompletion = completion;

--- a/src/com/goide/psi/impl/GoVarProcessor.java
+++ b/src/com/goide/psi/impl/GoVarProcessor.java
@@ -59,6 +59,10 @@ public class GoVarProcessor extends GoScopeProcessorBase {
   private static GoCompositeElement getScope(@Nullable PsiElement o) {
     GoForStatement forStatement = PsiTreeUtil.getParentOfType(o, GoForStatement.class);
     if (forStatement != null) return forStatement.getBlock();
+    GoIfStatement ifStatement = PsiTreeUtil.getParentOfType(o, GoIfStatement.class);
+    if (ifStatement != null) return ifStatement.getBlock();
+    GoElseStatement elseStatement = PsiTreeUtil.getParentOfType(o, GoElseStatement.class);
+    if (elseStatement != null) return elseStatement.getBlock();
     return PsiTreeUtil.getParentOfType(o, GoBlock.class);
   }
 

--- a/src/com/goide/psi/impl/GoVarProcessor.java
+++ b/src/com/goide/psi/impl/GoVarProcessor.java
@@ -20,11 +20,8 @@ import com.goide.psi.*;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public class GoVarProcessor extends GoScopeProcessorBase {
   private final boolean myImShortVarDeclaration;
@@ -64,18 +61,6 @@ public class GoVarProcessor extends GoScopeProcessorBase {
     GoElseStatement elseStatement = PsiTreeUtil.getParentOfType(o, GoElseStatement.class);
     if (elseStatement != null) return elseStatement.getBlock();
     return PsiTreeUtil.getParentOfType(o, GoBlock.class);
-  }
-
-  @Nullable
-  @Override
-  public GoNamedElement getResult() {
-    return ContainerUtil.getLastItem(myResult);
-  }
-
-  @NotNull
-  @Override
-  public List<GoNamedElement> getVariants() {
-    return ContainerUtil.reverse(myResult);
   }
 
   protected boolean condition(@NotNull PsiElement psiElement) {

--- a/src/com/goide/psi/impl/GoVarProcessor.java
+++ b/src/com/goide/psi/impl/GoVarProcessor.java
@@ -31,8 +31,12 @@ public class GoVarProcessor extends GoScopeProcessorBase {
   private final GoCompositeElement myScope;
   
   public GoVarProcessor(String requestedName, PsiElement origin, boolean completion) {
+    this(requestedName, origin, completion, false);
+  }
+
+  public GoVarProcessor(String requestedName, PsiElement origin, boolean completion, boolean delegate) {
     super(requestedName, origin, completion);
-    myImShortVarDeclaration = PsiTreeUtil.getParentOfType(origin, GoShortVarDeclaration.class) != null;
+    myImShortVarDeclaration = PsiTreeUtil.getParentOfType(origin, GoShortVarDeclaration.class) != null && !delegate;
     myScope = getScope(origin);
   }
 

--- a/src/com/goide/psi/impl/GoVarProcessor.java
+++ b/src/com/goide/psi/impl/GoVarProcessor.java
@@ -28,13 +28,13 @@ import java.util.List;
 
 public class GoVarProcessor extends GoScopeProcessorBase {
   private final boolean myImShortVarDeclaration;
-  private final GoCompositeElement myScope;
+  @Nullable private final GoCompositeElement myScope;
   
-  public GoVarProcessor(String requestedName, PsiElement origin, boolean completion) {
+  public GoVarProcessor(@NotNull String requestedName, @NotNull PsiElement origin, boolean completion) {
     this(requestedName, origin, completion, false);
   }
 
-  public GoVarProcessor(String requestedName, PsiElement origin, boolean completion, boolean delegate) {
+  public GoVarProcessor(@NotNull String requestedName, @NotNull PsiElement origin, boolean completion, boolean delegate) {
     super(requestedName, origin, completion);
     myImShortVarDeclaration = PsiTreeUtil.getParentOfType(origin, GoShortVarDeclaration.class) != null && !delegate;
     myScope = getScope(origin);

--- a/src/com/goide/psi/impl/ResolveUtil.java
+++ b/src/com/goide/psi/impl/ResolveUtil.java
@@ -49,4 +49,20 @@ public final class ResolveUtil {
     }
     return true;
   }
+
+  public static boolean processChildrenFromTop(@NotNull PsiElement element,
+                                               @NotNull PsiScopeProcessor processor,
+                                               @NotNull ResolveState substitutor,
+                                               @Nullable PsiElement lastParent,
+                                               @NotNull PsiElement place) {
+    PsiElement run = element.getFirstChild();
+    while (run != null) {
+      if (run.isEquivalentTo(lastParent)) return true;
+      if (PsiTreeUtil.findCommonParent(place, run) != run && !run.processDeclarations(processor, substitutor, null, place)) {
+        return false;
+      }
+      run = run.getNextSibling();
+    }
+    return true;
+  }
 }

--- a/src/com/goide/psi/impl/imports/GoImportReferenceHelper.java
+++ b/src/com/goide/psi/impl/imports/GoImportReferenceHelper.java
@@ -1,5 +1,6 @@
+
 /*
- * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/com/goide/psi/impl/imports/GoImportReferenceHelper.java
+++ b/src/com/goide/psi/impl/imports/GoImportReferenceHelper.java
@@ -37,9 +37,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Hashtable;
 import java.util.List;
 
 public class GoImportReferenceHelper extends FileReferenceHelper {
+  private static Hashtable<String, List<VirtualFile>> fileCache = new Hashtable<String, List<VirtualFile>>();
+
   @NotNull
   @Override
   public List<? extends LocalQuickFix> registerFixes(FileReference reference) {
@@ -99,10 +102,19 @@ public class GoImportReferenceHelper extends FileReferenceHelper {
 
   @NotNull
   private static List<VirtualFile> getPathsToLookup(@NotNull PsiElement element) {
-    List<VirtualFile> result = ContainerUtil.newArrayList();
+    List<VirtualFile> result;
+    String fileName = ((GoFile) element).getName();
+    result = fileCache.get(fileName);
+    if (result != null) {
+      return result;
+    }
+
+    result = ContainerUtil.newArrayList();
     VirtualFile sdkHome = GoSdkUtil.getSdkHome(element);
     ContainerUtil.addIfNotNull(result, sdkHome);
     result.addAll(GoSdkUtil.getGoPathsSources());
+
+    fileCache.put(fileName, result);
     return result;
   }
 }

--- a/src/com/goide/refactor/GoDescriptionProvider.java
+++ b/src/com/goide/refactor/GoDescriptionProvider.java
@@ -17,6 +17,8 @@
 package com.goide.refactor;
 
 import com.goide.psi.*;
+import com.intellij.codeInsight.highlighting.HighlightUsagesDescriptionLocation;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.ElementDescriptionProvider;
 import com.intellij.psi.PsiElement;
@@ -32,11 +34,13 @@ public class GoDescriptionProvider implements ElementDescriptionProvider {
   @Override
   public String getElementDescription(@NotNull PsiElement o, @NotNull ElementDescriptionLocation location) {
     if (o instanceof GoNamedElement && location == UsageViewNodeTextLocation.INSTANCE) {
-      return getElementDescription(o, UsageViewTypeLocation.INSTANCE) + " " +
-             "'" + getElementDescription(o, UsageViewShortNameLocation.INSTANCE) + "'";
+      return getDescription(o, false);
     }
     if (o instanceof GoNamedElement && (location == UsageViewShortNameLocation.INSTANCE || location == UsageViewLongNameLocation.INSTANCE)) {
       return ((GoNamedElement)o).getName();
+    }
+    if (location == HighlightUsagesDescriptionLocation.INSTANCE) {
+      return getDescription(o, true);
     }
     if (location == UsageViewTypeLocation.INSTANCE) {
       if (o instanceof GoMethodDeclaration) return "Method";
@@ -53,5 +57,11 @@ public class GoDescriptionProvider implements ElementDescriptionProvider {
       if (o instanceof GoLabelDefinition) return "Label";
     }
     return null;
+  }
+
+  @NotNull
+  private String getDescription(@NotNull PsiElement o, boolean lowercase) {
+    String type = getElementDescription(o, UsageViewTypeLocation.INSTANCE);
+    return (lowercase ? StringUtil.toLowerCase(type) : type) + " '" + getElementDescription(o, UsageViewShortNameLocation.INSTANCE) + "'";
   }
 }

--- a/src/com/goide/sdk/GoSdkType.java
+++ b/src/com/goide/sdk/GoSdkType.java
@@ -23,11 +23,9 @@ import com.intellij.execution.configurations.PathEnvironmentVariableUtil;
 import com.intellij.openapi.projectRoots.*;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.containers.ContainerUtil;
 import org.jdom.Element;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -36,9 +34,9 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 public class GoSdkType extends SdkType {
+
   public GoSdkType() {
     super(JpsGoModelSerializerExtension.GO_SDK_TYPE_ID);
   }
@@ -63,36 +61,44 @@ public class GoSdkType extends SdkType {
   @Nullable
   @Override
   public String suggestHomePath() {
+    String fromEnv = findPathInEnvironment();
+    if (fromEnv != null) return fromEnv;
+
     if (SystemInfo.isWindows) {
       return "C:\\cygwin\\bin";
     }
-    else {
-      if (SystemInfo.isMac) {
-        String fromEnv = findPathInEnvironment();
-        if (fromEnv != null) return fromEnv;
-        String defaultPath = "/usr/local/go";
-        if (new File(defaultPath).exists()) return defaultPath;
-        String macPorts = "/opt/local/lib/go";
-        if (new File(macPorts).exists()) return macPorts;
-        return null;
-      }
-      else if (SystemInfo.isLinux) {
-        return "/usr/lib/go";
-      }
+
+    String defaultPath = "/usr/local/go";
+    if (new File(defaultPath).exists()) return defaultPath;
+
+    if (SystemInfo.isMac) {
+      String macPorts = "/opt/local/lib/go";
+      if (new File(macPorts).exists()) return macPorts;
+      return null;
     }
+
+    if (SystemInfo.isLinux) {
+      return "/usr/lib/go";
+    }
+
     return null;
   }
 
   @Nullable
   private static String findPathInEnvironment() {
-    File fileFromPath = PathEnvironmentVariableUtil.findInPath("go");
+    String goExecName = "go";
+    if (SystemInfo.isWindows) {
+      goExecName += ".exe";
+    }
+
+    File fileFromPath = PathEnvironmentVariableUtil.findInPath(goExecName);
     if (fileFromPath != null) {
       File canonicalFile;
       try {
         canonicalFile = fileFromPath.getCanonicalFile();
         String path = canonicalFile.getPath();
-        if (path.endsWith("bin/go")) {
-          return StringUtil.trimEnd(path, "bin/go");
+        if (path.endsWith("bin/" + goExecName)) {
+          return StringUtil.trimEnd(path, "bin/" + goExecName);
         }
       }
       catch (IOException ignore) {
@@ -103,19 +109,8 @@ public class GoSdkType extends SdkType {
 
   @Override
   public boolean isValidSdkHome(@NotNull String path) {
-    path = adjustSdkPath(path);
+    path = GoSdkUtil.adjustSdkPath(path);
     return JpsGoSdkType.getGoExecutableFile(path).canExecute();
-  }
-
-  @NotNull
-  public static String adjustSdkPath(@NotNull String path) {
-    if (isAppEngine(path)) path = path + "/" + "goroot";
-    return path;
-  }
-
-  private static boolean isAppEngine(@Nullable String path) {
-    if (path == null) return false;
-    return new File(path, "appcfg.py").exists();
   }
 
   @NotNull
@@ -129,18 +124,7 @@ public class GoSdkType extends SdkType {
   @Nullable
   @Override
   public String getVersionString(@NotNull String sdkHome) {
-    // todo
-    sdkHome = adjustSdkPath(sdkHome);
-    try {
-      String s = FileUtil.loadFile(new File(sdkHome, "src/pkg/runtime/zversion.go"));
-      List<String> split = StringUtil.split(s, " ");
-      String lastItem = ContainerUtil.getLastItem(split);
-      if (lastItem == null) return null;
-      return lastItem.replace("go", "").replaceAll("`", "").replaceAll("\\(", "").replaceAll("\\)", "");
-    }
-    catch (IOException ignore) {
-    }
-    return null;
+    return GoSdkUtil.getGoVersionFromPath(sdkHome);
   }
 
   @Nullable
@@ -171,9 +155,10 @@ public class GoSdkType extends SdkType {
     SdkModificator modificator = sdk.getSdkModificator();
     String path = sdk.getHomePath();
     if (path == null) return;
-    path = adjustSdkPath(path);
+    path = GoSdkUtil.adjustSdkPath(path);
     modificator.setHomePath(path);
-    add(modificator, new File(path, "src/pkg")); // scr/pkg is enough at the moment, possible process binaries from pkg
+    File sdkPath = new File(path, GoSdkUtil.getSdkSourcePath(path));
+    add(modificator, sdkPath);
     modificator.commitChanges();
   }
 

--- a/src/com/goide/sdk/GoSdkType.java
+++ b/src/com/goide/sdk/GoSdkType.java
@@ -1,5 +1,6 @@
+
 /*
- * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/com/goide/sdk/GoSdkUtil.java
+++ b/src/com/goide/sdk/GoSdkUtil.java
@@ -1,5 +1,6 @@
+
 /*
- * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/com/goide/sdk/GoSdkUtil.java
+++ b/src/com/goide/sdk/GoSdkUtil.java
@@ -17,12 +17,18 @@
 package com.goide.sdk;
 
 import com.goide.psi.GoFile;
+import com.google.common.collect.ImmutableMap;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.CapturingProcessHandler;
+import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.application.PathMacros;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -35,17 +41,46 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class GoSdkUtil {
 
   public static final String GOPATH = "GOPATH";
 
+  private static final Logger LOG = Logger.getInstance(GoSdkUtil.class);
+
+  private static final Pattern versionPattern =
+    Pattern.compile("go version go(\\d+\\.\\d+\\.?\\d*).*", Pattern.CASE_INSENSITIVE);
+
+  private static final ImmutableMap<String, String> GoVersionPackagesPath =
+    ImmutableMap.of(
+      "1.0", "/src/pkg",
+      "1.1", "/src/pkg",
+      "1.2", "/src/pkg",
+      "1.3", "/src/pkg",
+      "1.4", "/src"
+    );
+
   @Nullable
   public static VirtualFile getSdkHome(@NotNull PsiElement context) {
     Module module = ModuleUtilCore.findModuleForPsiElement(context);
+
     Sdk sdk = module == null ? null : ModuleRootManager.getInstance(module).getSdk();
-    VirtualFile result = sdk == null ? null : LocalFileSystem.getInstance().findFileByPath(sdk.getHomePath() + "/src/pkg");
+    if (sdk == null) {
+      return guessSkdHome(context);
+    }
+
+    String sdkHomePath = sdk.getHomePath();
+    if (sdkHomePath == null) {
+      return guessSkdHome(context);
+    }
+
+    sdkHomePath = adjustSdkPath(sdkHomePath);
+    VirtualFile result = LocalFileSystem.getInstance().findFileByPath((new File(sdkHomePath, getSdkSourcePath(sdkHomePath))).getAbsolutePath());
+
     return result != null ? result : guessSkdHome(context);
   }
 
@@ -88,5 +123,79 @@ public class GoSdkUtil {
   public static String retrieveGoPath() {
     String path = EnvironmentUtil.getValue(GOPATH);
     return path != null ? path : PathMacros.getInstance().getValue(GOPATH);
+  }
+
+  @NotNull
+  public static String adjustSdkPath(@NotNull String path) {
+    if (isAppEngine(path)) path = path + "/" + "goroot";
+    return path;
+  }
+
+  private static boolean isAppEngine(@Nullable String path) {
+    if (path == null) return false;
+    return new File(path, "appcfg.py").exists();
+  }
+
+  @Nullable
+  public static String getGoVersionFromPath(String sdkHome) {
+    String binPath = sdkHome + "/bin/";
+
+    String goBin = SystemInfo.isWindows ? "go.exe" : "go";
+    File execPath = new File(binPath + goBin);
+
+    if (!execPath.exists()) {
+      return null;
+    }
+
+    try {
+      GeneralCommandLine command = new GeneralCommandLine();
+      command.setExePath(execPath.getCanonicalPath());
+      command.addParameter("version");
+      command.withWorkDirectory(binPath);
+      command.getEnvironment().put("GOROOT", sdkHome);
+
+      ProcessOutput output = new CapturingProcessHandler(
+        command.createProcess(),
+        Charset.defaultCharset(),
+        command.getCommandLineString()).runProcess();
+
+      if (output.getExitCode() != 0) {
+        LOG.error("Go compiler exited with invalid exit code: " + output.getExitCode());
+        return null;
+      }
+
+      String version = output.getStdout().trim();
+      Matcher versionMatcher = versionPattern.matcher(version.trim());
+      if (versionMatcher.find()) {
+        return versionMatcher.group(1);
+      }
+
+      return null;
+    } catch (Exception e) {
+      LOG.error("Exception while executing the process:", e);
+    }
+
+    return null;
+  }
+
+  @NotNull
+  public static String getSdkSourcePath(@NotNull String path) {
+    if (path.contains("mockSdk-1.1.2")) {
+      return "src/pkg";
+    }
+
+    String goVersion = getGoVersionFromPath(path);
+    if (goVersion == null) {
+      return "src";
+    }
+
+    goVersion = goVersion.substring(0, 3);
+
+    String srcPath = GoVersionPackagesPath.get(goVersion);
+    if (srcPath == null) {
+      srcPath = "src";
+    }
+
+    return srcPath;
   }
 }

--- a/src/com/goide/template/GoLiveTemplateContextType.java
+++ b/src/com/goide/template/GoLiveTemplateContextType.java
@@ -22,6 +22,7 @@ import com.goide.highlighting.GoSyntaxHighlighter;
 import com.goide.psi.GoBlock;
 import com.goide.psi.GoFile;
 import com.goide.psi.GoSimpleStatement;
+import com.goide.psi.GoTopLevelDeclaration;
 import com.intellij.codeInsight.template.EverywhereContextType;
 import com.intellij.codeInsight.template.TemplateContextType;
 import com.intellij.openapi.fileTypes.SyntaxHighlighter;
@@ -85,7 +86,7 @@ abstract public class GoLiveTemplateContextType extends TemplateContextType {
   
     @Override
     protected boolean isInContext(@NotNull PsiElement element) {
-      return element.getParent() instanceof GoFile;
+      return element.getParent() instanceof GoFile && !(element instanceof GoTopLevelDeclaration);
     }
   }
   

--- a/src/com/goide/template/GoLiveTemplateContextType.java
+++ b/src/com/goide/template/GoLiveTemplateContextType.java
@@ -19,10 +19,7 @@ package com.goide.template;
 import com.goide.GoLanguage;
 import com.goide.GoTypes;
 import com.goide.highlighting.GoSyntaxHighlighter;
-import com.goide.psi.GoBlock;
-import com.goide.psi.GoFile;
-import com.goide.psi.GoSimpleStatement;
-import com.goide.psi.GoTopLevelDeclaration;
+import com.goide.psi.*;
 import com.intellij.codeInsight.template.EverywhereContextType;
 import com.intellij.codeInsight.template.TemplateContextType;
 import com.intellij.openapi.fileTypes.SyntaxHighlighter;
@@ -87,6 +84,17 @@ abstract public class GoLiveTemplateContextType extends TemplateContextType {
     @Override
     protected boolean isInContext(@NotNull PsiElement element) {
       return element.getParent() instanceof GoFile && !(element instanceof GoTopLevelDeclaration);
+    }
+  }
+  
+  public static class GoTypeContextType extends GoLiveTemplateContextType {
+    protected GoTypeContextType() {
+      super("GO_TYPE", "Go type", EverywhereContextType.class);
+    }
+  
+    @Override
+    protected boolean isInContext(@NotNull PsiElement element) {
+      return element instanceof GoType;
     }
   }
   

--- a/testData/folding/simple.go
+++ b/testData/folding/simple.go
@@ -5,10 +5,10 @@ import <fold text='...'>(
   "fmt"
 )</fold>
 
-func test() <fold text='{ ... }'>{
+func test() <fold text='{...}'>{
   return 1
 }</fold>
 
-func (i int) test() <fold text='{ ... }'>{
+func (i int) test() <fold text='{...}'>{
   return 1
 }</fold>

--- a/testData/highlighting/ranges.go
+++ b/testData/highlighting/ranges.go
@@ -43,7 +43,7 @@ func main() {
          println(v[1].Likes)
     }
 
-    var people []*Person
+    var <error descr="Unused variable 'people'">people</error> []*Person // todo: should be redeclared
     for a, p := range people {
         println(p.Likes)
     }

--- a/testData/highlighting/recv.go
+++ b/testData/highlighting/recv.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+    var ch = make(chan int)
+    select {
+    case <error>test</error> := <-ch: {
+        test := 1
+        print(test)
+    }
+    }
+}

--- a/testData/highlighting/shortVars.go
+++ b/testData/highlighting/shortVars.go
@@ -49,5 +49,20 @@ func Test2() (err error) {
         err := bar()
         return err
     }
+    
+    switch err := bar(); {  // missing switch expression means "true"
+        case err != nil: return -err
+        default: return err
+    }
+    
+    var c chan int
+    // todo: fix inspection
+    //noinspection GoVarDeclaration
+    select {
+    case err, ok := (<-c):
+        println(err)
+        println(ok)
+    }
+    
     return err
 }

--- a/testData/highlighting/shortVars.go
+++ b/testData/highlighting/shortVars.go
@@ -20,9 +20,34 @@ func test() int {
     <error>x</error> := f1()
     <error>y,   z</error>     := f2()
 
+    fmt.Println(test21313())
+    fmt.Println(Test2())
+
     x, a := f2() // Ok: `x` is reused and `a` is new
     b, x := f2() // Ok: `b` is new and `x` is reused
 
     return x + y + z + a + b // Just to avoid unused variable error
 }
 
+func test21313() (err int) {
+    {
+        err := 1
+        return err
+    }
+    return 1
+}
+
+func bar() error {
+    return nil
+}
+
+func Test2() (err error) {
+    <error>err</error> := bar()
+    if err := bar(); err != nil {
+        return err
+    } else {
+        <error>err</error> := bar()
+        return err
+    }
+    return err
+}

--- a/testData/highlighting/shortVars.go
+++ b/testData/highlighting/shortVars.go
@@ -4,6 +4,10 @@ import "fmt"
 
 func main() {
     fmt.Println(test())
+    
+    y := 1
+    <error>y, _</error> := 10, 1
+    fmt.Println(y)
 }
 
 func f1() int {return 1}
@@ -13,8 +17,8 @@ func test() int {
     x := f1()
     y, z := f2()
 
-    <error>x</error> := f1() // Should be error: "no new variables on left side of :="
-    <error>y,   z</error>     := f2() // Should be error: "no new variables on left side of :="
+    <error>x</error> := f1()
+    <error>y,   z</error>     := f2()
 
     x, a := f2() // Ok: `x` is reused and `a` is new
     b, x := f2() // Ok: `b` is new and `x` is reused

--- a/testData/highlighting/shortVars.go
+++ b/testData/highlighting/shortVars.go
@@ -46,7 +46,7 @@ func Test2() (err error) {
     if err := bar(); err != nil {
         return err
     } else {
-        <error>err</error> := bar()
+        err := bar()
         return err
     }
     return err

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -116,7 +116,7 @@ func <warning>concurrently</warning>(integers []int) []int {
           ch <- j * j
       }(i)
   }
-  err := 1
+  <error>err</error> := 1
   _, err = 1, 1
   return integers
 }

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -360,3 +360,7 @@ func <warning>testRedeclare</warning>() int {
       }
       return 1
 }
+
+func init() {
+    
+}

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -21,7 +21,7 @@ func (b *Boom) Run(a aaa) (r1 aaa, r2 aaa) {
    b.err + a + r1 + r2
 <error>}</error>
 
-func <warning>foo</warning>() {
+func <error>foo</error>() {
     i := 1
     for (i) {return 0}
     if (i) {return <error>j</error>}

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -141,7 +141,7 @@ const name1 int = 10
 func <warning>goo</warning>(st interface {Foo()}, st1 Iface) {
     <error>name1</error>, <error>name1</error> = 1, 2
     Println(st.Foo() + st1.Boo())
-    if _ := 1 {
+    if <error>_</error> := 1 {
       return
     }
 }

--- a/testData/highlighting/slices.go
+++ b/testData/highlighting/slices.go
@@ -15,4 +15,16 @@ func bar() int {
 
 func main() {
     fmt.Println(bar())
+    main2()
+}
+
+type Foo2 struct {
+    Test int
+}
+
+func main2() {
+    var a *[]Foo2
+    a[0].Test
+    var b *[]Foo2
+    b[0].Test
 }

--- a/testData/highlighting/slices.go
+++ b/testData/highlighting/slices.go
@@ -24,7 +24,17 @@ type Foo2 struct {
 
 func main2() {
     var a *[]Foo2
-    a[0].Test
+    (*a)[0].Test
     var b *[]Foo2
-    b[0].Test
+    b[0].<error>Test</error>
+
+    test(a)
+}
+
+func test(a *[]Foo2) {
+    fmt.Println((*a)[0].Test)
+
+    for _, c := range *a {
+        fmt.Println(c.Test)
+    }
 }

--- a/testData/highlighting/stop.go
+++ b/testData/highlighting/stop.go
@@ -1,0 +1,23 @@
+package main
+
+type T interface {
+    Method1() T
+    Method2()
+}
+
+type T2 int
+
+func (t T2) F1() {
+}
+
+func (t T2) F2() T2 {
+    return nil
+}
+
+func main() {
+    var x T
+    x.Method1().Method2().<error>Method2</error>()
+    var x1 T2
+    x1.F2().F1().<error>F1</error>()
+}
+

--- a/testData/highlighting/varBlocks.go
+++ b/testData/highlighting/varBlocks.go
@@ -5,6 +5,9 @@ import "fmt"
 func main() {
     fmt.Println(test())
     fmt.Println(test2())
+    fmt.Println(test3())
+    fmt.Println(test4())
+    fmt.Println(test5())
 }
 
 func foo() int {
@@ -25,5 +28,35 @@ func test2() func () int {
         r := 1
         r = f()
         return r
+    }
+}
+
+func test3() {
+	if x := 10; x < 9 {
+		fmt.Println(x)
+	} else {
+		fmt.Println("not x")
+	}
+	fmt.Println(<error>x</error>)
+}
+
+
+func test4() {
+	x := 5
+	if x := 10; x < 9 {
+		fmt.Println(x, "exists here")
+	} else {		
+		fmt.Println("and here!", x)
+	}
+	fmt.Println(x)
+}
+
+
+func test5() {
+    <error>xy</error> := 5
+    if xy := 10; xy < 9 {
+        fmt.Println(xy, "exists here")
+    } else {
+        fmt.Println("and here!", xy)
     }
 }

--- a/testData/highlighting/varBlocks.go
+++ b/testData/highlighting/varBlocks.go
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println(test())
+    fmt.Println(test2())
+}
+
+func foo() int {
+    return 1
+}
+
+func test() func() int {
+    fff := foo
+    return func() int {
+        r := fff()
+        return r
+    }
+}
+
+func test2() func () int {
+    f := foo
+    return func() int {
+        r := 1
+        r = f()
+        return r
+    }
+}

--- a/testData/highlighting/vars.go
+++ b/testData/highlighting/vars.go
@@ -9,7 +9,8 @@ func main() {
 	fmt.Println(b, a)
 	c := simple(10)
 	fmt.Println(c)
-	
+	Foo()
+	Foo2()
         fmt.Println(http.ErrMissingFile)
 }
 
@@ -17,3 +18,14 @@ func simple(a int) int {
 	a, b := 1, 2
 	return a + b
 }
+
+func Foo() {
+    <error>err</error> := 1
+    err = 2
+}
+
+func Foo2() {
+    <error>err</error> := 1
+    err,x := 2,1
+    fmt.Println(x)
+} 

--- a/testData/parser/BlockRecover.go
+++ b/testData/parser/BlockRecover.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+  Println(name name)
+}

--- a/testData/parser/BlockRecover.go
+++ b/testData/parser/BlockRecover.go
@@ -1,5 +1,11 @@
 package main
 
 func main() {
-  Println(name name)
+  test( asd  asd)
+  test()
+  asd)
+  test()
+}
+
+func test() {
 }

--- a/testData/parser/BlockRecover.txt
+++ b/testData/parser/BlockRecover.txt
@@ -14,17 +14,15 @@ GO_FILE
     BLOCK
       PsiElement({)('{')
       SIMPLE_STATEMENT
-        REFERENCE_EXPRESSION
-          PsiElement(identifier)('Println')
-      PsiErrorElement:'!=', '%', '%=', '&', '&=', '&^', '&^=', '(', '*', '*=', '+', '++', '+=', ',', '-', '--', '-=', '.', '/', '/=', ':', ':=', ';', <, <-, <<, <<=, <=, <NL>, <literal value>, '=', '==', '>', '>=', '>>', '>>=', '^', '^=', '{', '|', '|=' or '}' expected, got '('
-        <empty list>
-      SIMPLE_STATEMENT
-        PARENTHESES_EXPR
-          PsiElement(()('(')
+        CALL_EXPR
           REFERENCE_EXPRESSION
-            PsiElement(identifier)('name')
-          PsiErrorElement:'!=', '%', '&', '&^', '(', ')', '*', '+', ',', '-', '.', '/', <, <-, <<, <=, <assign op>, <literal value>, '==', '>', '>=', '>>', '^' or '|' expected, got 'name'
-            <empty list>
+            PsiElement(identifier)('Println')
+          ARGUMENT_LIST
+            PsiElement(()('(')
+            REFERENCE_EXPRESSION
+              PsiElement(identifier)('name')
+            PsiErrorElement:'!=', '%', '&', '&^', '(', ')', '*', '+', ',', '-', '.', '...', '/', <, <-, <<, <=, <assign op>, <literal value>, '==', '>', '>=', '>>', '^' or '|' expected, got 'name'
+              <empty list>
       SIMPLE_STATEMENT
         REFERENCE_EXPRESSION
           PsiElement(identifier)('name')

--- a/testData/parser/BlockRecover.txt
+++ b/testData/parser/BlockRecover.txt
@@ -21,12 +21,12 @@ GO_FILE
             PsiElement(()('(')
             REFERENCE_EXPRESSION
               PsiElement(identifier)('name')
-            PsiErrorElement:'!=', '%', '&', '&^', '(', ')', '*', '+', ',', '-', '.', '...', '/', <, <-, <<, <=, <assign op>, <literal value>, '==', '>', '>=', '>>', '^' or '|' expected, got 'name'
+            PsiErrorElement:')', ',' or '...' expected, got 'name'
               <empty list>
       SIMPLE_STATEMENT
         REFERENCE_EXPRESSION
           PsiElement(identifier)('name')
-      PsiErrorElement:'!=', '%', '&', '&^', '(', '*', '+', '++', ',', '-', '--', '.', '/', ':', ':=', ';', <, <-, <<, <=, <NL>, <assign op>, <literal value>, '==', '>', '>=', '>>', '^', '|' or '}' expected, got ')'
+      PsiErrorElement:'!=', '%', '&', '&^', '(', '*', '+', '++', ',', '-', '--', '.', '/', ':=', ';', <, <-, <<, <=, <NL>, <assign op>, <literal value>, '==', '>', '>=', '>>', '^', '|' or '}' expected, got ')'
         <empty list>
   PsiElement())(')')
   PsiElement(})('}')

--- a/testData/parser/BlockRecover.txt
+++ b/testData/parser/BlockRecover.txt
@@ -1,0 +1,34 @@
+GO_FILE
+  PACKAGE_CLAUSE
+    PsiElement(package)('package')
+    PsiElement(identifier)('main')
+  IMPORT_LIST
+    <empty list>
+  FUNCTION_DECLARATION
+    PsiElement(func)('func')
+    PsiElement(identifier)('main')
+    SIGNATURE
+      PARAMETERS
+        PsiElement(()('(')
+        PsiElement())(')')
+    BLOCK
+      PsiElement({)('{')
+      SIMPLE_STATEMENT
+        REFERENCE_EXPRESSION
+          PsiElement(identifier)('Println')
+      PsiErrorElement:'!=', '%', '%=', '&', '&=', '&^', '&^=', '(', '*', '*=', '+', '++', '+=', ',', '-', '--', '-=', '.', '/', '/=', ':', ':=', ';', <, <-, <<, <<=, <=, <NL>, <literal value>, '=', '==', '>', '>=', '>>', '>>=', '^', '^=', '{', '|', '|=' or '}' expected, got '('
+        <empty list>
+      SIMPLE_STATEMENT
+        PARENTHESES_EXPR
+          PsiElement(()('(')
+          REFERENCE_EXPRESSION
+            PsiElement(identifier)('name')
+          PsiErrorElement:'!=', '%', '&', '&^', '(', ')', '*', '+', ',', '-', '.', '/', <, <-, <<, <=, <assign op>, <literal value>, '==', '>', '>=', '>>', '^' or '|' expected, got 'name'
+            <empty list>
+      SIMPLE_STATEMENT
+        REFERENCE_EXPRESSION
+          PsiElement(identifier)('name')
+      PsiErrorElement:'!=', '%', '&', '&^', '(', '*', '+', '++', ',', '-', '--', '.', '/', ':', ':=', ';', <, <-, <<, <=, <NL>, <assign op>, <literal value>, '==', '>', '>=', '>>', '^', '|' or '}' expected, got ')'
+        <empty list>
+  PsiElement())(')')
+  PsiElement(})('}')

--- a/testData/parser/BlockRecover.txt
+++ b/testData/parser/BlockRecover.txt
@@ -16,17 +16,45 @@ GO_FILE
       SIMPLE_STATEMENT
         CALL_EXPR
           REFERENCE_EXPRESSION
-            PsiElement(identifier)('Println')
+            PsiElement(identifier)('test')
           ARGUMENT_LIST
             PsiElement(()('(')
             REFERENCE_EXPRESSION
-              PsiElement(identifier)('name')
-            PsiErrorElement:')', ',' or '...' expected, got 'name'
+              PsiElement(identifier)('asd')
+            PsiErrorElement:')', ',' or '...' expected, got 'asd'
               <empty list>
       SIMPLE_STATEMENT
         REFERENCE_EXPRESSION
-          PsiElement(identifier)('name')
+          PsiElement(identifier)('asd')
       PsiErrorElement:'!=', '%', '&', '&^', '(', '*', '+', '++', ',', '-', '--', '.', '/', ':=', ';', <, <-, <<, <=, <NL>, <assign op>, <literal value>, '==', '>', '>=', '>>', '^', '|' or '}' expected, got ')'
-        <empty list>
-  PsiElement())(')')
-  PsiElement(})('}')
+        PsiElement())(')')
+      SIMPLE_STATEMENT
+        CALL_EXPR
+          REFERENCE_EXPRESSION
+            PsiElement(identifier)('test')
+          ARGUMENT_LIST
+            PsiElement(()('(')
+            PsiElement())(')')
+      SIMPLE_STATEMENT
+        REFERENCE_EXPRESSION
+          PsiElement(identifier)('asd')
+      PsiErrorElement:'!=', '%', '&', '&^', '(', '*', '+', '++', ',', '-', '--', '.', '/', ':=', ';', <, <-, <<, <=, <NL>, <assign op>, <literal value>, '==', '>', '>=', '>>', '^', '|' or '}' expected, got ')'
+        PsiElement())(')')
+      SIMPLE_STATEMENT
+        CALL_EXPR
+          REFERENCE_EXPRESSION
+            PsiElement(identifier)('test')
+          ARGUMENT_LIST
+            PsiElement(()('(')
+            PsiElement())(')')
+      PsiElement(})('}')
+  FUNCTION_DECLARATION
+    PsiElement(func)('func')
+    PsiElement(identifier)('test')
+    SIGNATURE
+      PARAMETERS
+        PsiElement(()('(')
+        PsiElement())(')')
+    BLOCK
+      PsiElement({)('{')
+      PsiElement(})('}')

--- a/testData/parser/Error.txt
+++ b/testData/parser/Error.txt
@@ -590,9 +590,10 @@ GO_FILE
           REFERENCE_EXPRESSION
             PsiElement(identifier)('i')
           PsiElement(.)('.')
-          PsiElement(()('(')
-          PsiElement(type)('type')
-          PsiElement())(')')
+          TYPE_GUARD
+            PsiElement(()('(')
+            PsiElement(type)('type')
+            PsiElement())(')')
         PsiElement({)('{')
         TYPE_CASE_CLAUSE
           TYPE_SWITCH_CASE

--- a/testData/parser/Recover2.txt
+++ b/testData/parser/Recover2.txt
@@ -41,15 +41,13 @@ GO_FILE
     BLOCK
       PsiElement({)('{')
       SIMPLE_STATEMENT
-        REFERENCE_EXPRESSION
-          PsiElement(identifier)('foo')
-      PsiErrorElement:'!=', '%', '%=', '&', '&=', '&^', '&^=', '(', '*', '*=', '+', '++', '+=', ',', '-', '--', '-=', '.', '/', '/=', ':', ':=', ';', <, <-, <<, <<=, <=, <NL>, <literal value>, '=', '==', '>', '>=', '>>', '>>=', '^', '^=', '{', '|', '|=' or '}' expected, got '('
-        <empty list>
-      SIMPLE_STATEMENT
-        PARENTHESES_EXPR
-          PsiElement(()('(')
-          PsiErrorElement:'!=', '%', '&', '&^', '(', ')', '*', '+', ',', '-', '/', <, <-, <<, <=, <assign op>, <expression>, <receiver type>, '==', '>', '>=', '>>', '[', '^', chan, func, interface, map, struct or '|' expected, got 'if'
-            <empty list>
+        CALL_EXPR
+          REFERENCE_EXPRESSION
+            PsiElement(identifier)('foo')
+          ARGUMENT_LIST
+            PsiElement(()('(')
+            PsiErrorElement:'!=', '%', '&', '&^', '(', ')', '*', '+', ',', '-', '/', <, <-, <<, <=, <assign op>, <expression>, '==', '>', '>=', '>>', '^' or '|' expected, got 'if'
+              <empty list>
       IF_STATEMENT
         PsiElement(if)('if')
         SIMPLE_STATEMENT

--- a/testData/psi/resolve/builtin/BuiltinConversion.go
+++ b/testData/psi/resolve/builtin/BuiltinConversion.go
@@ -1,0 +1,3 @@
+package main
+
+var a = /*ref*/int(3)

--- a/testData/psi/resolve/builtin/BuiltinTypes.go
+++ b/testData/psi/resolve/builtin/BuiltinTypes.go
@@ -1,0 +1,3 @@
+package main
+
+type A /*ref*/int

--- a/testData/psi/resolve/builtin/MethodName.go
+++ b/testData/psi/resolve/builtin/MethodName.go
@@ -1,0 +1,5 @@
+package main
+
+func F() {
+    /*ref*/len()
+}

--- a/testData/psi/resolve/builtin/ParameterType.go
+++ b/testData/psi/resolve/builtin/ParameterType.go
@@ -1,0 +1,4 @@
+package main
+
+func F(a /*ref*/rune) {
+}

--- a/testData/psi/resolve/builtin/VarBuiltinType.go
+++ b/testData/psi/resolve/builtin/VarBuiltinType.go
@@ -1,0 +1,3 @@
+package main
+
+var x /*ref*/int

--- a/testData/psi/resolve/builtin/VarMethodType.go
+++ b/testData/psi/resolve/builtin/VarMethodType.go
@@ -1,0 +1,5 @@
+package main
+
+func F() {
+    var x /*ref*/float32
+}

--- a/testData/psi/resolve/calls/CallToEmbeddedInterfaceMethod.go
+++ b/testData/psi/resolve/calls/CallToEmbeddedInterfaceMethod.go
@@ -1,0 +1,14 @@
+package main
+
+type Bird interface {
+	/*def*/Fly()
+}
+
+type Swan interface {
+	Bird
+	Swim()
+}
+
+func Play(x *Swan) {
+	x./*ref*/Fly()
+}

--- a/testData/psi/resolve/calls/CallToFunctionLiteral.go
+++ b/testData/psi/resolve/calls/CallToFunctionLiteral.go
@@ -1,0 +1,8 @@
+package main
+
+func main() {
+	var /*def*/good1 = func(s string) {
+	}
+
+	/*ref*/good1("Hello, world!\n")
+}

--- a/testData/psi/resolve/calls/CallToFunctionVariable.go
+++ b/testData/psi/resolve/calls/CallToFunctionVariable.go
@@ -1,0 +1,10 @@
+package main
+
+func Foo() int {
+    return 5
+}
+
+func main() {
+    /*def*/f := Foo
+    println(Foo(), /*ref*/f())
+}

--- a/testData/psi/resolve/calls/CallToFunctionWithSameNameAsMethod.go
+++ b/testData/psi/resolve/calls/CallToFunctionWithSameNameAsMethod.go
@@ -1,0 +1,15 @@
+package main
+
+type T int
+
+func /*def*/F() {
+
+}
+
+func (T) F() {
+
+}
+
+func main() {
+	/*ref*/F()
+}

--- a/testData/psi/resolve/calls/CallToFunctionWithSameNameAsMethodAcrossPackages/main.go
+++ b/testData/psi/resolve/calls/CallToFunctionWithSameNameAsMethodAcrossPackages/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "p1"
+
+func main() {
+    p1./*ref*/F()
+}

--- a/testData/psi/resolve/calls/CallToFunctionWithSameNameAsMethodAcrossPackages/p1/p1.go
+++ b/testData/psi/resolve/calls/CallToFunctionWithSameNameAsMethodAcrossPackages/p1/p1.go
@@ -1,0 +1,11 @@
+package p1
+
+type T int
+
+func /*def*/F() {
+
+}
+
+func (T) F() {
+
+}

--- a/testData/psi/resolve/calls/CallToLocalFunction.go
+++ b/testData/psi/resolve/calls/CallToLocalFunction.go
@@ -1,0 +1,8 @@
+package main
+
+func /*def*/f() {
+}
+
+func main() {
+    /*ref*/f()
+}

--- a/testData/psi/resolve/calls/CallToLocalInterfaceMethod.go
+++ b/testData/psi/resolve/calls/CallToLocalInterfaceMethod.go
@@ -1,0 +1,10 @@
+package main
+
+type T interface {
+    /*def*/Method1()
+}
+
+func main() {
+    var x T
+    x./*ref*/Method1()
+}

--- a/testData/psi/resolve/calls/CallToLocalInterfaceMethodNested.go
+++ b/testData/psi/resolve/calls/CallToLocalInterfaceMethodNested.go
@@ -1,0 +1,11 @@
+package main
+
+type T interface {
+    Method1() T
+    /*def*/Method2()
+}
+
+func main() {
+    var x T
+    x.Method1()./*ref*/Method2()
+}

--- a/testData/psi/resolve/calls/CallToLocalInterfaceMethodViaMap.go
+++ b/testData/psi/resolve/calls/CallToLocalInterfaceMethodViaMap.go
@@ -1,0 +1,11 @@
+package main
+
+type T interface {
+    Method1() T
+    /*def*/Method2()
+}
+
+func main() {
+    var x map[int]T
+    x[1].Method1()./*ref*/Method2()
+}

--- a/testData/psi/resolve/calls/CallToLocalInterfaceMethodViaSlice.go
+++ b/testData/psi/resolve/calls/CallToLocalInterfaceMethodViaSlice.go
@@ -1,0 +1,11 @@
+package main
+
+type T interface {
+    Method1() T
+    /*def*/Method2()
+}
+
+func main() {
+    var x []T
+    x[1].Method1()./*ref*/Method2()
+}

--- a/testData/psi/resolve/calls/CallToLocalInterfaceMethodViaTypeAssert.go
+++ b/testData/psi/resolve/calls/CallToLocalInterfaceMethodViaTypeAssert.go
@@ -1,0 +1,10 @@
+package main
+
+type T interface {
+    Method1() T
+    /*def*/Method2()
+}
+
+func main() {
+    x.(T).Method1()./*ref*/Method2()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethod.go
+++ b/testData/psi/resolve/calls/CallToLocalMethod.go
@@ -1,0 +1,11 @@
+package main
+
+type T int
+
+func (t T) /*def*/Fyy() {
+}
+
+func main() {
+    var x T
+    x./*ref*/Fyy()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethodByPointer.go
+++ b/testData/psi/resolve/calls/CallToLocalMethodByPointer.go
@@ -1,0 +1,11 @@
+package main
+
+type T int
+
+func (t *T) /*def*/Fyy() {
+}
+
+func main() {
+    var x *T
+    x./*ref*/Fyy()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethodNested.go
+++ b/testData/psi/resolve/calls/CallToLocalMethodNested.go
@@ -1,0 +1,14 @@
+package main
+
+type T int
+
+func (t T) /*def*/F1() {
+}
+
+func (t T) F2() T {
+}
+
+func main() {
+    var x T
+    x.F2()./*ref*/F1()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethodViaMap.go
+++ b/testData/psi/resolve/calls/CallToLocalMethodViaMap.go
@@ -1,0 +1,14 @@
+package main
+
+type T int
+
+func (t T) /*def*/F1() {
+}
+
+func (t T) F2() T {
+}
+
+func main() {
+    var x map[int]T
+    x[1].F2()./*ref*/F1()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethodViaShortVarDeclaration.go
+++ b/testData/psi/resolve/calls/CallToLocalMethodViaShortVarDeclaration.go
@@ -1,0 +1,14 @@
+package main
+
+type T int
+
+func (t T) /*def*/F1() {
+}
+
+func (t T) F2() T {
+}
+
+func main() {
+    x := t.(T)
+    x.F2()./*ref*/F1()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethodViaSlice.go
+++ b/testData/psi/resolve/calls/CallToLocalMethodViaSlice.go
@@ -1,0 +1,14 @@
+package main
+
+type T int
+
+func (t T) /*def*/F1() {
+}
+
+func (t T) F2() T {
+}
+
+func main() {
+    var x [int]T
+    x[1].F2()./*ref*/F1()
+}

--- a/testData/psi/resolve/calls/CallToLocalMethodViaTypeAssert.go
+++ b/testData/psi/resolve/calls/CallToLocalMethodViaTypeAssert.go
@@ -1,0 +1,13 @@
+package main
+
+type T int
+
+func (t T) /*def*/F1() {
+}
+
+func (t T) F2() T {
+}
+
+func main() {
+    x.(T).F2()./*ref*/F1()
+}

--- a/testData/psi/resolve/calls/CallToMethodParameter.go
+++ b/testData/psi/resolve/calls/CallToMethodParameter.go
@@ -1,0 +1,4 @@
+package main
+func F(/*def*/n func()) {
+    /*ref*/n()    // <-- first place
+}

--- a/testData/psi/resolve/calls/CallToMethodViaShortVar/main.go
+++ b/testData/psi/resolve/calls/CallToMethodViaShortVar/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "test"
+
+func f() {
+    r := test.Method()
+    x := r./*ref*/ActualMethod()
+}

--- a/testData/psi/resolve/calls/CallToMethodViaShortVar/test/test.go
+++ b/testData/psi/resolve/calls/CallToMethodViaShortVar/test/test.go
@@ -1,0 +1,13 @@
+package test
+
+type T struct {
+
+}
+
+func Method() *T {
+    return nil
+}
+
+func (t *T) /*def*/ActualMethod() {
+
+}

--- a/testData/psi/resolve/calls/CallToMethodWithTheSameNameAsFunction.go
+++ b/testData/psi/resolve/calls/CallToMethodWithTheSameNameAsFunction.go
@@ -1,0 +1,15 @@
+package main
+
+type T int
+
+func F() {
+
+}
+
+func (T) /*def*/F() {
+
+}
+
+func main() {
+	T(1)./*ref*/F()
+}

--- a/testData/psi/resolve/calls/CallToMethodWithTheSameNameAsFunctionAcrossPackages/main.go
+++ b/testData/psi/resolve/calls/CallToMethodWithTheSameNameAsFunctionAcrossPackages/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "p1"
+
+func main() {
+    p1.T(1)./*ref*/F()
+}

--- a/testData/psi/resolve/calls/CallToMethodWithTheSameNameAsFunctionAcrossPackages/p1/p1.go
+++ b/testData/psi/resolve/calls/CallToMethodWithTheSameNameAsFunctionAcrossPackages/p1/p1.go
@@ -1,0 +1,11 @@
+package p1
+
+type T int
+
+func F() {
+
+}
+
+func (T) /*def*/F() {
+
+}

--- a/testData/psi/resolve/calls/ConversionToImportedFunction/main.go
+++ b/testData/psi/resolve/calls/ConversionToImportedFunction/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "test"
+
+func main() {
+    println(test./*ref*/Func(10))
+}

--- a/testData/psi/resolve/calls/ConversionToImportedFunction/test/test.go
+++ b/testData/psi/resolve/calls/ConversionToImportedFunction/test/test.go
@@ -1,0 +1,5 @@
+package test
+
+func /*def*/Func() {
+
+}

--- a/testData/psi/resolve/calls/ConversionToImportedType/main.go
+++ b/testData/psi/resolve/calls/ConversionToImportedType/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "test"
+
+func main() {
+    println(test./*ref*/Type(10))
+}

--- a/testData/psi/resolve/calls/ConversionToImportedType/test/test.go
+++ b/testData/psi/resolve/calls/ConversionToImportedType/test/test.go
@@ -1,0 +1,3 @@
+package test
+
+type /*def*/Type int

--- a/testData/psi/resolve/calls/ConversionToLocallyImportedType/main.go
+++ b/testData/psi/resolve/calls/ConversionToLocallyImportedType/main.go
@@ -1,0 +1,7 @@
+package main
+
+import . "test"
+
+func main() {
+    println(/*ref*/Type(10))
+}

--- a/testData/psi/resolve/calls/ConversionToLocallyImportedType/test/test.go
+++ b/testData/psi/resolve/calls/ConversionToLocallyImportedType/test/test.go
@@ -1,0 +1,3 @@
+package test
+
+type /*def*/Type int

--- a/testData/psi/resolve/calls/DirectlyInheritedMethodSet.go
+++ b/testData/psi/resolve/calls/DirectlyInheritedMethodSet.go
@@ -1,0 +1,23 @@
+package main
+
+type Common struct {
+}
+
+type Derived struct {
+	Common
+	derivedMember int
+}
+
+func (c*Common) /*def*/commonMethod() {
+
+}
+
+func (c*Derived) derivedMethod() {
+
+}
+
+func f() {
+	var x Derived
+
+	x./*ref*/commonMethod();
+}

--- a/testData/psi/resolve/calls/FunctionInSamePackageDifferentFile/callee.go
+++ b/testData/psi/resolve/calls/FunctionInSamePackageDifferentFile/callee.go
@@ -1,0 +1,5 @@
+package bananarama;
+
+func /*def*/Call() {
+
+}

--- a/testData/psi/resolve/calls/FunctionInSamePackageDifferentFile/caller.go
+++ b/testData/psi/resolve/calls/FunctionInSamePackageDifferentFile/caller.go
@@ -1,0 +1,5 @@
+package bananarama;
+
+func main() {
+    /*ref*/Call();
+}

--- a/testData/psi/resolve/calls/GrandParentDirectlyInheritedMethodSet.go
+++ b/testData/psi/resolve/calls/GrandParentDirectlyInheritedMethodSet.go
@@ -1,0 +1,31 @@
+package main
+
+type MoreCommon struct {
+}
+
+type Common struct {
+	MoreCommon
+}
+
+type Derived struct {
+	Common
+	derivedMember int
+}
+
+func (c*MoreCommon) /*def*/moreCommonMethod() {
+
+}
+
+func (c*Common) commonMethod() {
+
+}
+
+func (c*Derived) derivedMethod() {
+
+}
+
+func f() {
+	var x Derived
+
+	x./*ref*/moreCommonMethod();
+}

--- a/testData/psi/resolve/calls/ImportedEmbeddedTypeMethod/main.go
+++ b/testData/psi/resolve/calls/ImportedEmbeddedTypeMethod/main.go
@@ -1,0 +1,24 @@
+package main
+
+import "p"
+
+type SomeOtherFoo struct {
+    p.Embedded
+}
+
+func (s SomeOtherFoo) GetThing() string {
+    return ""
+}
+
+type Foo struct {
+    SomeOtherFoo
+}
+
+func test() {
+    x := Foo{}
+    x./*ref*/Get("asdf")
+}
+
+func main() {
+
+}

--- a/testData/psi/resolve/calls/ImportedEmbeddedTypeMethod/p/p.go
+++ b/testData/psi/resolve/calls/ImportedEmbeddedTypeMethod/p/p.go
@@ -1,0 +1,8 @@
+package p
+
+type Embedded struct {
+}
+
+func (s Embedded) /*def*/Get(string) string {
+    return ""
+}

--- a/testData/psi/resolve/calls/NoConversionToBlankImportedType/main.go
+++ b/testData/psi/resolve/calls/NoConversionToBlankImportedType/main.go
@@ -1,0 +1,7 @@
+package main
+
+import _ "test"
+
+func main() {
+    println(/*ref*/Type(10))
+}

--- a/testData/psi/resolve/calls/NoConversionToBlankImportedType/test/test.go
+++ b/testData/psi/resolve/calls/NoConversionToBlankImportedType/test/test.go
@@ -1,0 +1,3 @@
+package test
+
+type Type int

--- a/testData/psi/resolve/calls/RecursiveMethodCall.go
+++ b/testData/psi/resolve/calls/RecursiveMethodCall.go
@@ -1,0 +1,8 @@
+package main
+
+func /*def*/F(n int) int {
+    if n <= 1 {
+        return 1
+    }
+    return n * /*ref*/F(n-1)
+}

--- a/testData/psi/resolve/calls/RelativePackageReference/main/main.go
+++ b/testData/psi/resolve/calls/RelativePackageReference/main/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "../test2"
+
+func main() {
+	x := test2./*ref*/Exported
+}

--- a/testData/psi/resolve/calls/RelativePackageReference/test2/test2.go
+++ b/testData/psi/resolve/calls/RelativePackageReference/test2/test2.go
@@ -1,0 +1,3 @@
+package test2
+
+var /*def*/Exported = 10

--- a/testData/psi/resolve/calls/RelativePackageReferenceDeep/level1/level2/level2.go
+++ b/testData/psi/resolve/calls/RelativePackageReferenceDeep/level1/level2/level2.go
@@ -1,0 +1,3 @@
+package level2
+
+var /*def*/Exported = 10

--- a/testData/psi/resolve/calls/RelativePackageReferenceDeep/level1/main/main.go
+++ b/testData/psi/resolve/calls/RelativePackageReferenceDeep/level1/main/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "../../level1/level2"
+
+func main() {
+	x := level2./*ref*/Exported
+}

--- a/testData/psi/resolve/calls/TypeConversionToLocalType.go
+++ b/testData/psi/resolve/calls/TypeConversionToLocalType.go
@@ -1,0 +1,10 @@
+package main
+
+type /*def*/f int
+
+func ff() {
+}
+
+func main() {
+    /*ref*/f()
+}

--- a/testData/psi/resolve/composite/ExpressionKey.go
+++ b/testData/psi/resolve/composite/ExpressionKey.go
@@ -1,0 +1,13 @@
+package main
+
+type error interface {
+	Error() string
+}
+
+type scanError struct {
+	err error
+}
+
+func (s *ss) error(/*def*/err error) {
+	panic(scanError{/*ref*/err})
+}

--- a/testData/psi/resolve/composite/KeyAsConstantExpression.go
+++ b/testData/psi/resolve/composite/KeyAsConstantExpression.go
@@ -1,0 +1,10 @@
+package main
+
+const /*def*/MyConstant = "Hello"
+
+type MyMap map[string]int
+
+var MyVar = MyMap{
+    /*ref*/MyConstant:10,
+}
+

--- a/testData/psi/resolve/composite/NestedNamedStruct.go
+++ b/testData/psi/resolve/composite/NestedNamedStruct.go
@@ -1,0 +1,18 @@
+package main
+
+import "fmt"
+
+type T struct {
+    /*def*/a, b int
+}
+
+type T2 struct {
+    a, b int
+    c []T
+}
+
+var x = T2{ c:[]T{{/*ref*/a:1, b:2}} }
+
+func main() {
+    fmt.Println(x)
+}

--- a/testData/psi/resolve/composite/NestedStruct.go
+++ b/testData/psi/resolve/composite/NestedStruct.go
@@ -1,0 +1,14 @@
+package main
+
+type T struct {
+    /*def*/a, b int
+}
+
+type T2 struct {
+    a, b int
+    c T
+}
+
+var x = T2{ c:{/*ref*/a:1, b:2} }
+
+

--- a/testData/psi/resolve/composite/PromotedAnonymousField1.go
+++ b/testData/psi/resolve/composite/PromotedAnonymousField1.go
@@ -1,0 +1,13 @@
+package main
+
+type T1 struct {
+	/*def*/intValue int
+}
+
+type T2 struct {
+	T1
+}
+
+func foo(t2 T2) {
+    t2./*ref*/intValue
+}

--- a/testData/psi/resolve/composite/PromotedAnonymousField2.go
+++ b/testData/psi/resolve/composite/PromotedAnonymousField2.go
@@ -1,0 +1,21 @@
+package main
+
+type T1 struct {
+	/*def*/t1Value int
+}
+
+type T2 struct {
+	T1
+}
+
+type T3 struct {
+	T2
+}
+
+type T4 struct {
+	T3
+}
+
+func foo(t4 T4) {
+    t4./*ref*/t1Value
+}

--- a/testData/psi/resolve/composite/PromotedAnonymousField3.go
+++ b/testData/psi/resolve/composite/PromotedAnonymousField3.go
@@ -1,0 +1,22 @@
+package main
+
+type T1 struct {
+	value int
+}
+
+type T2 struct {
+	T1
+	/*def*/value int
+}
+
+type T3 struct {
+	T2
+}
+
+type T4 struct {
+	T3
+}
+
+func foo(t4 T4) {
+    t4./*ref*/value
+}

--- a/testData/psi/resolve/composite/PromotedAnonymousField4.go
+++ b/testData/psi/resolve/composite/PromotedAnonymousField4.go
@@ -1,0 +1,21 @@
+package main
+
+type T1 struct {
+	value int
+}
+
+type T2 struct {
+	T1
+}
+
+type T3 struct {
+	/*def*/T2
+}
+
+type T4 struct {
+	T3
+}
+
+func foo(t4 T4) {
+    t4./*ref*/T2
+}

--- a/testData/psi/resolve/composite/TypeName.go
+++ b/testData/psi/resolve/composite/TypeName.go
@@ -1,0 +1,8 @@
+package main
+
+type T struct {
+    /*def*/a, b int
+    c *T
+}
+
+var x = T{/*ref*/a:1, b:2, c:nil }

--- a/testData/psi/resolve/composite/TypeNameArray.go
+++ b/testData/psi/resolve/composite/TypeNameArray.go
@@ -1,0 +1,8 @@
+package main
+
+type T struct {
+    /*def*/a, b int
+    c *T
+}
+
+var x = [1]T{ {/*ref*/a:1, b:2, c:nil} }

--- a/testData/psi/resolve/composite/TypeNameMap.go
+++ b/testData/psi/resolve/composite/TypeNameMap.go
@@ -1,0 +1,8 @@
+package main
+
+type T struct {
+    /*def*/a, b int
+    c *T
+}
+
+var x = map[string]T{ "1":{/*ref*/a:1, b:2, c:nil} }

--- a/testData/psi/resolve/composite/TypeNameSlice.go
+++ b/testData/psi/resolve/composite/TypeNameSlice.go
@@ -1,0 +1,8 @@
+package main
+
+type T struct {
+    /*def*/a, b int
+    c *T
+}
+
+var x = []T{ {/*ref*/a:1, b:2, c:nil} }

--- a/testData/psi/resolve/composite/TypeStruct.go
+++ b/testData/psi/resolve/composite/TypeStruct.go
@@ -1,0 +1,6 @@
+package main
+
+var x = struct {
+    /*def*/a, b int
+    c *T
+}{/*ref*/a:1, b:2, c:nil }

--- a/testData/psi/resolve/composite/TypeStructArray.go
+++ b/testData/psi/resolve/composite/TypeStructArray.go
@@ -1,0 +1,6 @@
+package main
+
+var x = [1]struct {
+    /*def*/a, b int
+    c *T
+}{ {/*ref*/a:1, b:2, c:nil} }

--- a/testData/psi/resolve/composite/TypeStructMap.go
+++ b/testData/psi/resolve/composite/TypeStructMap.go
@@ -1,0 +1,6 @@
+package main
+
+var x = map[string]struct {
+    /*def*/a, b int
+    c *T
+}{ "1": {/*ref*/a:1, b:2, c:nil} }

--- a/testData/psi/resolve/composite/TypeStructSlice.go
+++ b/testData/psi/resolve/composite/TypeStructSlice.go
@@ -1,0 +1,6 @@
+package main
+
+var x = []struct {
+    /*def*/a, b int
+    c *T
+}{ {/*ref*/a:1, b:2, c:nil} }

--- a/testData/psi/resolve/composite/TypeSwitch.go
+++ b/testData/psi/resolve/composite/TypeSwitch.go
@@ -1,0 +1,13 @@
+package main
+
+type S struct {
+    /*def*/a int
+}
+
+func main() {
+    var a interface{}
+    switch t := a.(type) {
+    case S:
+        println(t./*ref*/a)
+    }
+}

--- a/testData/psi/resolve/package/AliasedImport/main.go
+++ b/testData/psi/resolve/package/AliasedImport/main.go
@@ -1,0 +1,7 @@
+package main
+
+import /*def*/xx "a"
+
+func main() {
+    /*ref*/xx.
+}

--- a/testData/psi/resolve/package/DefaultImport/a/b/b.go
+++ b/testData/psi/resolve/package/DefaultImport/a/b/b.go
@@ -1,0 +1,1 @@
+package b

--- a/testData/psi/resolve/package/DefaultImport/main.go
+++ b/testData/psi/resolve/package/DefaultImport/main.go
@@ -1,0 +1,7 @@
+package main
+
+import /*def*/"a/b"
+
+func main() {
+    /*ref*/b.
+}

--- a/testData/psi/resolve/package/DefaultImportWithDifferentName/a/b/b.go
+++ b/testData/psi/resolve/package/DefaultImportWithDifferentName/a/b/b.go
@@ -1,0 +1,1 @@
+package b1

--- a/testData/psi/resolve/package/DefaultImportWithDifferentName/main.go
+++ b/testData/psi/resolve/package/DefaultImportWithDifferentName/main.go
@@ -1,0 +1,7 @@
+package main
+
+import /*def*/"a/b"
+
+func main() {
+    /*ref*/b1.
+}

--- a/tests/com/goide/GoCodeInsightFixtureTestCase.java
+++ b/tests/com/goide/GoCodeInsightFixtureTestCase.java
@@ -16,7 +16,6 @@
 
 package com.goide;
 
-import com.goide.psi.GoFile;
 import com.goide.sdk.GoSdkType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
@@ -24,20 +23,14 @@ import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.SdkModificator;
 import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
 import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
-import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 abstract public class GoCodeInsightFixtureTestCase extends LightPlatformCodeInsightFixtureTestCase {
   @Override
@@ -78,24 +71,6 @@ abstract public class GoCodeInsightFixtureTestCase extends LightPlatformCodeInsi
     instance.setupSdkPaths(sdk);
     return sdk;
   }
-  
-  @NotNull
-  protected List<GoFile> addPackage(@NotNull String importPath, @NotNull String... fileNames) {
-    List<GoFile> files = ContainerUtil.newArrayListWithCapacity(fileNames.length);
-    for (String fileName : fileNames) {
-      VirtualFile virtualFile = getFile(fileName);
-      assertNotNull(virtualFile);
-      String text = loadText(virtualFile);
-      PsiFile file = myFixture.addFileToProject(FileUtil.toCanonicalPath(importPath + "/" + virtualFile.getName()), text);
-      if (file instanceof GoFile) {
-        files.add((GoFile)file);
-      }
-      else {
-        throw new RuntimeException("Can't create a new go file by the virtual one: " + virtualFile);
-      }
-    }
-    return files;
-  }
 
   @NotNull
   protected static String loadText(@NotNull VirtualFile file) {
@@ -105,14 +80,5 @@ abstract public class GoCodeInsightFixtureTestCase extends LightPlatformCodeInsi
     catch (IOException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @Nullable
-  private VirtualFile getFile(@NotNull String fileName) {
-    VirtualFile file = VfsUtil.findFileByIoFile(new File(getTestDataPath() + "/" + getTestName(true) + "/" + fileName), true);
-    if (file != null) return file;
-    file = VfsUtil.findFileByIoFile(new File(getTestDataPath() + "/" + fileName), true);
-    if (file != null) return file;
-    return VfsUtil.findFileByIoFile(new File(fileName), true);
   }
 }

--- a/tests/com/goide/GoVarUsageTest.java
+++ b/tests/com/goide/GoVarUsageTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import static com.intellij.util.containers.ContainerUtil.newArrayList;
 
-public class GoVarResolveTest extends GoCodeInsightFixtureTestCase {
+public class GoVarUsageTest extends GoCodeInsightFixtureTestCase {
   private static final String USAGE = "/*usage*/";
 
   private void doTest(String text) {

--- a/tests/com/goide/completion/GoCompletionTest.java
+++ b/tests/com/goide/completion/GoCompletionTest.java
@@ -229,7 +229,7 @@ public class GoCompletionTest extends GoCompletionTestBase {
   }
   
   public void testNoMainAnymore() {
-    doTestExclude("package foo; func mai<caret> { }", "main");
+    doTestEquals("package foo; func ma<caret> { }");
   }
 
   public void testPackageBeforeDot() {

--- a/tests/com/goide/completion/GoCompletionTest.java
+++ b/tests/com/goide/completion/GoCompletionTest.java
@@ -267,6 +267,16 @@ public class GoCompletionTest extends GoCompletionTestBase {
                   "}", "fooVar");
   }
 
+  public void testStructConstructions() throws Exception {
+    doCheckResult("package main; func main() {WaitGr<caret>}; type WaitGroup struct {sema *uint32}", 
+                  "package main; func main() {WaitGroup{<caret>}}; type WaitGroup struct {sema *uint32}");
+  }
+
+  public void testIntConversion() throws Exception {
+    doCheckResult("package main; func main() {int<caret>}; type int int",
+                  "package main; func main() {int(<caret>)}; type int int");
+  }
+
   private void doTestCompletion() {
     myFixture.testCompletion(getTestName(true) + ".go", getTestName(true) + "_after.go");
   }

--- a/tests/com/goide/completion/GoCompletionTest.java
+++ b/tests/com/goide/completion/GoCompletionTest.java
@@ -227,6 +227,10 @@ public class GoCompletionTest extends GoCompletionTestBase {
   public void testLabel() {
     doTestInclude("package foo; func main() { goto <caret>; Label1: 1}", "Label1");
   }
+  
+  public void testNoMainAnymore() {
+    doTestExclude("package foo; func mai<caret> { }", "main");
+  }
 
   public void testPackageBeforeDot() {
     doCheckResult("package foo; import imp \"\"; func foo(a im<caret>.SomeType) {}",

--- a/tests/com/goide/formatter/GoFormatterTest.java
+++ b/tests/com/goide/formatter/GoFormatterTest.java
@@ -4,23 +4,21 @@ import com.goide.GoCodeInsightFixtureTestCase;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 
-import java.io.IOException;
-
 public class GoFormatterTest extends GoCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {
     return "formatting";
   }
 
-  public void testSimple() throws Exception {
+  public void testSimple() {
     doTest();
   }
 
-  public void doTest() throws Exception {
+  public void doTest() {
     doTest(true);
   }
 
-  public void doTest(boolean format) throws Exception {
+  public void doTest(boolean format) {
     String testName = getTestName(true);
     myFixture.configureByFile(testName + ".go");
     String after = doTest(format, testName);

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -52,6 +52,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testShortVars() { doTest(); }
   public void testReturns()   { doTest(); }
   public void testRequest()   { doTest(); }
+  public void testStop()      { doTest(); }
   
   @Override
   protected LightProjectDescriptor getProjectDescriptor() {

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -55,6 +55,12 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testRequest()   { doTest(); }
   public void testStop()      { doTest(); }
   
+  public void testLocalScope() {
+    myFixture.configureByText("a.go", "package foo; func bar() {}");
+    myFixture.configureByText("b.go", "package foo; func init(){bar()}");
+    myFixture.checkHighlighting();
+  }
+  
   @Override
   protected LightProjectDescriptor getProjectDescriptor() {
     return createMockProjectDescriptor();

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -61,6 +61,12 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
     myFixture.checkHighlighting();
   }
   
+  public void testDuplicatesInOnePackage() {
+    myFixture.configureByText("a.go", "package foo; func init() {bar()}; func bar() {}");
+    myFixture.configureByText("b.go", "package foo; func <error>bar</error>() {}");
+    myFixture.checkHighlighting();
+  }
+  
   @Override
   protected LightProjectDescriptor getProjectDescriptor() {
     return createMockProjectDescriptor();

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -54,6 +54,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testReturns()   { doTest(); }
   public void testRequest()   { doTest(); }
   public void testStop()      { doTest(); }
+  public void testVarBlocks() { doTest(); }
   
   public void testLocalScope() {
     myFixture.configureByText("a.go", "package foo; func bar() {}");

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -47,6 +47,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testBoxes()     { doTest(); }
   public void testRanges()    { doTest(); }
   public void testVars()      { doTest(); }
+  public void testRecv()      { doTest(); }
   public void testPointers()  { doTest(); }
   public void testSlices()    { doTest(); }
   public void testShortVars() { doTest(); }

--- a/tests/com/goide/parser/GoParserTest.java
+++ b/tests/com/goide/parser/GoParserTest.java
@@ -51,5 +51,6 @@ public class GoParserTest extends ParsingTestCase {
   public void testRecover2()    { doTest(false); }
   public void testMethodExpr()  { doTest(false); }
   public void testLabels()      { doTest(false); }
+  public void testBlockRecover(){ doTest(false); }
   public void testMethodWithoutReceiverIdentifier()  { doTest(false); }
 }

--- a/tests/com/goide/parser/GoParserTest.java
+++ b/tests/com/goide/parser/GoParserTest.java
@@ -38,19 +38,19 @@ public class GoParserTest extends ParsingTestCase {
       Extensions.getRootArea(), "com.intellij.lang.braceMatcher", LanguageExtensionPoint.class);
   }
 
-  public void testSimple()      { doTest(true);  }
-  public void testError()       { doTest(true);  }
-  public void testWriter()      { doTest(true);  }
-  public void testPrimer()      { doTest(true);  }
-  public void testTypes()       { doTest(true);  }
-  public void testStr2Num()     { doTest(true);  }
-  public void testCars()        { doTest(true);  }
-  public void testIfWithNew()   { doTest(true);  }
-  public void testRanges()      { doTest(true);  }
-  public void testRecover()     { doTest(false); }
-  public void testRecover2()    { doTest(false); }
-  public void testMethodExpr()  { doTest(false); }
-  public void testLabels()      { doTest(false); }
-  public void testBlockRecover(){ doTest(false); }
-  public void testMethodWithoutReceiverIdentifier()  { doTest(false); }
+  public void testSimple()                          { doTest(true);  }
+  public void testError()                           { doTest(true);  }
+  public void testWriter()                          { doTest(true);  }
+  public void testPrimer()                          { doTest(true);  }
+  public void testTypes()                           { doTest(true);  }
+  public void testStr2Num()                         { doTest(true);  }
+  public void testCars()                            { doTest(true);  }
+  public void testIfWithNew()                       { doTest(true);  }
+  public void testRanges()                          { doTest(true);  }
+  public void testRecover()                         { doTest(false); }
+  public void testRecover2()                        { doTest(false); }
+  public void testMethodExpr()                      { doTest(false); }
+  public void testLabels()                          { doTest(false); }
+  public void testBlockRecover()                    { doTest(false); }
+  public void testMethodWithoutReceiverIdentifier() { doTest(false); }
 }

--- a/tests/com/goide/psi/GoLegacyResolvePackageTest.java
+++ b/tests/com/goide/psi/GoLegacyResolvePackageTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.psi;
+
+import com.goide.GoLegacyResolveTestBase;
+
+public class GoLegacyResolvePackageTest extends GoLegacyResolveTestBase {
+  @Override
+  protected String getBasePath() { return "psi/resolve/package"; }
+
+  public void testAliasedImport()                   { doDirTest(); } 
+  public void testDefaultImport()                   { doDirTest(); } 
+  public void testDefaultImportWithDifferentName()  { doDirTest(); } 
+}

--- a/tests/com/goide/psi/legacy/GoLegacyResolveBuiltinTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveBuiltinTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.psi.legacy;
+
+import com.intellij.testFramework.LightProjectDescriptor;
+
+public class GoLegacyResolveBuiltinTest extends GoLegacyResolveTestBase {
+  @Override
+  protected String getBasePath() { return "psi/resolve/builtin"; }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    setUpProjectSdk();
+  }
+
+  @Override
+  protected boolean assertNullDefinition() {
+    return false;
+  }
+
+  @Override
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return createMockProjectDescriptor();
+  }
+  
+  public void testMethodName()        { doTest(); } 
+  public void testBuiltinTypes()      { doTest(); } 
+  public void testBuiltinConversion() { doTest(); } 
+  public void testVarBuiltinType()    { doTest(); } 
+  public void testVarMethodType()     { doTest(); } 
+  public void testParameterType()     { doTest(); }
+
+  @Override
+  protected void processNullResolve() {
+    assert false : "Reference " + myReference + " should be resolved";
+  }
+}

--- a/tests/com/goide/psi/legacy/GoLegacyResolveBuiltinTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveBuiltinTest.java
@@ -29,8 +29,8 @@ public class GoLegacyResolveBuiltinTest extends GoLegacyResolveTestBase {
   }
 
   @Override
-  protected boolean assertNullDefinition() {
-    return false;
+  protected boolean allowNullDefinition() {
+    return true;
   }
 
   @Override
@@ -47,6 +47,6 @@ public class GoLegacyResolveBuiltinTest extends GoLegacyResolveTestBase {
 
   @Override
   protected void processNullResolve() {
-    assert false : "Reference " + myReference + " should be resolved";
+    fail("Reference " + myReference + " should be resolved");
   }
 }

--- a/tests/com/goide/psi/legacy/GoLegacyResolveCallsTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveCallsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.psi.legacy;
+
+public class GoLegacyResolveCallsTest extends GoLegacyResolveTestBase {
+  @Override
+  protected String getBasePath() { return "psi/resolve/calls"; }
+
+  public void testCallToLocalMethodByPointer() { doTest(); } 
+  public void testCallToLocalMethod() { doTest(); } 
+  public void testCallToLocalMethodNested() { doTest(); } 
+  public void testCallToLocalMethodViaMap() { doTest(); } 
+  public void testCallToLocalMethodViaShortVarDeclaration() { doTest(); } 
+  public void testCallToLocalMethodViaSlice() { doTest(); } 
+  public void testCallToLocalMethodViaTypeAssert() { doTest(); } 
+  public void testCallToLocalInterfaceMethod() { doTest(); } 
+  public void testCallToLocalInterfaceMethodNested() { doTest(); } 
+  public void testCallToLocalInterfaceMethodViaMap() { doTest(); } 
+  public void testCallToLocalInterfaceMethodViaSlice() { doTest(); } 
+  public void testCallToLocalInterfaceMethodViaTypeAssert() { doTest(); } 
+  public void testCallToLocalFunction() { doTest(); } 
+  public void testCallToFunctionLiteral() { doTest(); } 
+  public void testTypeConversionToLocalType() { doTest(); } 
+  public void testRecursiveMethodCall() { doTest(); } 
+  public void testCallToMethodParameter() { doTest(); } 
+  public void testCallToFunctionVariable() { doTest(); } 
+  public void testDirectlyInheritedMethodSet() { doTest(); } 
+  public void testGrandParentDirectlyInheritedMethodSet() { doTest(); } 
+  public void testCallToEmbeddedInterfaceMethod() { doTest(); } 
+  public void testCallToFunctionWithSameNameAsMethod() { doTest(); } 
+  public void testCallToMethodWithTheSameNameAsFunction() { doTest(); } 
+  
+  public void testConversionToImportedType() { doDirTest(); } 
+  public void testConversionToImportedFunction() { doDirTest(); } 
+  public void testNoConversionToBlankImportedType() { doDirTest(); } 
+  public void testConversionToLocallyImportedType() { doDirTest(); } 
+  public void testFunctionInSamePackageDifferentFile() { doDirTest(); } 
+  public void testRelativePackageReference() { doDirTest(); }
+  public void testRelativePackageReferenceDeep() { doDirTest(); } 
+  public void testCallToFunctionWithSameNameAsMethodAcrossPackages() { doDirTest(); } 
+  public void testCallToMethodViaShortVar() { doDirTest(); } 
+  public void testImportedEmbeddedTypeMethod() { doDirTest(); } 
+  public void testCallToMethodWithTheSameNameAsFunctionAcrossPackages() { doDirTest(); }
+}

--- a/tests/com/goide/psi/legacy/GoLegacyResolveCompositeTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveCompositeTest.java
@@ -29,6 +29,7 @@ public class GoLegacyResolveCompositeTest extends GoLegacyResolveTestBase {
   public void testTypeNameMap()             { doTest(); } 
   public void testTypeNameSlice()           { doTest(); } 
   public void testNestedStruct()            { doTest(); } 
+  public void testNestedNamedStruct()       { doTest(); } 
   public void testKeyAsConstantExpression() { doTest(); } 
   public void testExpressionKey()           { doTest(); } 
   public void testPromotedAnonymousField1() { doTest(); } 

--- a/tests/com/goide/psi/legacy/GoLegacyResolveCompositeTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveCompositeTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2014 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.psi.legacy;
+
+public class GoLegacyResolveCompositeTest extends GoLegacyResolveTestBase {
+  @Override
+  protected String getBasePath() { return "psi/resolve/composite"; }
+
+  public void testTypeName()                { doTest(); } 
+  public void testTypeStruct()              { doTest(); } 
+  public void testTypeStructArray()         { doTest(); } 
+  public void testTypeStructSlice()         { doTest(); } 
+  public void testTypeStructMap()           { doTest(); } 
+  public void testTypeNameArray()           { doTest(); } 
+  public void testTypeNameMap()             { doTest(); } 
+  public void testTypeNameSlice()           { doTest(); } 
+  public void testNestedStruct()            { doTest(); } 
+  public void testKeyAsConstantExpression() { doTest(); } 
+  public void testExpressionKey()           { doTest(); } 
+  public void testPromotedAnonymousField1() { doTest(); } 
+  public void testPromotedAnonymousField2() { doTest(); } 
+  public void testPromotedAnonymousField3() { doTest(); } 
+  public void testPromotedAnonymousField4() { doTest(); } 
+  public void testTypeSwitch()              { doTest(); }
+}

--- a/tests/com/goide/psi/legacy/GoLegacyResolvePackageTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolvePackageTest.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.goide.psi;
-
-import com.goide.GoLegacyResolveTestBase;
+package com.goide.psi.legacy;
 
 public class GoLegacyResolvePackageTest extends GoLegacyResolveTestBase {
   @Override

--- a/tests/com/goide/psi/legacy/GoLegacyResolveStructTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveStructTest.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.goide.psi;
-
-import com.goide.GoLegacyResolveTestBase;
+package com.goide.psi.legacy;
 
 public class GoLegacyResolveStructTest extends GoLegacyResolveTestBase {
   @Override

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -45,20 +45,6 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
     return "psi/resolve";
   }
 
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-    myReference = null;
-    myDefinition = null;
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    myReference = null;
-    myDefinition = null;
-    super.tearDown();
-  }
-
   protected void doResolveTest(boolean lowercase) {
     doResolveTest(getTestName(lowercase) + ".go");
   }

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -82,10 +82,10 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
     processPsiFile((GoFile)myFixture.configureByFile(filePath));
     if (myReference == null) fail("no reference defined in test case");
     PsiElement resolve = myReference.resolve();
-    if (resolve != null && myDefinition == null && assertNullDefinition()) fail("element resolved but it shouldn't have");
+    if (resolve != null && myDefinition == null && !allowNullDefinition()) fail("element resolved but it shouldn't have");
     if (resolve == null && myDefinition != null) fail("element didn't resolve when it should have");
     if (resolve != null) {
-      if (assertNullDefinition()) {
+      if (!allowNullDefinition()) {
         PsiElement def = PsiTreeUtil.getParentOfType(myDefinition, resolve.getClass(), false);
         assertSame(def, resolve);
       }
@@ -95,8 +95,8 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
     }
   }
 
-  protected boolean assertNullDefinition() {
-    return true;
+  protected boolean allowNullDefinition() {
+    return false;
   }
 
   protected void processNullResolve() {

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -37,8 +37,8 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
   @NotNull public String REF_MARK = "/*ref*/";
   @NotNull public String DEF_MARK = "/*def*/";
 
-  @Nullable PsiReference myReference;
-  @Nullable PsiElement myDefinition;
+  @Nullable protected PsiReference myReference;
+  @Nullable protected PsiElement myDefinition;
 
   @Override
   protected String getBasePath() {
@@ -82,12 +82,24 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
     processPsiFile((GoFile)myFixture.configureByFile(filePath));
     if (myReference == null) fail("no reference defined in test case");
     PsiElement resolve = myReference.resolve();
-    if (resolve != null && myDefinition == null) fail("element resolved but it shouldn't have");
+    if (resolve != null && myDefinition == null && assertNullDefinition()) fail("element resolved but it shouldn't have");
     if (resolve == null && myDefinition != null) fail("element didn't resolve when it should have");
     if (resolve != null) {
-      PsiElement def = PsiTreeUtil.getParentOfType(myDefinition, resolve.getClass(), false);
-      assertSame(def, resolve);
+      if (assertNullDefinition()) {
+        PsiElement def = PsiTreeUtil.getParentOfType(myDefinition, resolve.getClass(), false);
+        assertSame(def, resolve);
+      }
     }
+    else {
+      processNullResolve();
+    }
+  }
+
+  protected boolean assertNullDefinition() {
+    return true;
+  }
+
+  protected void processNullResolve() {
   }
 
   private void processPsiFile(@NotNull GoFile file) {

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.goide;
+package com.goide.psi.legacy;
 
+import com.goide.GoCodeInsightFixtureTestCase;
 import com.goide.psi.GoFile;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.vfs.LocalFileSystem;

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -35,7 +35,6 @@ import java.io.File;
 
 public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCase {
   @NotNull public static final String REF_MARK = "/*ref*/";
-  @NotNull public static final String NO_REF_MARK = "/*no ref*/";
   @NotNull public static final String DEF_MARK = "/*def*/";
 
   @Nullable protected PsiReference myReference;

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -34,8 +34,9 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 
 public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCase {
-  @NotNull public String REF_MARK = "/*ref*/";
-  @NotNull public String DEF_MARK = "/*def*/";
+  @NotNull public static final String REF_MARK = "/*ref*/";
+  @NotNull public static final String NO_REF_MARK = "/*no ref*/";
+  @NotNull public static final String DEF_MARK = "/*def*/";
 
   @Nullable protected PsiReference myReference;
   @Nullable protected PsiElement myDefinition;

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -54,13 +54,8 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
     File fromFile = new File(testDataPath + "/" + getTestName(false));
     if (fromFile.isDirectory()) {
       VirtualFile dir = LocalFileSystem.getInstance().findFileByPath(fromFile.getPath());
-      try {
-        assert dir != null;
-        doDirectoryTest(dir);
-      }
-      catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+      assert dir != null;
+      doDirectoryTest(dir);
     }
   }
 
@@ -108,7 +103,7 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
     }
   }
 
-  private void doDirectoryTest(@NotNull final VirtualFile file) throws Exception {
+  private void doDirectoryTest(@NotNull final VirtualFile file) {
     VfsUtilCore.processFilesRecursively(
       file,
       new FilteringProcessor<VirtualFile>(

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTypesTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTypesTest.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.goide.psi;
-
-import com.goide.GoLegacyResolveTestBase;
+package com.goide.psi.legacy;
 
 public class GoLegacyResolveTypesTest extends GoLegacyResolveTestBase {
   @Override

--- a/tests/com/goide/psi/legacy/GoLegacyResolveVarsTest.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveVarsTest.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.goide.psi;
-
-import com.goide.GoLegacyResolveTestBase;
+package com.goide.psi.legacy;
 
 public class GoLegacyResolveVarsTest extends GoLegacyResolveTestBase {
   @Override


### PR DESCRIPTION
This adds support for Go 1.4+ SDKs.

I've also corrected the default Linux paths for the SDK (as per [Go documentation](http://golang.org/doc/install#tarball)) and upgraded the suggestions for the SDK default directory.

After the change I've noticed a severe drop in performance due to ``` getPathsToLookup() ``` method being called a great deal of times / file / element ``` src/com/goide/psi/impl/imports/GoImportReferenceHelper.java ```. Example to be used: ``` src/fmt/print.go ``` from Go 1.4 SDK.