### PR TITLE
Disable debugging for now

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -161,12 +161,12 @@
     <testSrcLocator implementation="com.goide.runconfig.testing.GoTestLocationProvider"/>
 
     <!-- debugger -->
-    <xdebugger.breakpointType implementation="com.goide.debugger.ideagdb.debug.breakpoints.GdbBreakpointType"/>
+    <!--xdebugger.breakpointType implementation="com.goide.debugger.ideagdb.debug.breakpoints.GdbBreakpointType"/-->
 
     <!-- temporary debugger configurations -->
     <!-- todo: move it to run/test configurations -->
-    <configurationType implementation="com.goide.debugger.ideagdb.run.GdbRunConfigurationType"/>
-    <programRunner implementation="com.goide.debugger.ideagdb.run.GdbRunner"/>
+    <!--configurationType implementation="com.goide.debugger.ideagdb.run.GdbRunConfigurationType"/>
+    <programRunner implementation="com.goide.debugger.ideagdb.run.GdbRunner"/-->
 
     <checkinHandlerFactory implementation="com.goide.actions.fmt.GoFmtCheckinFactory" order="last"/>
 

--- a/src/com/goide/runconfig/GoBuildingRunner.java
+++ b/src/com/goide/runconfig/GoBuildingRunner.java
@@ -26,6 +26,7 @@ import com.intellij.execution.RunProfileStarter;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;

--- a/src/com/goide/runconfig/GoRunner.java
+++ b/src/com/goide/runconfig/GoRunner.java
@@ -17,6 +17,7 @@
 package com.goide.runconfig;
 
 import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.DefaultProgramRunner;
 import org.jetbrains.annotations.NotNull;


### PR DESCRIPTION
I'd like to disable the debug options for now as we don't really support them (also I want to disable GDB until I have some time to look at it and improve it, apparently it should support apps compiled with gccgo??)