### PR TITLE
Fix compilation for not-JetBrains environments

### DIFF
--- a/src/com/goide/runconfig/before/GoBeforeRunTaskProvider.java
+++ b/src/com/goide/runconfig/before/GoBeforeRunTaskProvider.java
@@ -28,12 +28,12 @@ import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.concurrency.Semaphore;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.generate.tostring.util.StringUtil;
 
 import javax.swing.*;
 import java.util.ArrayList;


### PR DESCRIPTION
I can't compile the plugin on the latest branch without this change :)