### PR TITLE
Fix result count for 'make', 'new' functions (fixes #1760)

### DIFF
--- a/src/com/goide/inspections/GoInspectionUtil.java
+++ b/src/com/goide/inspections/GoInspectionUtil.java
@@ -29,7 +29,7 @@ public class GoInspectionUtil {
   public static final int UNKNOWN_COUNT = -1;
 
   public static int getExpressionResultCount(GoExpression call) {
-    if (call instanceof GoLiteral || call instanceof GoBinaryExpr || call instanceof GoParenthesesExpr ||
+    if (call instanceof GoLiteral || call instanceof GoStringLiteral || call instanceof GoBinaryExpr || call instanceof GoParenthesesExpr ||
         (call instanceof GoUnaryExpr && ((GoUnaryExpr)call).getSendChannel() == null) || call instanceof GoBuiltinCallExpr) {
       return 1;
     }

--- a/src/com/goide/inspections/GoInspectionUtil.java
+++ b/src/com/goide/inspections/GoInspectionUtil.java
@@ -30,7 +30,7 @@ public class GoInspectionUtil {
 
   public static int getExpressionResultCount(GoExpression call) {
     if (call instanceof GoLiteral || call instanceof GoBinaryExpr || call instanceof GoParenthesesExpr ||
-        (call instanceof GoUnaryExpr && ((GoUnaryExpr)call).getSendChannel() == null)) {
+        (call instanceof GoUnaryExpr && ((GoUnaryExpr)call).getSendChannel() == null) || call instanceof GoBuiltinCallExpr) {
       return 1;
     }
     else if (call instanceof GoTypeAssertionExpr) {

--- a/tests/com/goide/inspections/GoInspectionUtilTest.java
+++ b/tests/com/goide/inspections/GoInspectionUtilTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.GoCodeInsightFixtureTestCase;
+import com.goide.psi.*;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class GoInspectionUtilTest extends GoCodeInsightFixtureTestCase {
+
+  private <T extends GoExpression> void doTest(@NotNull String text, @NotNull Class<T> aClass, int expected) {
+    myFixture.configureByText("a.go", text);
+    PsiElement element = myFixture.getFile().findElementAt(myFixture.getEditor().getCaretModel().getOffset());
+    T callExpr = PsiTreeUtil.getParentOfType(element, aClass);
+    assertEquals(expected, GoInspectionUtil.getExpressionResultCount(callExpr));
+  }
+
+  public void testBuiltinCallResultCount() {
+    String text = "package a; func b() {\n b := <caret>make(int, 10); _ = b }";
+    doTest(text, GoBuiltinCallExpr.class, 1);
+  }
+
+  public void testMultipleResultCount() {
+    String text = "package a; func vals() (int, int) {\n return 42, 0}; func b() {\n <caret>vals()}";
+    doTest(text, GoCallExpr.class, 2);
+  }
+
+  public void testLiteralResultCount() {
+    String text = "package a; func b() {\n a := \"hello <caret>world\"}";
+    doTest(text, GoStringLiteral.class, 1);
+  }
+}


### PR DESCRIPTION
Due to `GoBuiltinCallExpr` is used for `make` and `new` calls only, I think it's safe to say that it returns a single value.
See GoParserUtil:
https://github.com/eugene-auduchinok/go-lang-idea-plugin/blob/497fcd84047d91cb8907f1585e8d298074c1f976/src/com/goide/parser/GoParserUtil.java#L167-167