### PR TITLE
Parameters help does not work for method calls made on struct fields

### DIFF
--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -860,7 +860,21 @@ public class GoPsiImplUtil {
   public static PsiReference getCallReference(@Nullable GoExpression first) {
     if (!(first instanceof GoCallExpr)) return null;
     GoExpression e = ((GoCallExpr)first).getExpression();
+    if (e instanceof GoSelectorExpr) {
+      return getCallReferenceFromSelectorExpr((GoSelectorExpr)e);
+    }
     GoReferenceExpression r = e instanceof GoReferenceExpression ? ((GoReferenceExpression)e) : PsiTreeUtil.getChildOfType(e, GoReferenceExpression.class);
     return (r != null ? r : e).getReference();
+  }
+
+  @Nullable
+  private static PsiReference getCallReferenceFromSelectorExpr(@NotNull GoSelectorExpr selectorExpr) {
+    if (selectorExpr.getChildren().length < 2) {
+      return null;
+    }
+    if (!(selectorExpr.getChildren()[1] instanceof GoReferenceExpression)) {
+      return null;
+    }
+    return ((GoReferenceExpression)selectorExpr.getChildren()[1]).getReference();
   }
 }

--- a/testData/parameterInfo/fieldMethCall.go
+++ b/testData/parameterInfo/fieldMethCall.go
@@ -1,0 +1,13 @@
+package main
+
+type Outer struct {
+    inner Inner
+}
+
+type Inner struct {}
+
+func (i* Inner) f(a, b int) {}
+
+func (o* Outer) Test() {
+    o.inner.f(<caret>)
+}

--- a/tests/com/goide/editor/GoParameterInfoHandlerTest.java
+++ b/tests/com/goide/editor/GoParameterInfoHandlerTest.java
@@ -46,7 +46,8 @@ public class GoParameterInfoHandlerTest extends GoCodeInsightFixtureTestCase {
   public void testMethParam()         { doTest(1, "<html>num int, <b>text string</b></html>"); } 
   public void testMethParamNone()     { doTest(0, ""); } 
   public void testMethParamEllipsis() { doTest(5, "<html>num int, text string, <b>more ...int</b></html>"); }
-  
+  public void testFieldMethCall()     { doTest(0, "<html><b>a int</b>, b int</html>"); }
+
   private void doTest(int expectedParamIdx, String expectedPresentation) {
     // Given
     myFixture.configureByFile(getTestName(true) + ".go");


### PR DESCRIPTION
Parameter help is not provided for calls that are made on struct fields, e.g. `a.b.f(1, "foo")`. This PR fixes this deficiency.