### PR TITLE
Add inspection for functions with the same name as builtin functions (fixes #1450)

### DIFF
--- a/resources/inspectionDescriptions/GoReservedWordUsedAsName.html
+++ b/resources/inspectionDescriptions/GoReservedWordUsedAsName.html
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+<body>
+Inspects for declarations of variables, arguments or functions that overlap with the built-in or reserved keyword.
+<!-- tooltip end -->
+If you receive this error then your code might not be as explicit as possible
+and might confuse other users.
+</body>
+</html>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -200,6 +200,9 @@
     <localInspection language="go" displayName="Duplicate argument"
                      groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoDuplicateArgumentInspection"/>
+    <localInspection language="go" displayName="Reserved word used as name"
+                     groupName="Go" enabledByDefault="true" level="WARNING"
+                     implementationClass="com.goide.inspections.GoReservedWordUsedAsName"/>
     <localInspection language="go" displayName="Duplicate return argument"
                      groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoDuplicateReturnArgumentInspection"/>

--- a/src/com/goide/inspections/GoRenameQuickFix.java
+++ b/src/com/goide/inspections/GoRenameQuickFix.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.GoFunctionDeclaration;
+import com.goide.psi.GoVarDefinition;
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.refactoring.rename.RenameProcessor;
+import org.jetbrains.annotations.NotNull;
+
+public class GoRenameQuickFix extends LocalQuickFixOnPsiElement {
+  private final String myNewName;
+  private final PsiElement myElement;
+
+  protected GoRenameQuickFix(@NotNull PsiElement element, String newName) {
+    super(element);
+    myNewName = newName;
+    myElement = element;
+  }
+
+
+  @Override
+  public void invoke(@NotNull Project project, @NotNull PsiFile file, @NotNull PsiElement startElement, @NotNull PsiElement endElement) {
+    if (!startElement.isWritable()) {
+      return;
+    }
+
+    new RenameProcessor(project, startElement, myNewName, false, true).run();
+  }
+
+  @NotNull
+  public String getFamilyName() {
+    return "Go";
+  }
+
+  @NotNull
+  @Override
+  public String getText() {
+    if (myElement instanceof GoFunctionDeclaration) {
+      return "Rename function to " + myNewName;
+    }
+    else if (myElement instanceof GoVarDefinition) {
+      return "Rename variable to " + myNewName;
+    }
+    else {
+      return "Rename to " + myNewName;
+    }
+  }
+}

--- a/src/com/goide/inspections/GoReservedWordUsedAsName.java
+++ b/src/com/goide/inspections/GoReservedWordUsedAsName.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.*;
+import com.goide.sdk.GoSdkUtil;
+import com.intellij.codeInspection.LocalInspectionToolSession;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import org.jetbrains.annotations.NotNull;
+
+public class GoReservedWordUsedAsName extends GoInspectionBase {
+  private GoFile builtin;
+
+  @NotNull
+  @Override
+  protected GoVisitor buildGoVisitor(@NotNull final ProblemsHolder holder, @NotNull LocalInspectionToolSession session) {
+    return new GoVisitor() {
+      @Override
+      public void visitFunctionDeclaration(@NotNull GoFunctionDeclaration o) {
+        check(o, holder);
+      }
+
+      @Override
+      public void visitVarDefinition(@NotNull GoVarDefinition o) {
+        check(o, holder);
+      }
+    };
+  }
+
+  protected void check(@NotNull GoFunctionDeclaration goFunction, @NotNull ProblemsHolder holder) {
+    if (builtin == null) {
+      builtin = GoSdkUtil.findBuiltinFile(goFunction);
+      if (builtin == null) {
+        return;
+      }
+    }
+
+    String functionName = goFunction.getName();
+    if (functionName == null) {
+      return;
+    }
+
+    for (GoFunctionDeclaration builtinFunctionDeclaration : builtin.getFunctions()) {
+      if (functionName.equals(builtinFunctionDeclaration.getName())) {
+        String prefix = "my";
+        if (goFunction.isPublic()) {
+          prefix = "My";
+        }
+        String newFunctionName = prefix + functionName.substring(0, 1).toUpperCase() + functionName.substring(1);
+        holder.registerProblem(goFunction.getIdentifier(), errorTextFunction(functionName), ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                               new GoRenameQuickFix(goFunction, newFunctionName));
+        break;
+      }
+    }
+  }
+
+  protected void check(@NotNull GoVarDefinition goVarDefinition, @NotNull ProblemsHolder holder) {
+    if (builtin == null) {
+      builtin = GoSdkUtil.findBuiltinFile(goVarDefinition);
+      if (builtin == null) {
+        return;
+      }
+    }
+
+    String varName = goVarDefinition.getName();
+    if (varName == null) {
+      return;
+    }
+
+    for (GoTypeSpec builtinTypeDeclaration : builtin.getTypes()) {
+      if (varName.equals(builtinTypeDeclaration.getName())) {
+        String prefix = "my";
+        if (goVarDefinition.isPublic()) {
+          prefix = "My";
+        }
+        String newVarName = prefix + varName.substring(0, 1).toUpperCase() + varName.substring(1);
+        holder.registerProblem(goVarDefinition.getIdentifier(), errorVarDeclaration(varName), ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                               new GoRenameQuickFix(goVarDefinition, newVarName));
+        break;
+      }
+    }
+  }
+
+  private static String errorTextFunction(@NotNull String name) {
+    return "Function '" + name + "' collides with builtin function '" + name + "'";
+  }
+
+  private static String errorVarDeclaration(@NotNull String name) {
+    return "Variable '" + name + "' collides with builtin type '" + name + "'";
+  }
+}

--- a/testData/highlighting/ranges.go
+++ b/testData/highlighting/ranges.go
@@ -2,13 +2,13 @@ package main
 
 import "fmt"
 
-func append(slice []Type, elems ...Type) []Type
-func make(Type, size int) Type
+func append1(slice []Type, elems ...Type) []Type
+func make1(Type, size int) Type
 type Type int
 type int int
 type string string
 
-func println(o... interface {}) {
+func println1(o... interface {}) {
     fmt.Println(o)
 }
 type Person struct {
@@ -34,13 +34,13 @@ func main() {
     likes := make(map[string][]*Person)
     for _, p := range people {
         for _, l := range p.Likes {
-            likes[l] = append(likes[l], p)
+            likes[l] = append1(likes[l], p)
         }
     }
 
     for k, v := range likes {
-         println(k)
-         println(v[1].Likes)
+         println1(k)
+         println1(v[1].Likes)
     }
 
     var <error descr="Unused variable 'people'">people</error> []*Person // todo: should be redeclared
@@ -51,16 +51,16 @@ func main() {
     for _, p2 := range create() {
         println(p2.Likes)
     }
-    
+
     var p Plugin = nil
     for _, p := range p.Packets {
         println(p.path)
     }
-    
+
     for _, <error descr="Unused variable 'd'">d</error> := range <error descr="Unresolved reference 'd'">d</error>.Packets {
     }
 }
-func create() []*Person {return make([]*Person, 0)}
+func create() []*Person {return make1([]*Person, 0)}
 
 type myStruct struct {
     MyVal bool

--- a/testData/highlighting/struct.go
+++ b/testData/highlighting/struct.go
@@ -30,7 +30,7 @@ func (e E) foo() {
 
 type Type int
 
-func new(Type) *Type
+func new1(Type) *Type
 
 type T int
 func (t T) name()  {


### PR DESCRIPTION
Lets see if I've understood anything from today :D 
I'm not really sure about the 
```java
    String functionName = psiElement.getText();
    for (GoFunctionDeclaration builtinFunctionDeclaration : builtin.getFunctions()) {
      if (builtinFunctionDeclaration.getIdentifier().getText().equals(functionName)) {
```
part but I don't see another way to get the identifier text out of it.

Also, I'm sorry for the commit noise related to the white space at the end of the lines.

One last thing that's not clear to me is why all the tests that break now break because of the missing description which wasn't there in the first place. On master everything works as expected, on this branch once I have errors/warnings from the inspections, tests break.

Thank you!