### PR TITLE
Allow build configurations with packages (fixes #1520)

### DIFF
--- a/src/com/goide/runconfig/GoRunConfigurationBase.java
+++ b/src/com/goide/runconfig/GoRunConfigurationBase.java
@@ -209,4 +209,8 @@ public abstract class GoRunConfigurationBase<RunningState extends GoRunningState
   public void setWorkingDirectory(@NotNull String workingDirectory) {
     myWorkingDirectory = workingDirectory;
   }
+
+  public enum Kind {
+    DIRECTORY, PACKAGE, FILE
+  }
 }

--- a/src/com/goide/runconfig/application/GoApplicationRunningState.java
+++ b/src/com/goide/runconfig/application/GoApplicationRunningState.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 
+import static com.goide.runconfig.GoRunConfigurationBase.Kind;
+
 public class GoApplicationRunningState extends GoRunningState<GoApplicationConfiguration> {
   private String myTmpFilePath;
 
@@ -33,10 +35,20 @@ public class GoApplicationRunningState extends GoRunningState<GoApplicationConfi
                                    @NotNull GoApplicationConfiguration configuration) {
     super(env, module, configuration);
   }
-  
+
   @NotNull
   public String getMainFilePath() {
     return myConfiguration.getFilePath();
+  }
+
+  @NotNull
+  public String getPackage() {
+    return myConfiguration.getPackage();
+  }
+
+  @NotNull
+  public Kind getKind() {
+    return myConfiguration.getKind();
   }
 
   @NotNull

--- a/src/com/goide/runconfig/testing/GoTestRunConfiguration.java
+++ b/src/com/goide/runconfig/testing/GoTestRunConfiguration.java
@@ -43,7 +43,7 @@ public class GoTestRunConfiguration extends GoRunConfigurationBase<GoTestRunning
   private static final String DIRECTORY_ATTRIBUTE_NAME = "directory";
   private static final String PACKAGE_ATTRIBUTE_NAME = "package";
   private static final String KIND_ATTRIBUTE_NAME = "kind";
-  
+
   @NotNull private String myPackage = "";
   @NotNull private String myFilePath = "";
   @NotNull private String myDirectoryPath = "";
@@ -137,7 +137,7 @@ public class GoTestRunConfiguration extends GoRunConfigurationBase<GoTestRunning
     super.readExternal(element);
     try {
       String kindName = JDOMExternalizerUtil.getFirstChildValueAttribute(element, KIND_ATTRIBUTE_NAME);
-      myKind = kindName != null ? Kind.valueOf(kindName) : Kind.DIRECTORY; 
+      myKind = kindName != null ? Kind.valueOf(kindName) : Kind.DIRECTORY;
     }
     catch (IllegalArgumentException e) {
       myKind = Kind.DIRECTORY;
@@ -156,7 +156,7 @@ public class GoTestRunConfiguration extends GoRunConfigurationBase<GoTestRunning
   public void setPattern(@NotNull String pattern) {
     myPattern = pattern;
   }
-  
+
   @NotNull
   public Kind getKind() {
     return myKind;
@@ -191,9 +191,5 @@ public class GoTestRunConfiguration extends GoRunConfigurationBase<GoTestRunning
 
   public void setDirectoryPath(@NotNull String directoryPath) {
     myDirectoryPath = directoryPath;
-  }
-
-  public enum Kind {
-    DIRECTORY, PACKAGE, FILE
   }
 }

--- a/src/com/goide/runconfig/testing/GoTestRunConfigurationProducer.java
+++ b/src/com/goide/runconfig/testing/GoTestRunConfigurationProducer.java
@@ -52,7 +52,7 @@ public class GoTestRunConfigurationProducer extends RunConfigurationProducer<GoT
     if (module == null || !GoSdkService.getInstance(configuration.getProject()).isGoModule(module)) {
       return false;
     }
-    
+
     configuration.setModule(module);
     if (contextElement instanceof PsiDirectory) {
       configuration.setName("All in '" + ((PsiDirectory)contextElement).getName() + "'");
@@ -113,13 +113,13 @@ public class GoTestRunConfigurationProducer extends RunConfigurationProducer<GoT
         if (!GoTestFinder.isTestFile(file)) return false;
         if (!Comparing.equal(((GoFile)file).getImportPath(), configuration.getPackage())) return false;
         if (isPackageContext(contextElement) && configuration.getPattern().isEmpty()) return true;
-        
+
         String functionNameFromContext = findFunctionNameFromContext(contextElement);
-        return functionNameFromContext != null 
-               ? configuration.getPattern().equals("^" + functionNameFromContext + "$") 
+        return functionNameFromContext != null
+               ? configuration.getPattern().equals("^" + functionNameFromContext + "$")
                : configuration.getPattern().isEmpty();
       case FILE:
-        return GoTestFinder.isTestFile(file) && FileUtil.pathsEqual(configuration.getFilePath(), file.getVirtualFile().getPath()) &&
+        return file != null && FileUtil.pathsEqual(configuration.getFilePath(), file.getVirtualFile().getPath()) &&
           findFunctionNameFromContext(contextElement) == null;
     }
     return false;

--- a/src/com/goide/runconfig/testing/ui/GoTestRunConfigurationEditorForm.java
+++ b/src/com/goide/runconfig/testing/ui/GoTestRunConfigurationEditorForm.java
@@ -17,6 +17,7 @@
 package com.goide.runconfig.testing.ui;
 
 import com.goide.completion.GoImportPathsCompletionProvider;
+import com.goide.runconfig.GoRunConfigurationBase;
 import com.goide.runconfig.testing.GoTestRunConfiguration;
 import com.goide.runconfig.ui.GoCommonSettingsPanel;
 import com.goide.util.GoUtil;
@@ -98,7 +99,7 @@ public class GoTestRunConfigurationEditorForm extends SettingsEditor<GoTestRunCo
 
   @Override
   protected void applyEditorTo(@NotNull GoTestRunConfiguration configuration) throws ConfigurationException {
-    configuration.setKind((GoTestRunConfiguration.Kind)myTestKindComboBox.getSelectedItem());
+    configuration.setKind((GoRunConfigurationBase.Kind)myTestKindComboBox.getSelectedItem());
     configuration.setPackage(myPackageField.getText());
     configuration.setDirectoryPath(myDirectoryField.getText());
     configuration.setFilePath(myFileField.getText());

--- a/src/com/goide/runconfig/ui/GoRunConfigurationEditorForm.form
+++ b/src/com/goide/runconfig/ui/GoRunConfigurationEditorForm.form
@@ -3,12 +3,12 @@
   <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="657" height="194"/>
+      <xy x="20" y="20" width="657" height="277"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="487df" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="487df" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -16,21 +16,68 @@
         <properties/>
         <border type="none"/>
         <children>
-          <component id="be44b" class="javax.swing.JLabel">
+          <component id="4edfe" class="javax.swing.JComboBox" binding="myRunKindComboBox">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                <preferred-size width="57" height="15"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="123" height="26"/>
               </grid>
             </constraints>
             <properties>
-              <text value="&amp;File:"/>
+              <model>
+                <item value="Package"/>
+                <item value="File"/>
+              </model>
             </properties>
           </component>
-          <component id="ffb40" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myFilePathField">
+          <component id="491ca" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
-            <properties/>
+            <properties>
+              <labelFor value="4edfe"/>
+              <text value="&amp;Run kind"/>
+            </properties>
+          </component>
+          <hspacer id="50e45">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="9d007" class="javax.swing.JLabel" binding="myPackageLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <labelFor value="57642"/>
+              <text value="&amp;Package"/>
+            </properties>
+          </component>
+          <component id="57642" class="com.intellij.ui.EditorTextField" binding="myPackageField" custom-create="true">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <visible value="true"/>
+            </properties>
+          </component>
+          <component id="ffb40" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myFileField">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <visible value="true"/>
+            </properties>
+          </component>
+          <component id="f9f16" class="javax.swing.JLabel" binding="myFileLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <labelFor value="ffb40"/>
+              <text value="&amp;File"/>
+            </properties>
           </component>
         </children>
       </grid>
@@ -46,4 +93,10 @@
       </nested-form>
     </children>
   </grid>
+  <buttonGroups>
+    <group name="myRunnerType">
+      <member id="eaa7a"/>
+      <member id="eb72c"/>
+    </group>
+  </buttonGroups>
 </form>

--- a/src/com/goide/runconfig/ui/GoRunConfigurationEditorForm.java
+++ b/src/com/goide/runconfig/ui/GoRunConfigurationEditorForm.java
@@ -18,55 +18,134 @@ package com.goide.runconfig.ui;
 
 import com.goide.GoConstants;
 import com.goide.GoFileType;
+import com.goide.completion.GoImportPathsCompletionProvider;
 import com.goide.psi.GoFile;
+import com.goide.runconfig.GoRunConfigurationBase;
 import com.goide.runconfig.GoRunConfigurationWithMain;
 import com.goide.util.GoUtil;
+import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
+import com.intellij.ui.EditorTextField;
+import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.util.TextFieldCompletionProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class GoRunConfigurationEditorForm extends SettingsEditor<GoRunConfigurationWithMain<?>> {
+  @NotNull private final Project myProject;
   private JPanel myComponent;
-  private TextFieldWithBrowseButton myFilePathField;
+  private TextFieldWithBrowseButton myFileField;
   private GoCommonSettingsPanel myCommonSettingsPanel;
+  private EditorTextField myPackageField;
+  private JComboBox myRunKindComboBox;
+  private JLabel myPackageLabel;
+  private JLabel myFileLabel;
 
 
   public GoRunConfigurationEditorForm(@NotNull final Project project) {
     super(null);
+    myProject = project;
     myCommonSettingsPanel.init(project);
-    GoUtil.installFileChooser(project, myFilePathField, false, new Condition<VirtualFile>() {
+
+    installRunKindComboBox();
+    installFileChoosers();
+  }
+
+  private void onRunKindChanged() {
+    GoRunConfigurationBase.Kind selectedKind = (GoRunConfigurationBase.Kind) myRunKindComboBox.getSelectedItem();
+    if (selectedKind == null) {
+      selectedKind = GoRunConfigurationBase.Kind.PACKAGE;
+    }
+    boolean thePackage = selectedKind == GoRunConfigurationBase.Kind.PACKAGE;
+    boolean file = selectedKind == GoRunConfigurationBase.Kind.FILE;
+
+    myPackageField.setVisible(thePackage);
+    myPackageLabel.setVisible(thePackage);
+    myFileField.setVisible(file);
+    myFileLabel.setVisible(file);
+  }
+
+  @Override
+  protected void resetEditorFrom(@NotNull GoRunConfigurationWithMain<?> configuration) {
+    myFileField.setText(configuration.getFilePath());
+    myPackageField.setText(configuration.getPackage());
+    myRunKindComboBox.setSelectedItem(configuration.getKind());
+    myCommonSettingsPanel.resetEditorFrom(configuration);
+  }
+
+  @Override
+  protected void applyEditorTo(@NotNull GoRunConfigurationWithMain<?> configuration) throws ConfigurationException {
+    configuration.setFilePath(myFileField.getText());
+    configuration.setPackage(myPackageField.getText());
+    configuration.setKind((GoRunConfigurationBase.Kind)myRunKindComboBox.getSelectedItem());
+    myCommonSettingsPanel.applyEditorTo(configuration);
+  }
+
+  private void createUIComponents() {
+    myPackageField = new TextFieldCompletionProvider() {
+      @Override
+      protected void addCompletionVariants(@NotNull String text,
+                                           int offset,
+                                           @NotNull String prefix,
+                                           @NotNull final CompletionResultSet result) {
+        GoImportPathsCompletionProvider.addCompletions(result, myCommonSettingsPanel.getSelectedModule() ,null);
+      }
+    }.createEditor(myProject);
+  }
+
+  @Nullable
+  private static ListCellRendererWrapper<GoRunConfigurationBase.Kind> getRunKindListCellRendererWrapper() {
+    return new ListCellRendererWrapper<GoRunConfigurationBase.Kind>() {
+      @Override
+      public void customize(JList list, @Nullable GoRunConfigurationBase.Kind kind, int index, boolean selected, boolean hasFocus) {
+        if (kind != null) {
+          String kindName = StringUtil.capitalize(kind.toString().toLowerCase());
+          setText(kindName);
+        }
+      }
+    };
+  }
+
+  private void installRunKindComboBox() {
+    myRunKindComboBox.removeAllItems();
+    myRunKindComboBox.setRenderer(getRunKindListCellRendererWrapper());
+    // TODO this should be present only for "go build" configurations not for "go run" configurations
+    myRunKindComboBox.addItem(GoRunConfigurationBase.Kind.PACKAGE);
+    myRunKindComboBox.addItem(GoRunConfigurationBase.Kind.FILE);
+    myRunKindComboBox.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        onRunKindChanged();
+      }
+    });
+  }
+
+  private void installFileChoosers() {
+    GoUtil.installFileChooser(myProject, myFileField, false, new Condition<VirtualFile>() {
       @Override
       public boolean value(VirtualFile file) {
         if (file.getFileType() != GoFileType.INSTANCE) {
           return false;
         }
-        final PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
+        final PsiFile psiFile = PsiManager.getInstance(myProject).findFile(file);
         if (psiFile != null && psiFile instanceof GoFile) {
           return GoConstants.MAIN.equals(((GoFile)psiFile).getPackageName()) && ((GoFile)psiFile).findMainFunction() != null;
         }
         return false;
       }
     });
-  }
-
-  @Override
-  protected void resetEditorFrom(@NotNull GoRunConfigurationWithMain<?> configuration) {
-    myFilePathField.setText(configuration.getFilePath());
-    myCommonSettingsPanel.resetEditorFrom(configuration);
-  }
-
-  @Override
-  protected void applyEditorTo(@NotNull GoRunConfigurationWithMain<?> configuration) throws ConfigurationException {
-    configuration.setFilePath(myFilePathField.getText());
-    myCommonSettingsPanel.applyEditorTo(configuration);
   }
 
   @NotNull


### PR DESCRIPTION
The only thing that remains to be done, aside from cleaning the interface a bit, is to show the "Package" option only when the dialog is shown for the "go build configuration".