### PR TITLE
Add support for go1.4 SDK

### DIFF
--- a/src/com/goide/psi/impl/imports/GoImportReferenceHelper.java
+++ b/src/com/goide/psi/impl/imports/GoImportReferenceHelper.java
@@ -100,8 +100,8 @@ public class GoImportReferenceHelper extends FileReferenceHelper {
   @NotNull
   private static List<VirtualFile> getPathsToLookup(@NotNull PsiElement element) {
     List<VirtualFile> result = ContainerUtil.newArrayList();
-    VirtualFile sdkHome = GoSdkUtil.getSdkHome(element);
-    ContainerUtil.addIfNotNull(result, sdkHome);
+    VirtualFile sdkSrcDir = GoSdkUtil.getSdkSrcDir(element);
+    ContainerUtil.addIfNotNull(result, sdkSrcDir);
     result.addAll(GoSdkUtil.getGoPathsSources());
     return result;
   }

--- a/tests/com/goide/GoCodeInsightFixtureTestCase.java
+++ b/tests/com/goide/GoCodeInsightFixtureTestCase.java
@@ -66,7 +66,7 @@ abstract public class GoCodeInsightFixtureTestCase extends LightPlatformCodeInsi
     Sdk sdk = new ProjectJdkImpl(release, instance);
     SdkModificator sdkModificator = sdk.getSdkModificator();
     sdkModificator.setHomePath(sdkHome);
-    sdkModificator.setVersionString(release); // must be set after home path, otherwise setting home path clears the version string
+    sdkModificator.setVersionString(version); // must be set after home path, otherwise setting home path clears the version string
     sdkModificator.commitChanges();
     instance.setupSdkPaths(sdk);
     return sdk;

--- a/tests/com/goide/sdk/GoSdkUtilTest.java
+++ b/tests/com/goide/sdk/GoSdkUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.sdk;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GoSdkUtilTest {
+
+  @Test
+  public void testCompareVersions() throws Exception {
+    assertEquals(-1, GoSdkUtil.compareVersions("1.1.2", "1.1.3"));
+    assertEquals(-1, GoSdkUtil.compareVersions("1.1.2", "1.2.1"));
+    assertEquals(-1, GoSdkUtil.compareVersions("1.1.2", "2.1.1"));
+    assertEquals(-1, GoSdkUtil.compareVersions("1.2", "1.2.1"));
+    assertEquals(-1, GoSdkUtil.compareVersions("1", "1.1"));
+    assertEquals(0, GoSdkUtil.compareVersions("1.2.3", "1.2.3"));
+    assertEquals(0, GoSdkUtil.compareVersions("1.2", "1.2"));
+    assertEquals(0, GoSdkUtil.compareVersions("1", "1"));
+    assertEquals(1, GoSdkUtil.compareVersions("1.2.4", "1.2.3"));
+    assertEquals(1, GoSdkUtil.compareVersions("1.3.3", "1.2.4"));
+    assertEquals(1, GoSdkUtil.compareVersions("2.2.3", "1.4.4"));
+    assertEquals(1, GoSdkUtil.compareVersions("1.2.1", "1.2"));
+  }
+
+  @Test
+  public void testGetSrcLocation() {
+    assertEquals("src/pkg", GoSdkUtil.getSrcLocation("1.1.2"));
+    assertEquals("src/pkg", GoSdkUtil.getSrcLocation("1.2.1"));
+    assertEquals("src/pkg", GoSdkUtil.getSrcLocation("1.3"));
+    assertEquals("src/pkg", GoSdkUtil.getSrcLocation("1.3.1"));
+    assertEquals("src", GoSdkUtil.getSrcLocation("1.4"));
+    assertEquals("src", GoSdkUtil.getSrcLocation("1.4.1"));
+    assertEquals("src", GoSdkUtil.getSrcLocation("1.5"));
+  }
+}


### PR DESCRIPTION
In version **1.4** the format of the `zversion.go` file has been changed that broke the SDK version detection logic. Besides all SDK src files were moved from `${GOROOT}/src/pkg` to `${GOROOT}/src`. This pull request makes the plugin aware of those changes.