### PR TITLE
replaced /null/nil/ in the go livetemplate

### DIFF
--- a/resources/liveTemplates/go.xml
+++ b/resources/liveTemplates/go.xml
@@ -84,7 +84,7 @@
     </context>
   </template>
   <template description='If error' name='err' toReformat='true' toShortenFQNames='true'
-            value='if err != null {&#10;	$END$&#10;}'>
+            value='if err != nil {&#10;	$END$&#10;}'>
     <context>
       <option name='GO_BLOCK' value='true'/>
     </context>


### PR DESCRIPTION
-quick fix on replacing null with nil in the go.xml template

great work thanks for all the effort, the alpha branch is great.

Signed-off-by: Brent Salisbury <brent@socketplane.io>