### PR TITLE
Go Build: output file customisation (fixes #1658)

### DIFF
--- a/src/com/goide/runconfig/application/GoApplicationRunningState.java
+++ b/src/com/goide/runconfig/application/GoApplicationRunningState.java
@@ -33,7 +33,7 @@ public class GoApplicationRunningState extends GoRunningState<GoApplicationConfi
                                    @NotNull GoApplicationConfiguration configuration) {
     super(env, module, configuration);
   }
-  
+
   @NotNull
   public String getTarget() {
     return myConfiguration.getKind() == GoApplicationConfiguration.Kind.PACKAGE
@@ -53,10 +53,12 @@ public class GoApplicationRunningState extends GoRunningState<GoApplicationConfi
       return super.startProcess();
     }
     finally {
-      File file = new File(myTmpFilePath);
-      if (file.exists()) {
-        //noinspection ResultOfMethodCallIgnored
-        file.delete();
+      if (myConfiguration.getOutputFilePath() == "") {
+        File file = new File(myTmpFilePath);
+        if (file.exists()) {
+          //noinspection ResultOfMethodCallIgnored
+          file.delete();
+        }
       }
     }
   }

--- a/src/com/goide/runconfig/ui/GoApplicationConfigurationEditorForm.form
+++ b/src/com/goide/runconfig/ui/GoApplicationConfigurationEditorForm.form
@@ -3,12 +3,12 @@
   <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="657" height="277"/>
+      <xy x="20" y="20" width="712" height="333"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="487df" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="487df" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="true"/>
@@ -77,6 +77,29 @@
             <properties>
               <labelFor value="ffb40"/>
               <text value="&amp;File"/>
+            </properties>
+          </component>
+          <component id="ad311" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="O&amp;utput file location"/>
+            </properties>
+          </component>
+          <component id="580da" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myOutputFilePath">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="63ef0" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <icon value="ide/info_notifications.png"/>
+              <text value="*Note: if you set this directory the output file name will be the name of this configuration"/>
             </properties>
           </component>
         </children>

--- a/src/com/goide/runconfig/ui/GoApplicationConfigurationEditorForm.java
+++ b/src/com/goide/runconfig/ui/GoApplicationConfigurationEditorForm.java
@@ -19,12 +19,16 @@ package com.goide.runconfig.ui;
 import com.goide.runconfig.GoRunUtil;
 import com.goide.runconfig.application.GoApplicationConfiguration;
 import com.goide.runconfig.testing.ui.GoPackageFieldCompletionProvider;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextBrowseFolderListener;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.ui.EditorTextField;
 import com.intellij.ui.ListCellRendererWrapper;
 import com.intellij.util.Producer;
@@ -44,6 +48,7 @@ public class GoApplicationConfigurationEditorForm extends SettingsEditor<GoAppli
   private JComboBox myRunKindComboBox;
   private JLabel myPackageLabel;
   private JLabel myFileLabel;
+  private TextFieldWithBrowseButton myOutputFilePath;
 
 
   public GoApplicationConfigurationEditorForm(@NotNull final Project project) {
@@ -53,6 +58,10 @@ public class GoApplicationConfigurationEditorForm extends SettingsEditor<GoAppli
 
     installRunKindComboBox();
     GoRunUtil.installGoWithMainFileChooser(myProject, myFileField);
+    FileChooserDescriptor chooseOutputFileDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+      .withTitle("Save Build File to")
+      .withDescription("Choose build file save location");
+    myOutputFilePath.addBrowseFolderListener(new TextBrowseFolderListener(chooseOutputFileDescriptor));
   }
 
   private void onRunKindChanged() {
@@ -74,6 +83,7 @@ public class GoApplicationConfigurationEditorForm extends SettingsEditor<GoAppli
     myFileField.setText(configuration.getFilePath());
     myPackageField.setText(configuration.getPackage());
     myRunKindComboBox.setSelectedItem(configuration.getKind());
+    myOutputFilePath.setText(configuration.getOutputFilePath());
     myCommonSettingsPanel.resetEditorFrom(configuration);
   }
 
@@ -82,6 +92,7 @@ public class GoApplicationConfigurationEditorForm extends SettingsEditor<GoAppli
     configuration.setFilePath(myFileField.getText());
     configuration.setPackage(myPackageField.getText());
     configuration.setKind((GoApplicationConfiguration.Kind)myRunKindComboBox.getSelectedItem());
+    configuration.setFileOutputPath(myOutputFilePath.getText());
     myCommonSettingsPanel.applyEditorTo(configuration);
   }
 


### PR DESCRIPTION
The only thing that I'd change to this is to make the output file dialog open to either the project root or to GOPATH/bin by default (but I don't know how to do this yet) and it can still be used as is.