### PR TITLE
Fix nil assignment inspection for short vars, constants declarations 

### DIFF
--- a/src/com/goide/inspections/GoAssignmentNilWithoutExplicitType.java
+++ b/src/com/goide/inspections/GoAssignmentNilWithoutExplicitType.java
@@ -18,9 +18,11 @@ package com.goide.inspections;
 
 import com.goide.GoConstants;
 import com.goide.psi.*;
+import com.goide.psi.impl.GoPsiImplUtil;
 import com.goide.psi.impl.GoReferenceExpressionImpl;
 import com.intellij.codeInspection.LocalInspectionToolSession;
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -64,8 +66,9 @@ public class GoAssignmentNilWithoutExplicitType extends GoInspectionBase {
       private void checkExpressions(@NotNull List<GoExpression> expressions) {
         for (GoExpression expr : expressions) {
           if (expr instanceof GoReferenceExpressionImpl) {
-            // todo check if there is 'nil' var/const
-            if (((GoReferenceExpressionImpl)expr).getIdentifier().textMatches(GoConstants.NIL)) {
+            GoReferenceExpressionImpl ref = (GoReferenceExpressionImpl)expr;
+            PsiElement resolve = ref.getReference().resolve();
+            if (ref.getIdentifier().textMatches(GoConstants.NIL) && resolve != null && GoPsiImplUtil.builtin(resolve)) {
               holder.registerProblem(expr, "Cannot assign nil without explicit type", GENERIC_ERROR_OR_WARNING);
             }
           }

--- a/src/com/goide/inspections/GoAssignmentNilWithoutExplicitType.java
+++ b/src/com/goide/inspections/GoAssignmentNilWithoutExplicitType.java
@@ -18,6 +18,7 @@ package com.goide.inspections;
 
 import com.goide.GoConstants;
 import com.goide.psi.*;
+import com.goide.psi.impl.GoReferenceExpressionImpl;
 import com.intellij.codeInspection.LocalInspectionToolSession;
 import com.intellij.codeInspection.ProblemsHolder;
 import org.jetbrains.annotations.NotNull;
@@ -32,12 +33,22 @@ public class GoAssignmentNilWithoutExplicitType extends GoInspectionBase {
       @Override
       public void visitVarDeclaration(@NotNull GoVarDeclaration o) {
         for (GoVarSpec spec : o.getVarSpecList()) {
-          if (spec.getType() != null) continue;
-          for (GoExpression expr : spec.getExpressionList()) {
-            if (expr instanceof GoReferenceExpression) {
-              if (((GoReferenceExpression)expr).getIdentifier().textMatches(GoConstants.NIL)) {
-                holder.registerProblem(expr, "Cannot assign nil without explicit type", GENERIC_ERROR_OR_WARNING);
-              }
+          check(spec);
+        }
+      }
+
+      @Override
+      public void visitShortVarDeclaration(@NotNull GoShortVarDeclaration o) {
+        check(o);
+      }
+
+      private void check(@NotNull GoVarSpec spec) {
+        if (spec.getType() != null) return;
+        for (GoExpression expr : spec.getExpressionList()) {
+          if (expr instanceof GoReferenceExpressionImpl) {
+            // todo check if there is 'nil' var/const
+            if (((GoReferenceExpressionImpl)expr).getIdentifier().textMatches(GoConstants.NIL)) {
+              holder.registerProblem(expr, "Cannot assign nil without explicit type", GENERIC_ERROR_OR_WARNING);
             }
           }
         }

--- a/src/com/goide/inspections/GoAssignmentNilWithoutExplicitType.java
+++ b/src/com/goide/inspections/GoAssignmentNilWithoutExplicitType.java
@@ -23,6 +23,8 @@ import com.intellij.codeInspection.LocalInspectionToolSession;
 import com.intellij.codeInspection.ProblemsHolder;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 import static com.intellij.codeInspection.ProblemHighlightType.GENERIC_ERROR_OR_WARNING;
 
 public class GoAssignmentNilWithoutExplicitType extends GoInspectionBase {
@@ -33,18 +35,34 @@ public class GoAssignmentNilWithoutExplicitType extends GoInspectionBase {
       @Override
       public void visitVarDeclaration(@NotNull GoVarDeclaration o) {
         for (GoVarSpec spec : o.getVarSpecList()) {
-          check(spec);
+          checkVar(spec);
         }
       }
 
       @Override
       public void visitShortVarDeclaration(@NotNull GoShortVarDeclaration o) {
-        check(o);
+        checkVar(o);
       }
 
-      private void check(@NotNull GoVarSpec spec) {
+      @Override
+      public void visitConstDeclaration(@NotNull GoConstDeclaration o) {
+        for (GoConstSpec spec : o.getConstSpecList()) {
+          checkConst(spec);
+        }
+      }
+
+      private void checkVar(@NotNull GoVarSpec spec) {
         if (spec.getType() != null) return;
-        for (GoExpression expr : spec.getExpressionList()) {
+        checkExpressions(spec.getExpressionList());
+      }
+
+      private void checkConst(@NotNull GoConstSpec spec) {
+        if (spec.getType() != null) return;
+        checkExpressions(spec.getExpressionList());
+      }
+
+      private void checkExpressions(@NotNull List<GoExpression> expressions) {
+        for (GoExpression expr : expressions) {
           if (expr instanceof GoReferenceExpressionImpl) {
             // todo check if there is 'nil' var/const
             if (((GoReferenceExpressionImpl)expr).getIdentifier().textMatches(GoConstants.NIL)) {

--- a/testData/highlighting/nil.go
+++ b/testData/highlighting/nil.go
@@ -1,0 +1,18 @@
+package nil
+
+func <warning>nilAssign</warning>() {
+	var a, b, c = 1, <error>nil</error>, 2
+	_, _, _ = a, b, c
+
+	d, e, f := 1, <error>nil</error>, 2
+	_, _, _ = d, e, f
+
+	const g, h, i = 1, <error>nil</error>, 2
+	_, _, _ = g, h, i
+}
+
+func <warning>nilVar</warning>() {
+	var nil = 123
+	var a = nil
+	_ = a
+}

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -229,7 +229,7 @@ type ServiceError struct {
 
 
 func <warning>typeAssert</warning>() {
-  err := <error>nil</error>
+  err := nil
   switch err.(type) {
     case ServiceError:
             ser := err.(ServiceError)
@@ -411,13 +411,3 @@ func _() {
 	st.Get("key") // <- unresolved Get
 }
 
-func <warning>nilAssign</warning>() {
-	var a, b, c = 1, <error>nil</error>, 2
-	_, _, _ = a, b, c
-
-	d, e, f := 1, <error>nil</error>, 2
-	_, _, _ = d, e, f
-
-	const g, h, i = 1, <error>nil</error>, 2
-	_, _, _ = g, h, i
-}

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -417,4 +417,7 @@ func <warning>nilAssign</warning>() {
 
 	d, e, f := 1, <error>nil</error>, 2
 	_, _, _ = d, e, f
+
+	const g, h, i = 1, <error>nil</error>, 2
+	_, _, _ = g, h, i
 }

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -229,7 +229,7 @@ type ServiceError struct {
 
 
 func <warning>typeAssert</warning>() {
-  err := nil
+  err := <error>nil</error>
   switch err.(type) {
     case ServiceError:
             ser := err.(ServiceError)
@@ -409,4 +409,12 @@ func (t MyType) Get(key string) string { return "hello" }
 func _() {
 	st := MyType("tag")
 	st.Get("key") // <- unresolved Get
+}
+
+func <warning>nilAssign</warning>() {
+	var a, b, c = 1, <error>nil</error>, 2
+	_, _, _ = a, b, c
+
+	d, e, f := 1, <error>nil</error>, 2
+	_, _, _ = d, e, f
 }

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -103,6 +103,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testForRange()    { doTest(); }
   public void testMismatch()    { doTest(); }
   public void testStubParams()  { doTest(); }
+  public void testNil()         { doTest(); }
   public void testAssignmentUsages()  { doTest(); }
 
   public void testRelativeImportIgnoringDirectories() throws IOException {


### PR DESCRIPTION
There was an inspection for nil assignments to variables but it hadn't work for short assignments or constants, so I've fixed it.