### PR TITLE
Initial go get manager

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -26,7 +26,7 @@
     <p>Alpha pre-release of the 1.0.0 version.</p>
     <p>Doesn't contain all the functionality of the 0.9.x branch but has a completely reworked internals.
       It's faster than 0.9.x, refactoring works to some degree and has native support for gopath packages.</p>
-    
+
     <h3>Compatibility</h3>
     <p>Plugin can be installed on IntelliJ platform 141.2 or greater. It corresponds to IntelliJ IDEA 14.1, WebStorm 10, PhpStorm 9</p>
     ]]></description>
@@ -41,13 +41,13 @@
 
   <idea-version since-build="141.2" until-build="141.9999"/>
   <depends>com.intellij.modules.lang</depends>
-  
+
   <depends optional="true" config-file="java-deps.xml">com.intellij.modules.java</depends>
   <depends optional="true" config-file="coverage.xml">Coverage</depends>
   <depends optional="true" config-file="coverage.xml">com.intellij.modules.coverage</depends>
   <!-- todo[IDEA 15] replace with real dependency -->
   <depends optional="true" config-file="app-engine.xml">com.intellij.modules.lang</depends>
-  
+
   <module-components>
     <component>
       <implementation-class>com.goide.project.GoModuleLibrariesInitializer</implementation-class>
@@ -69,9 +69,9 @@
     <applicationService serviceImplementation="com.goide.project.GoApplicationLibrariesService"/>
     <projectService serviceImplementation="com.goide.project.GoProjectLibrariesService"/>
     <moduleService serviceImplementation="com.goide.project.GoModuleLibrariesService"/>
-    <projectConfigurable groupId="language" provider="com.goide.configuration.GoConfigurableProvider" dynamic="true" 
+    <projectConfigurable groupId="language" provider="com.goide.configuration.GoConfigurableProvider" dynamic="true"
                          bundle="do.not.touch.this.attribute" />
-    
+
     <defaultLiveTemplatesProvider implementation="com.goide.template.GoLiveTemplatesProvider"/>
     <liveTemplateContext implementation="com.goide.template.GoEverywhereContextType"/>
     <liveTemplateContext implementation="com.goide.template.GoLiveTemplateContextType$GoFileContextType"/>
@@ -84,11 +84,11 @@
     <errorHandler implementation="com.intellij.diagnostic.ITNReporter"/>
     <extendWordSelectionHandler implementation="com.goide.editor.GoWordSelectioner"/>
     <annotator language="go" implementationClass="com.goide.GoAnnotator"/>
-    
+
     <lang.importOptimizer language="go" implementationClass="com.goide.codeInsight.imports.GoImportOptimizer"/>
     <psi.fileReferenceHelper implementation="com.goide.psi.impl.imports.GoImportReferenceHelper"/>
     <fileContextProvider implementation="com.goide.psi.impl.imports.GoFileContextProvider"/>
-    
+
     <lang.parserDefinition language="go" implementationClass="com.goide.GoParserDefinition"/>
     <fileTypeFactory implementation="com.goide.GoFileTypeFactory"/>
     <lang.syntaxHighlighterFactory key="go" implementationClass="com.goide.highlighting.GoSyntaxHighlighterFactory"/>
@@ -98,13 +98,13 @@
     <quoteHandler fileType="Go" className="com.goide.editor.GoQuoteHandler"/>
     <lang.commenter language="go" implementationClass="com.goide.GoCommenter"/>
     <lang.elementManipulator forClass="com.goide.psi.impl.GoStringLiteralImpl" implementationClass="com.goide.psi.impl.manipulator.GoStringManipulator"/>
-    
+
     <completion.contributor language="go" implementationClass="com.goide.completion.GoCompletionContributor"/>
     <completion.contributor language="go" implementationClass="com.goide.completion.GoKeywordCompletionContributor"/>
     <completion.contributor language="go" order="last" implementationClass="com.goide.completion.GoAutoImportCompletionContributor"/>
     <completion.confidence language="go" order="last" implementationClass="com.goide.completion.GoCompletionConfidence"/>
     <lookup.charFilter implementation="com.goide.completion.GoCharFilter"/>
-    
+
     <lang.refactoringSupport language="go" implementationClass="com.goide.refactor.GoRefactoringSupportProvider"/>
     <spellchecker.support language="go" implementationClass="com.goide.inspections.GoSpellcheckingStrategy"/>
     <elementDescriptionProvider implementation="com.goide.refactor.GoDescriptionProvider"/>
@@ -122,7 +122,7 @@
     <lang.formatter language="go" implementationClass="com.goide.formatter.GoFormattingModelBuilder"/>
     <codeStyleSettingsProvider implementation="com.goide.formatter.settings.GoCodeStyleSettingsProvider"/>
     <langCodeStyleSettingsProvider implementation="com.goide.formatter.settings.GoLanguageCodeStyleSettingsProvider"/>
-    
+
     <renamePsiElementProcessor implementation="com.goide.refactor.GoAnonymousFieldProcessor"/>
 
     <gotoSymbolContributor implementation="com.goide.go.GoSymbolContributor"/>
@@ -161,9 +161,9 @@
     <programRunner implementation="com.goide.debugger.ideagdb.run.GdbRunner"/>
 
     <checkinHandlerFactory implementation="com.goide.actions.fmt.GoFmtCheckinFactory" order="last"/>
-    
+
     <lang.inspectionSuppressor language="go" implementationClass="com.goide.inspections.suppression.GoInspectionSuppressor"/>
-    
+
     <localInspection language="go" displayName="Unresolved reference inspection"
                      groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.unresolved.GoUnresolvedReferenceInspection"/>
@@ -171,16 +171,16 @@
                      groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoUnusedImportDeclaration"/>
     <localInspection language="go" displayName="Duplicate fields and methods inspection"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoDuplicateFieldsOrMethodsInspection"/>
     <localInspection language="go" displayName="Unused variables inspection"
-                     groupName="Go" enabledByDefault="true" level="ERROR"  
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.unresolved.GoUnusedVariableInspection"/>
     <localInspection language="go" displayName="Unused global variables inspection"
-                     groupName="Go" enabledByDefault="true" level="WARNING" 
+                     groupName="Go" enabledByDefault="true" level="WARNING"
                      implementationClass="com.goide.inspections.unresolved.GoUnusedGlobalVariableInspection"/>
     <localInspection language="go" displayName="Unused function inspection"
-                     groupName="Go" enabledByDefault="true" level="WARNING" 
+                     groupName="Go" enabledByDefault="true" level="WARNING"
                      implementationClass="com.goide.inspections.unresolved.GoUnusedFunctionInspection"/>
     <localInspection language="go" displayName="Assignment to constant"
                      groupName="Go" enabledByDefault="true" level="ERROR"
@@ -189,25 +189,25 @@
                      groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoDuplicateFunctionInspection"/>
     <localInspection language="go" displayName="Duplicate argument"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoDuplicateArgumentInspection"/>
     <localInspection language="go" displayName="Duplicate return argument"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoDuplicateReturnArgumentInspection"/>
     <localInspection language="go" displayName="Incorrect variadic parameter"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoFunctionVariadicParameterInspection"/>
     <localInspection language="go" displayName="Incorrect variable declaration"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoVarDeclarationInspection"/>
     <localInspection language="go" displayName="No new variables on left side of :="
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoNoNewVariablesInspection"/>
     <localInspection language="go" displayName="Missing return at end of function"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoReturnInspection"/>
     <localInspection language="go" displayName="Function call inspection"
-                     groupName="Go" enabledByDefault="true" level="ERROR" 
+                     groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoFunctionCallInspection"/>
     <localInspection language="go" displayName="Defer/go statements check"
                      groupName="Go" enabledByDefault="true" level="ERROR"
@@ -218,7 +218,7 @@
             text="Go File" description="Create new Go file">
       <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
     </action>
-    
+
     <action id="GoShowTypeInternalAction"
             class="com.goide.actions.internal.GoShowTypeInternalAction"
             text="Show Go type info">
@@ -248,6 +248,19 @@
             description="Optimizes imports for selected file with goimports util">
       <add-to-group group-id="CodeMenu" anchor="last"/>
     </action>
+
+    <group id="Go.Tools" popup="true" text="Go Tools"
+           description="Go tools" icon="/icons/go.png" class="com.goide.actions.NewGoGroup">
+
+      <action id="Go.Package.Manager"
+              class="com.goide.ui.pm.ManagerAction"
+              text="go get manager" description="go get manager">
+        <keyboard-shortcut first-keystroke="alt shift p" keymap="$default"/>
+      </action>
+
+      <add-to-group group-id="ToolsMenu" anchor="last"/>
+    </group>
+
   </actions>
 
   <application-components>
@@ -255,10 +268,10 @@
       <implementation-class>com.goide.ui.ProjectTutorialNotification</implementation-class>
     </component>
   </application-components>
-  
-  
+
+
   <!-- GAE -->
-  
+
   <!-- START plugin.xml of future GAE module -->
   <!-- todo[IDEA 15] It's supposed that GAE-core module will be moved to IDEA source and bundled in IDEA 15 -->
   <!--<id>com.intellij.appengine</id>-->

--- a/src/com/goide/actions/NewGoGroup.java
+++ b/src/com/goide/actions/NewGoGroup.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.actions;
+
+import com.goide.sdk.GoSdkType;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
+
+public class NewGoGroup extends DefaultActionGroup {
+  @Override
+  public void update(AnActionEvent e)
+  {
+    super.update(e);
+
+    if (e.getProject() == null) {
+      return;
+    }
+
+    Sdk sdk = ProjectRootManager.getInstance(e.getProject()).getProjectSdk();
+
+    final Module data = LangDataKeys.MODULE.getData(e.getDataContext());
+    e.getPresentation().setVisible(data != null &&
+                                   sdk != null &&
+                                   sdk.getSdkType() instanceof GoSdkType);
+  }
+}

--- a/src/com/goide/ui/pm/Manager.form
+++ b/src/com/goide/ui/pm/Manager.form
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.goide.ui.pm.Manager">
+  <grid id="27dc6" binding="myPanel1" default-binding="true" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="800" height="500"/>
+    </constraints>
+    <properties>
+      <inheritsPopupMenu value="false"/>
+      <minimumSize width="800" height="480"/>
+      <preferredSize width="650" height="480"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <splitpane id="2f646">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <minimum-size width="800" height="400"/>
+            <preferred-size width="800" height="400"/>
+          </grid>
+        </constraints>
+        <properties>
+          <dividerLocation value="350"/>
+        </properties>
+        <border type="none"/>
+        <children>
+          <grid id="dc7a5" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="5" left="5" bottom="5" right="5"/>
+            <constraints>
+              <splitpane position="left"/>
+            </constraints>
+            <properties>
+              <minimumSize width="350" height="83"/>
+              <preferredSize width="350" height="83"/>
+            </properties>
+            <border type="none"/>
+            <children>
+              <component id="9ebfc" class="javax.swing.JTextField" binding="mySearchText">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
+              </component>
+              <vspacer id="3333d">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                    <minimum-size width="-1" height="2"/>
+                    <preferred-size width="-1" height="2"/>
+                    <maximum-size width="-1" height="2"/>
+                  </grid>
+                </constraints>
+              </vspacer>
+              <scrollpane id="9a702">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="9fb70" class="javax.swing.JList" binding="myPackagesList">
+                    <constraints/>
+                    <properties>
+                      <visibleRowCount value="20"/>
+                    </properties>
+                  </component>
+                </children>
+              </scrollpane>
+            </children>
+          </grid>
+          <grid id="9b216" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="5" left="5" bottom="5" right="5"/>
+            <constraints>
+              <splitpane position="right"/>
+            </constraints>
+            <properties>
+              <minimumSize width="350" height="-1"/>
+              <name value=""/>
+              <preferredSize width="450" height="-1"/>
+            </properties>
+            <border type="none"/>
+            <children>
+              <component id="7eecb" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Package name:"/>
+                </properties>
+              </component>
+              <component id="578ba" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Package author:"/>
+                </properties>
+              </component>
+              <component id="80f0b" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Package URL:"/>
+                </properties>
+              </component>
+              <component id="7573a" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Description:"/>
+                </properties>
+              </component>
+              <component id="4a1b8" class="javax.swing.JButton" binding="myGoGetButton" default-binding="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false">
+                    <minimum-size width="-1" height="26"/>
+                    <preferred-size width="120" height="26"/>
+                    <maximum-size width="-1" height="26"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <enabled value="false"/>
+                  <icon value="actions/download.png"/>
+                  <selected value="false"/>
+                  <text value="go &amp;get"/>
+                </properties>
+              </component>
+              <component id="92bef" class="javax.swing.JLabel" binding="myPackageName">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="165" height="15"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
+              </component>
+              <component id="952f3" class="javax.swing.JLabel" binding="myPackageAuthor">
+                <constraints>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="165" height="15"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
+              </component>
+              <component id="6219d" class="javax.swing.JLabel" binding="myPackageURL">
+                <constraints>
+                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="165" height="15"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
+              </component>
+              <component id="2977b" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Documentation:"/>
+                </properties>
+              </component>
+              <component id="818f" class="javax.swing.JLabel" binding="myDocumentationURL">
+                <constraints>
+                  <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
+              </component>
+              <scrollpane id="84305">
+                <constraints>
+                  <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="a4e67" class="javax.swing.JTextArea" binding="myPackageDescription">
+                    <constraints/>
+                    <properties>
+                      <editable value="false"/>
+                      <enabled value="true"/>
+                    </properties>
+                  </component>
+                </children>
+              </scrollpane>
+            </children>
+          </grid>
+        </children>
+      </splitpane>
+      <grid id="93634" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="e4b26" class="javax.swing.JButton" binding="myCloseButton">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="&amp;Close"/>
+            </properties>
+          </component>
+          <component id="8bf8e" class="javax.swing.JLabel" binding="poweredBy">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="&lt;html&gt;Powered by &lt;a href=&quot;http://go-search.org&quot;&gt;go-search.org&lt;/a&gt;&lt;/html&gt;"/>
+            </properties>
+          </component>
+          <hspacer id="e664c">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/com/goide/ui/pm/Manager.java
+++ b/src/com/goide/ui/pm/Manager.java
@@ -262,16 +262,16 @@ public class Manager {
 
     DefaultListModel model = new DefaultListModel();
     List<GoPackage> goPackages = myPackages.getHits();
-    if (goPackages.size() == 0) {
+    if (goPackages.isEmpty()) {
       model.addElement("No packages found");
     }
     else {
       for (GoPackage goPackage : goPackages) {
         String description = goPackage.name;
-        if (goPackage.synopsis != "") {
+        if (!goPackage.synopsis.isEmpty()) {
           description += " (" + goPackage.synopsis + ")";
         }
-        else if (goPackage.description != "") {
+        else if (!goPackage.description.isEmpty()) {
           description += " (";
           if (goPackage.description.length() > 30) {
             description += goPackage.description.substring(0, 30);

--- a/src/com/goide/ui/pm/Manager.java
+++ b/src/com/goide/ui/pm/Manager.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.ui.pm;
+
+import com.goide.sdk.GoSdkService;
+import com.goide.util.GoExecutor;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.PerformInBackgroundOption;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.WindowWrapper;
+import com.intellij.openapi.util.text.StringUtil;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import java.awt.*;
+import java.awt.event.*;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+public class Manager {
+  private JPanel myPanel1;
+  private JTextField mySearchText;
+  private JButton myGoGetButton;
+  private JLabel myPackageName;
+  private JTextArea myPackageDescription;
+  private JLabel myPackageAuthor;
+  private JLabel myPackageURL;
+  private JList myPackagesList;
+  private JLabel myDocumentationURL;
+  private JButton myCloseButton;
+  private JLabel poweredBy;
+  private String mySearchedPackage = "";
+
+  private static WindowWrapper myWindow;
+  private static Manager myInstance;
+  private static Project myProject;
+  private static Module myModule;
+
+  private final CloseableHttpClient myHttpClient;
+  private HttpResponse myHttpResponse;
+  private HttpGet myHttpRequest;
+  private String myUserAgent = "go plugin for IntelliJ Platform (contact us at https://github.com/go-lang-plugin-org/go-lang-idea-plugin)";
+  @NotNull private String mySearchUrl = "http://go-search.org/api?action=search&q=%s";
+  private Response myPackages;
+  private Task.Backgroundable mySearchTask;
+
+  private Manager() {
+    myHttpClient = HttpClientBuilder.create().build();
+
+    mySearchText.addKeyListener(new KeyAdapter() {
+      @Override
+      public void keyReleased(KeyEvent e) {
+        super.keyReleased(e);
+        if (mySearchText.getText() != mySearchedPackage) {
+          if (myHttpRequest != null) {
+            myHttpRequest.abort();
+          }
+          mySearchedPackage = mySearchText.getText();
+          if (mySearchedPackage.length() >= 3) {
+            mySearchTask = new Task.Backgroundable(myProject, "searching for packages", true, PerformInBackgroundOption.ALWAYS_BACKGROUND) {
+              @Override
+              public void run(@NotNull ProgressIndicator indicator) {
+                searchPackage();
+              }
+            };
+
+            ProgressManager.getInstance().run(mySearchTask);
+          }
+        }
+      }
+    });
+    myCloseButton.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        if (myWindow != null) {
+          myWindow.close();
+        }
+      }
+    });
+    myPackagesList.addListSelectionListener(new ListSelectionListener() {
+      @Override
+      public void valueChanged(ListSelectionEvent e) {
+        populateGoPackageDetails(myPackagesList.getSelectedIndex());
+      }
+    });
+    myPackageURL.addMouseListener(new MouseListener() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (Desktop.isDesktopSupported()) {
+          String url = myPackages.getHits().get(myPackagesList.getSelectedIndex()).getProjectUrl();
+          try {
+            Desktop.getDesktop().browse(URI.create(url));
+          }
+          catch (IOException ignored) {
+
+          }
+        }
+      }
+
+      @Override
+      public void mousePressed(MouseEvent e) {
+
+      }
+
+      @Override
+      public void mouseReleased(MouseEvent e) {
+
+      }
+
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        myPackageURL.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        myPackageURL.setCursor(Cursor.getDefaultCursor());
+      }
+    });
+    myDocumentationURL.addMouseListener(new MouseListener() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (Desktop.isDesktopSupported()) {
+          String url = myPackages.getHits().get(myPackagesList.getSelectedIndex()).getPackage();
+          try {
+            Desktop.getDesktop().browse(URI.create("https://godoc.org/" + url));
+          }
+          catch (IOException ignored) {
+
+          }
+        }
+      }
+
+      @Override
+      public void mousePressed(MouseEvent e) {
+
+      }
+
+      @Override
+      public void mouseReleased(MouseEvent e) {
+
+      }
+
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        myDocumentationURL.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        myDocumentationURL.setCursor(Cursor.getDefaultCursor());
+      }
+    });
+    poweredBy.addMouseListener(new MouseListener() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (Desktop.isDesktopSupported()) {
+          try {
+            Desktop.getDesktop().browse(URI.create("http://go-search.org"));
+          }
+          catch (IOException ignored) {
+
+          }
+        }
+      }
+
+      @Override
+      public void mousePressed(MouseEvent e) {
+
+      }
+
+      @Override
+      public void mouseReleased(MouseEvent e) {
+
+      }
+
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        poweredBy.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        poweredBy.setCursor(Cursor.getDefaultCursor());
+      }
+    });
+    myGoGetButton.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        goGet();
+      }
+    });
+  }
+
+  private void searchPackage() {
+    if (myHttpRequest != null) {
+      myHttpRequest.abort();
+    }
+    if (mySearchedPackage == "") {
+      myPackagesList.removeAll();
+      populateGoPackageDetails(-1);
+      return;
+    }
+    mySearchTask.setTitle(String.format("Searching for Go Package: \"%s\"", mySearchedPackage));
+    myHttpRequest = new HttpGet(String.format(mySearchUrl, mySearchedPackage));
+    try {
+      myHttpRequest.addHeader("Content-Type", "application/json");
+      myHttpRequest.addHeader("User-Agent", myUserAgent);
+      myHttpResponse = myHttpClient.execute(myHttpRequest);
+
+      ApplicationManager.getApplication().invokeLater(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            handlerAnswer();
+          }
+          catch (IOException ignored) {
+          }
+        }
+      });
+    }
+    catch (IOException ignored) {
+    }
+  }
+
+  private void handlerAnswer() throws IOException {
+    String json = EntityUtils.toString(myHttpResponse.getEntity(), "UTF-8");
+
+    Gson gson = new Gson();
+    myPackages = gson.fromJson(json, Response.class);
+
+    myPackagesList.removeAll();
+
+    DefaultListModel model = new DefaultListModel();
+    List<GoPackage> goPackages = myPackages.getHits();
+    if (goPackages.size() == 0) {
+      model.addElement("No packages found");
+    }
+    else {
+      for (GoPackage goPackage : goPackages) {
+        String description = goPackage.name;
+        if (goPackage.synopsis != "") {
+          description += " (" + goPackage.synopsis + ")";
+        }
+        else if (goPackage.description != "") {
+          description += " (";
+          if (goPackage.description.length() > 30) {
+            description += goPackage.description.substring(0, 30);
+            description += "...";
+          }
+          description += ")";
+        }
+        model.addElement(description);
+      }
+    }
+
+    myPackagesList.setModel(model);
+  }
+
+  private void populateGoPackageDetails(int goPackageId) {
+    if (goPackageId == -1) {
+      myPackageName.setText("");
+      myPackageAuthor.setText("");
+      myPackageURL.setText("");
+      myDocumentationURL.setText("");
+      myPackageDescription.setText("");
+      myGoGetButton.setEnabled(false);
+      return;
+    }
+
+    GoPackage goPackage = myPackages.getHits().get(goPackageId);
+    myPackageName.setText(goPackage.getName());
+    myPackageAuthor.setText(goPackage.getAuthor());
+
+    myPackageURL.setText(String.format(
+      "<html><a href=\"%s\">%s</a></html>",
+      goPackage.getProjectUrl(),
+      goPackage.getProjectUrl()));
+
+    myDocumentationURL.setText(String.format(
+      "<html><a href=\"https://godoc.org/%s\">https://godoc.org/%s</a></html>",
+      goPackage.getPackage(),
+      goPackage.getPackage()));
+
+    myPackageDescription.setText(goPackage.getDescription());
+    myPackageDescription.setCaretPosition(0);
+    myGoGetButton.setEnabled(true);
+
+    // TODO check if package is already installed and display / run go get -u instead if so
+  }
+
+  private void goGet() {
+    final String sdkPath = GoSdkService.getInstance(myProject).getSdkHomePath(myModule);
+    if (StringUtil.isEmpty(sdkPath)) {
+      return;
+    }
+
+    final String packageName = myPackages.getHits().get(myPackagesList.getSelectedIndex()).packageName;
+
+    CommandProcessor.getInstance().runUndoTransparentAction(new Runnable() {
+      @Override
+      public void run() {
+        GoExecutor.in(myModule).withPresentableName("go get " + packageName)
+          .withParameters("get", packageName).showNotifications(false).showOutputOnError().executeWithProgress(true);
+      }
+    });
+  }
+
+  public static class GoPackage {
+    private String name;
+    @SerializedName("package")
+    private String packageName;
+    private String author;
+    private String synopsis;
+    private String description;
+    @SerializedName("projecturl")
+    private String projectUrl;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getPackage() {
+      return packageName;
+    }
+
+    public void setPackage(String packageName) {
+      this.packageName = packageName;
+    }
+
+    public String getAuthor() {
+      return author;
+    }
+
+    public void setAuthor(String author) {
+      this.author = author;
+    }
+
+    public String getSynopsis() {
+      return synopsis;
+    }
+
+    public void setSynopsis(String synopsis) {
+      this.synopsis = synopsis;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public String getProjectUrl() {
+      return projectUrl;
+    }
+
+    public void setProjectUrl(String projectUrl) {
+      this.projectUrl = projectUrl;
+    }
+  }
+
+  public static class Response {
+    private String query;
+    private List<GoPackage> hits;
+
+    public String getQuery() {
+      return query;
+    }
+
+    public void setQuery(String query) {
+      this.query = query;
+    }
+
+    public List<GoPackage> getHits() {
+      return hits;
+    }
+
+    public void setHits(List<GoPackage> hits) {
+      this.hits = hits;
+    }
+  }
+
+  public JPanel getComponent() {
+    return myPanel1;
+  }
+
+  public static Manager getInstance() {
+    if (myInstance == null) {
+      myInstance = new Manager();
+    }
+
+    return myInstance;
+  }
+
+  public static void setWindow(WindowWrapper windowWrapper) {
+    myWindow = windowWrapper;
+  }
+
+  public static void setProject(Project project) {
+    myProject = project;
+  }
+
+  public static void setModule(Module module) {
+    myModule = module;
+  }
+
+}

--- a/src/com/goide/ui/pm/ManagerAction.java
+++ b/src/com/goide/ui/pm/ManagerAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.ui.pm;
+
+import com.goide.GoModuleType;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.WindowWrapper;
+import com.intellij.openapi.ui.WindowWrapperBuilder;
+
+import java.util.Collection;
+
+public class ManagerAction extends AnAction {
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    Collection<Module> modules = ModuleUtil.getModulesOfType(project, GoModuleType.getInstance());
+    if (modules.size() == 0) {
+      return;
+    }
+
+    WindowWrapperBuilder window = new WindowWrapperBuilder(WindowWrapper.Mode.MODAL, Manager.getInstance().getComponent());
+    WindowWrapper myWindow = window.build();
+    myWindow.setTitle("go get package manager");
+    Manager.setWindow(myWindow);
+    Manager.setProject(project);
+    Manager.setModule(modules.iterator().next());
+    myWindow.show();
+    myWindow.getWindow().transferFocus();
+  }
+}


### PR DESCRIPTION
This allows people to use [go-search.org](http://go-search.org) to find packages they are looking for.

There are a few things that could definitely be improved:
- set focus on the input box when the window is displayed
- add a search field like IDEA itself has (the one with the x button on the right side)
- deduplicate pacakges (maybe this one should be in the go-search repository?)
- detect when a package is already installed and run go get -u instead of go get
- the UI?
- the whole code itself? :D

Here's a screenshot of it in action:
![snapshot40](https://cloud.githubusercontent.com/assets/607868/7106539/70735542-e144-11e4-874f-3add4e6072ed.png)
