### PR TITLE
The "New > Go File" menu item doesn't display where it should on PyCharm.

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -240,7 +240,7 @@
   <actions>
     <action id="Go.NewGoFile" class="com.goide.actions.GoCreateFileAction"
             text="Go File" description="Create new Go file">
-      <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+      <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
     </action>
 
     <action id="GoShowTypeInternalAction"


### PR DESCRIPTION
![screen shot 2015-07-26 at 17 25 56](https://cloud.githubusercontent.com/assets/36160/8893476/8780789a-33bb-11e5-8da2-88294dd556c4.png)

This PR is a shot in the dark since I don't know how to test it out, but hopefully it points someone in the right direction.

