### PR TITLE
Proper getUseScope for local variables and constants

### DIFF
--- a/src/com/goide/psi/impl/GoNamedElementImpl.java
+++ b/src/com/goide/psi/impl/GoNamedElementImpl.java
@@ -32,6 +32,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.impl.ElementBase;
 import com.intellij.psi.scope.PsiScopeProcessor;
+import com.intellij.psi.search.LocalSearchScope;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.util.CachedValueProvider;
@@ -210,6 +211,10 @@ public abstract class GoNamedElementImpl<T extends GoNamedStub<?>> extends GoStu
       return module != null ? GoUtil.moduleScope(getProject(), module) : super.getUseScope();
     }
     else {
+      if (this instanceof GoVarDefinition || this instanceof GoConstDefinition) {
+        GoBlock block = PsiTreeUtil.getParentOfType(this, GoBlock.class);
+        if (block != null) return new LocalSearchScope(block);
+      }
       return GoPsiImplUtil.packageScope(getContainingFile());
     }
   }

--- a/tests/com/goide/psi/impl/GoNamedElementTest.java
+++ b/tests/com/goide/psi/impl/GoNamedElementTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.psi.impl;
+
+import com.goide.GoCodeInsightFixtureTestCase;
+import com.goide.psi.GoVarDefinition;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.LocalSearchScope;
+import com.intellij.psi.util.PsiTreeUtil;
+
+public class GoNamedElementTest extends GoCodeInsightFixtureTestCase{
+  private <T> void doTestGetUseScope(String text, Class<T> scope) {
+    myFixture.configureByText("a.go", text);
+    PsiFile file = myFixture.getFile();
+    GoVarDefinition var = PsiTreeUtil.findChildOfType(file, GoVarDefinition.class);
+    assertNotNull(var);
+    assertTrue(scope.isInstance(var.getUseScope()));
+  }
+
+  public void testGlobalVarScope() {
+    doTestGetUseScope("package a; var b = 1", GlobalSearchScope.class);
+  }
+
+  public void testLocalVarScope() {
+    doTestGetUseScope("package a; func a() {\n var b = 1 }", LocalSearchScope.class);
+  }
+
+}


### PR DESCRIPTION
Is it efficient to get use scopes this way?