### PR TITLE
Remove removed method use from debugger (fixes #1245)

### DIFF
--- a/src/com/goide/debugger/ideagdb/run/GdbRunner.java
+++ b/src/com/goide/debugger/ideagdb/run/GdbRunner.java
@@ -73,7 +73,6 @@ public class GdbRunner extends DefaultProgramRunner {
       @NotNull
       @Override
       public XDebugProcess start(@NotNull XDebugSession session) throws ExecutionException {
-        session.setAutoInitBreakpoints(false);
         final ExecutionResult result = state.execute(executor, GdbRunner.this);
         return new GdbDebugProcess(session, (GdbExecutionResult)result);
       }


### PR DESCRIPTION
Not sure if it's the best way but at the same time, the debugger is not there yet anyway.