### PR TITLE
Use correct delve command to debug existing binary

### DIFF
--- a/src/com/goide/runconfig/application/GoApplicationRunningState.java
+++ b/src/com/goide/runconfig/application/GoApplicationRunningState.java
@@ -104,7 +104,7 @@ public class GoApplicationRunningState extends GoRunningState<GoApplicationConfi
         dlv.setExecutable(true, false);
       }
       return executor.withExePath(dlv.getAbsolutePath())
-        .withParameters("--listen=localhost:" + myDebugPort, "--headless=true", "debug", myOutputFilePath, "--");
+        .withParameters("--listen=localhost:" + myDebugPort, "--headless=true", "exec", myOutputFilePath, "--");
     }
     return executor.withExePath(myOutputFilePath);
   }


### PR DESCRIPTION
The delve version that is shipped with the plugin supports the `exec` command which fixes the following bug: currently the plugin uses the `debug` which builds the sources from the current working directory. However the plugin builds the sources correctly by itself in form of a binary file that should be ran by delve.