### PR TITLE
Fix tests inheritance

### DIFF
--- a/tests/com/goide/completion/GoCompletionSdkAwareTest.java
+++ b/tests/com/goide/completion/GoCompletionSdkAwareTest.java
@@ -19,22 +19,10 @@ package com.goide.completion;
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.codeInsight.lookup.Lookup;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.testFramework.LightProjectDescriptor;
 
 import java.io.IOException;
 
-public class GoCompletionSdkAwareTest extends GoCompletionTestBase {
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    setUpProjectSdk();
-  }
-
-  @Override
-  protected LightProjectDescriptor getProjectDescriptor() {
-    return createMockProjectDescriptor();
-  }
-
+public class GoCompletionSdkAwareTest extends GoCompletionSdkAwareTestBase {
   public void testFormatter() {
     doTestInclude("package main; import . \"fmt\"; type alias <caret>", "Formatter");
   }
@@ -79,7 +67,7 @@ public class GoCompletionSdkAwareTest extends GoCompletionTestBase {
                   "import \"fmt\"\n" +
                   "func test(){fmt.Fprintln(<caret>)}", "fmt.Fprintln");
   }
-  
+
   public void testVariableAutoImport() {
     doCheckResult("package main; \n" +
                   "func test(){ErrNotSuppor<caret>}",
@@ -87,7 +75,7 @@ public class GoCompletionSdkAwareTest extends GoCompletionTestBase {
                   "import \"net/http\"\n" +
                   "func test(){http.ErrNotSupported}", "http.ErrNotSupported");
   }
-  
+
   public void testConstantAutoImport() {
     doCheckResult("package main; \n" +
                   "func test(){O_RDO<caret>}", "package main;\n" +
@@ -298,14 +286,14 @@ public class GoCompletionSdkAwareTest extends GoCompletionTestBase {
     myFixture.completeBasic();
     myFixture.checkResult("package a; func main() { _ = ExampleF<caret>");
   }
-  
+
   public void testCompleteTestBenchmarkExamplesFromNonTestFiles() throws IOException {
     myFixture.getTempDirFixture().createFile("pack/pack.go", "package pack; func TestFoo() {} func BenchmarkFoo() {} func ExampleFoo() {}");
     myFixture.configureByText("my_test.go", "package a; func main() { _ = Foo<caret>");
     myFixture.completeBasic();
     assertContainsElements(myFixture.getLookupElementStrings(), "pack.TestFoo", "pack.BenchmarkFoo", "pack.ExampleFoo");
   }
-  
+
   public void testDoNotAutoImportWithTheSameImportPath() throws IOException {
     myFixture.getTempDirFixture().createFile("pack1/file2.go", "package pack1; func MyFunctionFromSamePath() {}");
     myFixture.getTempDirFixture().createFile("pack2/file2.go", "package pack1; func MyFunctionFromOtherPath() {}");

--- a/tests/com/goide/completion/GoCompletionSdkAwareTestBase.java
+++ b/tests/com/goide/completion/GoCompletionSdkAwareTestBase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.completion;
+
+import com.intellij.testFramework.LightProjectDescriptor;
+
+public abstract class GoCompletionSdkAwareTestBase extends GoCompletionTestBase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    setUpProjectSdk();
+  }
+
+  @Override
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return createMockProjectDescriptor();
+  }
+}

--- a/tests/com/goide/completion/GoExcludedPackagesTest.java
+++ b/tests/com/goide/completion/GoExcludedPackagesTest.java
@@ -19,7 +19,7 @@ package com.goide.completion;
 import com.goide.project.GoExcludedPathsSettings;
 import com.intellij.util.ArrayUtil;
 
-public class GoExcludePackagesTest extends GoCompletionSdkAwareTest {
+public class GoExcludedPackagesTest extends GoCompletionSdkAwareTestBase {
   @Override
   protected void tearDown() throws Exception {
     GoExcludedPathsSettings.getInstance(getProject()).setExcludedPackages(ArrayUtil.EMPTY_STRING_ARRAY);


### PR DESCRIPTION
After previous tests cleanup we had tests in `GoCompletionSdkAwareTest` run twice because of inheritance.