### PR TITLE
GAE Windows installations should search for 'goapp.bat' instead of 'goapp.exe'

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -12,6 +12,7 @@ This is a list of all the people we'd like to thank for helping us with active d
 - [@jakecoffman](https://github.com/jakecoffman)
 - [@kokizzu](https://github.com/kokizzu)
 - [@linniksa](https://github.com/linniksa)
+- [@nisckis](https://github.com/nisckis)
 - [@stuartcarnie](https://github.com/stuartcarnie)
 
 

--- a/src/com/goide/sdk/GoSdkService.java
+++ b/src/com/goide/sdk/GoSdkService.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.PathUtil;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -70,12 +71,11 @@ public abstract class GoSdkService extends SimpleModificationTracker {
   public static String getGoExecutablePath(@Nullable String sdkHomePath) {
     if (sdkHomePath != null) {
       if (isAppEngineSdkPath(sdkHomePath)) {
-        String executable = GoEnvironmentUtil.getBinaryFileNameForPath(GoConstants.GAE_EXECUTABLE_NAME);
-        sdkHomePath = StringUtil.trimEnd(sdkHomePath, GoConstants.APP_ENGINE_GO_ROOT_DIRECTORY_PATH);
+        sdkHomePath = StringUtil.trimEnd(PathUtil.toSystemIndependentName(sdkHomePath), GoConstants.APP_ENGINE_GO_ROOT_DIRECTORY_PATH);
         // gcloud and standalone installations
         return sdkHomePath.endsWith(GoConstants.GCLOUD_APP_ENGINE_DIRECTORY_PATH)
-               ? FileUtil.join(StringUtil.trimEnd(sdkHomePath, GoConstants.GCLOUD_APP_ENGINE_DIRECTORY_PATH), "bin", executable)
-               : FileUtil.join(sdkHomePath, SystemInfo.isWindows ? StringUtil.replace(executable, ".exe", ".bat") : executable);
+               ? FileUtil.join(StringUtil.trimEnd(sdkHomePath, GoConstants.GCLOUD_APP_ENGINE_DIRECTORY_PATH), "bin", SystemInfo.isWindows ? GoConstants.GAE_CMD_EXECUTABLE_NAME : GoConstants.GAE_EXECUTABLE_NAME)
+               : FileUtil.join(sdkHomePath, SystemInfo.isWindows ? GoConstants.GAE_BAT_EXECUTABLE_NAME : GoConstants.GAE_EXECUTABLE_NAME);
       }
       else {
         return FileUtil.join(sdkHomePath, "bin", GoEnvironmentUtil.getBinaryFileNameForPath(GoConstants.GO_EXECUTABLE_NAME));

--- a/src/com/goide/sdk/GoSdkService.java
+++ b/src/com/goide/sdk/GoSdkService.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SimpleModificationTracker;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
@@ -74,7 +75,7 @@ public abstract class GoSdkService extends SimpleModificationTracker {
         // gcloud and standalone installations
         return sdkHomePath.endsWith(GoConstants.GCLOUD_APP_ENGINE_DIRECTORY_PATH)
                ? FileUtil.join(StringUtil.trimEnd(sdkHomePath, GoConstants.GCLOUD_APP_ENGINE_DIRECTORY_PATH), "bin", executable)
-               : FileUtil.join(sdkHomePath, executable);
+               : FileUtil.join(sdkHomePath, SystemInfo.isWindows ? StringUtil.replace(executable, ".exe", ".bat") : executable);
       }
       else {
         return FileUtil.join(sdkHomePath, "bin", GoEnvironmentUtil.getBinaryFileNameForPath(GoConstants.GO_EXECUTABLE_NAME));

--- a/utils/src/com/goide/GoConstants.java
+++ b/utils/src/com/goide/GoConstants.java
@@ -28,7 +28,9 @@ public class GoConstants {
   @NonNls public static final String APP_ENGINE_GO_ROOT_DIRECTORY_PATH = "/goroot";
   @NonNls public static final String GCLOUD_APP_ENGINE_DIRECTORY_PATH = "/platform/google_appengine";
   @NonNls public static final String GAE_EXECUTABLE_NAME = "goapp";
-  
+  @NonNls public static final String GAE_BAT_EXECUTABLE_NAME = "goapp.bat";
+  @NonNls public static final String GAE_CMD_EXECUTABLE_NAME = "goapp.cmd";
+
   @NonNls public static final String GO_EXECUTABLE_NAME = "go";
 
   private GoConstants() {


### PR DESCRIPTION
GAE Windows installations should search for `goapp.bat` instead of `goapp.exe`

Related Issue is #1512
