### PR TITLE
Add Github error handling reporter

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -72,7 +72,7 @@
     <lang.elementManipulator forClass="com.goide.psi.GoImportString"
                              implementationClass="com.goide.psi.impl.manipulator.GoImportStringManipulator"/>
 
-    <errorHandler implementation="com.intellij.diagnostic.ITNReporter"/>
+    <errorHandler implementation="com.goide.diagnostics.error.ErrorReporter"/>
     <extendWordSelectionHandler implementation="com.goide.editor.GoWordSelectioner"/>
     <annotator language="go" implementationClass="com.goide.GoAnnotator"/>
     

--- a/src/com/goide/diagnostics/error/AnonymousFeedback.java
+++ b/src/com/goide/diagnostics/error/AnonymousFeedback.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.diagnostics.error;
+
+import com.google.gson.Gson;
+import com.intellij.ide.plugins.IdeaPluginDescriptorImpl;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.extensions.PluginId;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class AnonymousFeedback {
+
+  public AnonymousFeedback() {
+  }
+
+  public static String sendFeedback(
+    AnonymousFeedback.HttpConnectionFactory httpConnectionFactory,
+    LinkedHashMap<String, String> environmentDetails) throws IOException {
+
+    sendFeedback(httpConnectionFactory, convertToGithubIssueFormat(environmentDetails));
+
+    return Long.toString(System.currentTimeMillis());
+  }
+
+  private static byte[] convertToGithubIssueFormat(LinkedHashMap<String, String> environmentDetails) {
+    LinkedHashMap<String, String> result = new LinkedHashMap<String, String>(5);
+    result.put("title", "[auto-generated] Crash in plugin");
+    result.put("body", generateGithubIssueBody(environmentDetails));
+
+    return ((new Gson()).toJson(result)).getBytes(Charset.forName("UTF-8"));
+  }
+
+  private static String generateGithubIssueBody(LinkedHashMap<String, String> body) {
+    String errorDescription = body.get("error.description");
+    if (errorDescription == null) {
+      errorDescription = "";
+    }
+    body.remove("error.description");
+
+    String errorMessage = body.get("error.message");
+    if (errorMessage == null || errorMessage.isEmpty()) {
+      errorMessage = "invalid error";
+    }
+    body.remove("error.message");
+
+    String stackTrace = body.get("error.stacktrace");
+    if (stackTrace == null || stackTrace.isEmpty()) {
+      stackTrace = "invalid stacktrace";
+    }
+    body.remove("error.stacktrace");
+
+    String result = "";
+
+    if (!errorDescription.isEmpty()) {
+      result += errorDescription + "\n\n";
+    }
+
+    for (Map.Entry<String, String> entry : body.entrySet()) {
+      result += entry.getKey() + ": " + entry.getValue() + "\n";
+    }
+
+    result += "\n```\n" + stackTrace + "\n```\n";
+
+    result += "\n```\n" + errorMessage + "\n```";
+
+    return result;
+  }
+
+  private static void sendFeedback(AnonymousFeedback.HttpConnectionFactory httpConnectionFactory, byte[] payload) throws IOException {
+    String url = "https://github-intellij-plugin.appspot.com/go-lang-plugin-org/go-lang-idea-plugin/submitError";
+    String userAgent = "golang IntelliJ IDEA plugin";
+
+    IdeaPluginDescriptorImpl pluginDescriptor = (IdeaPluginDescriptorImpl)PluginManager.getPlugin(PluginId.getId("ro.redeul.google.go"));
+    if (pluginDescriptor != null) {
+      String name = pluginDescriptor.getName();
+      String version = pluginDescriptor.getVersion();
+      userAgent = name + " (" + version + ")";
+    }
+
+    HttpURLConnection httpURLConnection = connect(httpConnectionFactory, url);
+    httpURLConnection.setDoOutput(true);
+    httpURLConnection.setRequestMethod("POST");
+    httpURLConnection.setRequestProperty("User-Agent", userAgent);
+    httpURLConnection.setRequestProperty("Content-Type", "application/json");
+    OutputStream outputStream = httpURLConnection.getOutputStream();
+
+    try {
+      outputStream.write(payload);
+    }
+    finally {
+      outputStream.close();
+    }
+
+    int responseCode = httpURLConnection.getResponseCode();
+    if (responseCode != 201) {
+      throw new RuntimeException("Expected HTTP_CREATED (201), obtained " + responseCode);
+    }
+  }
+
+  private static HttpURLConnection connect(AnonymousFeedback.HttpConnectionFactory httpConnectionFactory, String url) throws IOException {
+    HttpURLConnection httpURLConnection = httpConnectionFactory.openHttpConnection(url);
+    httpURLConnection.setConnectTimeout(5000);
+    httpURLConnection.setReadTimeout(5000);
+    return httpURLConnection;
+  }
+
+  public static class HttpConnectionFactory {
+    public HttpConnectionFactory() {
+    }
+
+    protected HttpURLConnection openHttpConnection(String url) throws IOException {
+      return (HttpURLConnection)((new URL(url)).openConnection());
+    }
+  }
+}

--- a/src/com/goide/diagnostics/error/AnonymousFeedbackTask.java
+++ b/src/com/goide/diagnostics/error/AnonymousFeedbackTask.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.diagnostics.error;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.Consumer;
+import com.intellij.util.net.HttpConfigurable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.LinkedHashMap;
+
+import static com.goide.diagnostics.error.AnonymousFeedback.sendFeedback;
+
+public class AnonymousFeedbackTask extends Task.Backgroundable {
+  private final Consumer<String> myCallback;
+  private final Consumer<Exception> myErrorCallback;
+  private final LinkedHashMap<String, String> myParams;
+
+  public AnonymousFeedbackTask(@Nullable Project project,
+                               @NotNull String title,
+                               boolean canBeCancelled,
+                               LinkedHashMap<String, String> params,
+                               final Consumer<String> callback,
+                               final Consumer<Exception> errorCallback) {
+    super(project, title, canBeCancelled);
+
+    myParams = params;
+    myCallback = callback;
+    myErrorCallback = errorCallback;
+  }
+
+  @Override
+  public void run(@NotNull ProgressIndicator indicator) {
+    indicator.setIndeterminate(true);
+    try {
+      String token = sendFeedback(new ProxyHttpConnectionFactory(), myParams);
+      myCallback.consume(token);
+    }
+    catch (Exception e) {
+      myErrorCallback.consume(e);
+    }
+  }
+
+  private static class ProxyHttpConnectionFactory extends AnonymousFeedback.HttpConnectionFactory {
+    @Override
+    protected HttpURLConnection openHttpConnection(String url) throws IOException {
+      return HttpConfigurable.getInstance().openHttpConnection(url);
+    }
+  }
+}

--- a/src/com/goide/diagnostics/error/ErrorReporter.java
+++ b/src/com/goide/diagnostics/error/ErrorReporter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.diagnostics.error;
+
+
+import com.intellij.diagnostic.IdeErrorsDialog;
+import com.intellij.diagnostic.LogMessageEx;
+import com.intellij.diagnostic.ReportMessages;
+import com.intellij.errorreport.bean.ErrorBean;
+import com.intellij.ide.DataManager;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.idea.IdeaLogger;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ApplicationNamesInfo;
+import com.intellij.openapi.application.ex.ApplicationInfoEx;
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
+import com.intellij.openapi.diagnostic.SubmittedReportInfo;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.Consumer;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.util.LinkedHashMap;
+
+/**
+ * Sends crash reports to Github.
+ * Extensively inspired by the one used in the Android Studio.
+ * https://android.googlesource.com/platform/tools/adt/idea/+/master/android/src/com/android/tools/idea/diagnostics/error/ErrorReporter.java
+ * As per answer from here: http://devnet.jetbrains.com/message/5526206;jsessionid=F5422B4AF1AFD05AAF032636E5455E90#5526206
+ */
+public class ErrorReporter extends ErrorReportSubmitter {
+  @Override
+  public String getReportActionText() {
+    return "&Report on Github";
+  }
+
+  @Override
+  public boolean submit(@NotNull IdeaLoggingEvent[] events,
+                        String additionalInfo,
+                        @NotNull Component parentComponent,
+                        @NotNull Consumer<SubmittedReportInfo> consumer) {
+    ErrorBean errorBean = new ErrorBean(events[0].getThrowable(), IdeaLogger.ourLastActionId);
+    return doSubmit(events[0], parentComponent, consumer, errorBean, additionalInfo);
+  }
+
+  private static boolean doSubmit(final IdeaLoggingEvent event,
+                                  final Component parentComponent,
+                                  final Consumer<SubmittedReportInfo> callback,
+                                  final ErrorBean bean,
+                                  final String description) {
+    final DataContext dataContext = DataManager.getInstance().getDataContext(parentComponent);
+
+    bean.setDescription(description);
+    bean.setMessage(event.getMessage());
+
+    Throwable throwable = event.getThrowable();
+    if (throwable != null) {
+      final PluginId pluginId = IdeErrorsDialog.findPluginId(throwable);
+      if (pluginId != null) {
+        final IdeaPluginDescriptor ideaPluginDescriptor = PluginManager.getPlugin(pluginId);
+        if (ideaPluginDescriptor != null && !ideaPluginDescriptor.isBundled()) {
+          bean.setPluginName(ideaPluginDescriptor.getName());
+          bean.setPluginVersion(ideaPluginDescriptor.getVersion());
+        }
+      }
+    }
+
+    Object data = event.getData();
+
+    if (data instanceof LogMessageEx) {
+      bean.setAttachments(((LogMessageEx)data).getAttachments());
+    }
+
+    LinkedHashMap<String, String> reportValues = IdeaITNProxy
+      .getKeyValuePairs(bean,
+                        ApplicationManager.getApplication(),
+                        (ApplicationInfoEx)ApplicationInfo.getInstance(),
+                        ApplicationNamesInfo.getInstance());
+
+    final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
+    Consumer<String> successCallback = new Consumer<String>() {
+      @Override
+      public void consume(String token) {
+        final SubmittedReportInfo reportInfo = new SubmittedReportInfo(
+          null, "Issue " + token, SubmittedReportInfo.SubmissionStatus.NEW_ISSUE);
+        callback.consume(reportInfo);
+
+        ReportMessages.GROUP.createNotification(ReportMessages.ERROR_REPORT,
+                                                "Submitted",
+                                                NotificationType.INFORMATION,
+                                                null).setImportant(false).notify(project);
+      }
+    };
+
+    Consumer<Exception> errorCallback = new Consumer<Exception>() {
+      @Override
+      public void consume(Exception e) {
+        String message = String.format("Error Submitting Feedback: %s<br>\n" +
+                         "+  Consider creating an issue at \n" +
+                         "+  <a href=\"https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues\">Github Issue Tracker</a></html>",
+                                       e.getMessage());
+        ReportMessages.GROUP.createNotification(ReportMessages.ERROR_REPORT,
+                                                message,
+                                                NotificationType.ERROR,
+                                                NotificationListener.URL_OPENING_LISTENER).setImportant(false).notify(project);
+      }
+    };
+    AnonymousFeedbackTask task =
+      new AnonymousFeedbackTask(project, "Submitting error report", true, reportValues, successCallback, errorCallback);
+    if (project == null) {
+      task.run(new EmptyProgressIndicator());
+    }
+    else {
+      ProgressManager.getInstance().run(task);
+    }
+    return true;
+  }
+}

--- a/src/com/goide/diagnostics/error/IdeaITNProxy.java
+++ b/src/com/goide/diagnostics/error/IdeaITNProxy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.diagnostics.error;
+
+import com.intellij.errorreport.bean.ErrorBean;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationNamesInfo;
+import com.intellij.openapi.application.ex.ApplicationInfoEx;
+import com.intellij.openapi.diagnostic.Attachment;
+import com.intellij.util.SystemProperties;
+
+import java.util.LinkedHashMap;
+
+public class IdeaITNProxy {
+  public static LinkedHashMap<String, String> getKeyValuePairs(ErrorBean error,
+                                                               Application application,
+                                                               ApplicationInfoEx appInfo,
+                                                               ApplicationNamesInfo namesInfo) {
+    LinkedHashMap<String, String> params = new LinkedHashMap<String, String>(21);
+
+    params.put("error.description", error.getDescription());
+
+    params.put("Plugin Name", error.getPluginName());
+    params.put("Plugin Version", error.getPluginVersion());
+
+    params.put("OS Name", SystemProperties.getOsName());
+    params.put("Java version", SystemProperties.getJavaVersion());
+    params.put("Java vm vendor", SystemProperties.getJavaVmVendor());
+
+    params.put("App Name", namesInfo.getProductName());
+    params.put("App Full Name", namesInfo.getFullProductName());
+    params.put("App Version name", appInfo.getVersionName());
+    params.put("Is EAP", Boolean.toString(appInfo.isEAP()));
+    params.put("App Build", appInfo.getBuild().asString());
+    params.put("App Version", appInfo.getFullVersion());
+
+    params.put("Last Action", error.getLastAction());
+
+    //params.put("previous.exception", error.getPreviousException() == null ? null : Integer.toString(error.getPreviousException()));
+
+    params.put("error.message", error.getMessage());
+    params.put("error.stacktrace", error.getStackTrace());
+
+    for (Attachment attachment : error.getAttachments()) {
+      params.put("attachment.name", attachment.getName());
+      params.put("attachment.value", attachment.getEncodedBytes());
+    }
+
+    return params;
+  }
+}


### PR DESCRIPTION
I've ported the error handler we've had on 0.9.16 to 1.0. I've seen that previously it was using the internal one but in this case, I can't see the crashes for example. I'm still petitioning Github to add issue deduplication so this doesn't become a problem in case of too many crashes.