### PR TITLE
Fix GoInspectionTestCase.doTestWithDirectory() to work on Windows.

### DIFF
--- a/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
+++ b/test/ro/redeul/google/go/inspection/GoInspectionTestCase.java
@@ -71,7 +71,14 @@ public abstract class GoInspectionTestCase extends GoLightCodeInsightFixtureTest
         List<String> fileNames = ContainerUtil.map(files, new Function<File, String>() {
             @Override
             public String fun(File file) {
-                return FileUtil.getRelativePath(folder, file);
+                // NOTE: configureFromTempProjectFile needs '/' as the path separator
+                //       (but FileUtil.getRelativePath(File, File) uses File.pathSeparator
+                //        by default, which is equal to '\\' on Windows).
+                final String filePath = FileUtil.getRelativePath(folder, file);
+                if (filePath == null) {
+                    return null;
+                }
+                return FileUtil.toSystemIndependentName(filePath);
             }
         });
 


### PR DESCRIPTION
Because `FileUtil.getRelativePath(File, File)` uses the character specified by `File.pathSeparator` for the returned file path, the returned paths use `'/'` on Linux and `'\\'` on Windows. This causes a number of tests to fail on Windows, because `myFixture.configureFromTempProjectFile(fileName)` requires `'/'` as the path separator.

The issue can be fixed by normalizing the path before passing it to `configureFromTempProjectFile` (as it is done in this commit).
