### PR TITLE
Introduce isVariadic() in GoParamDefinition, fix type in index expression for variadic parameter

### DIFF
--- a/gen/com/goide/psi/GoParamDefinition.java
+++ b/gen/com/goide/psi/GoParamDefinition.java
@@ -12,4 +12,7 @@ public interface GoParamDefinition extends GoNamedElement, StubBasedPsiElement<G
   @NotNull
   PsiElement getIdentifier();
 
+  @NotNull
+  boolean isVariadic();
+
 }

--- a/gen/com/goide/psi/impl/GoParamDefinitionImpl.java
+++ b/gen/com/goide/psi/impl/GoParamDefinitionImpl.java
@@ -33,4 +33,9 @@ public class GoParamDefinitionImpl extends GoNamedElementImpl<GoParamDefinitionS
     return findNotNullChildByType(IDENTIFIER);
   }
 
+  @NotNull
+  public boolean isVariadic() {
+    return GoPsiImplUtil.isVariadic(this);
+  }
+
 }

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -154,6 +154,7 @@ ParameterDeclaration ::= ParamDefinitionListNoPin? '...'? Type | Type { stubClas
 private ParamDefinitionListNoPin ::= ParamDefinition &(!('.' | ')')) (',' ParamDefinition)* // todo
 ParamDefinition ::= identifier {
   stubClass="com.goide.stubs.GoParamDefinitionStub"
+  methods = [isVariadic]
 }
 
 InterfaceType ::= interface '{' MethodSpecs? '}' {


### PR DESCRIPTION
Hi @ignatov , just had time now, i end up by closing the other pull request accidentally, i rebase and i am sending the pull request again, but i am not sure about how to make the test for this.

The case is following.
```go
func Add(users ...*User){
      users[i].Name() // Name was unresolved, now we resolve "users" reference
      // and check if this is a parameter and if is Variadic, then if is true
      // we return the type of the parameter which in this case is *User
}
```