### PR TITLE
Improve default path detection for go SDK

### DIFF
--- a/jps-plugin/tests/com/goide/jps/GoBuilderTest.java
+++ b/jps-plugin/tests/com/goide/jps/GoBuilderTest.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class GoBuilderTest extends JpsBuildTestCase {
-  public static final String GO_LINUX_SDK_PATH = "/usr/lib/go";
+  public static final String GO_LINUX_SDK_PATH = "/usr/local/go";
   public static final String GO_MAC_SDK_PATH = "/usr/local/go";
 
   public void testSimple() throws Exception {
@@ -29,7 +29,7 @@ public class GoBuilderTest extends JpsBuildTestCase {
     rebuildAll();
     assertCompiled(moduleName, "simple");
   }
-  
+
   public void testDependentFiles() throws Exception {
     if (!SystemInfo.isMac && !SystemInfo.isLinux) return;
 
@@ -49,13 +49,13 @@ public class GoBuilderTest extends JpsBuildTestCase {
     addModule(moduleName, PathUtilRt.getParentPath(depFile));
     BuildResult result = doBuild(CompileScopeTestBuilder.rebuild().all());
     result.assertFailed();
-    
+
     List<BuildMessage> errors = result.getMessages(BuildMessage.Kind.ERROR);
     assertEquals(2, errors.size());
-    
+
     assertEquals("newline in string", errors.get(0).getMessageText());
     assertEquals(BuildMessage.Kind.ERROR, errors.get(0).getKind());
-    
+
     assertEquals("syntax error: unexpected }, expecting )", errors.get(1).getMessageText());
     assertEquals(BuildMessage.Kind.ERROR, errors.get(1).getKind());
   }

--- a/src/com/goide/sdk/GoSdkType.java
+++ b/src/com/goide/sdk/GoSdkType.java
@@ -68,21 +68,19 @@ public class GoSdkType extends SdkType {
   @Override
   public String suggestHomePath() {
     if (SystemInfo.isWindows) {
-      return "C:\\cygwin\\bin";
+      String defaultPath = "C:\\Go";
+      if (new File(defaultPath).exists()) return defaultPath;
+      return "C:\\cygwin";
     }
-    else {
-      if (SystemInfo.isMac) {
-        String fromEnv = findPathInEnvironment();
-        if (fromEnv != null) return fromEnv;
-        String defaultPath = "/usr/local/go";
-        if (new File(defaultPath).exists()) return defaultPath;
-        String macPorts = "/opt/local/lib/go";
-        if (new File(macPorts).exists()) return macPorts;
-        return null;
-      }
-      else if (SystemInfo.isLinux) {
-        return "/usr/lib/go";
-      }
+    if (SystemInfo.isMac || SystemInfo.isLinux) {
+      String fromEnv = findPathInEnvironment();
+      if (fromEnv != null) return fromEnv;
+      String defaultPath = "/usr/local/go";
+      if (new File(defaultPath).exists()) return defaultPath;
+    }
+    if (SystemInfo.isMac) {
+      String macPorts = "/opt/local/lib/go";
+      if (new File(macPorts).exists()) return macPorts;
     }
     return null;
   }


### PR DESCRIPTION
This allows me to have the Browse for sdk folder dialog open directly in the SDK dir.

I've followed the instructions from here: [http://golang.org/doc/install#tarball](http://golang.org/doc/install#tarball)

Also, the tests now finally pass on my computer due to this.