### PR TITLE
fix bug in redeclared import detector

### DIFF
--- a/testData/highlighting/relativeImportIgnoringDirectories.go
+++ b/testData/highlighting/relativeImportIgnoringDirectories.go
@@ -1,5 +1,5 @@
 package test
 
 import `./<error descr="Cannot resolve file '.name'">.name</error>`
-import <error descr="Redeclared import">`./<error descr="Cannot resolve file '_name'">_name</error>`</error>
+import `./<error descr="Cannot resolve file '_name'">_name</error>`
 import `./<error descr="Cannot resolve file 'testdata'">testdata</error>`


### PR DESCRIPTION
The previous version used GoFile.getImportMap(), which returns entries
for every package in a given package source directory, even those with
build tags such as "build +ignore".

This change introduces getImportNameMap, which does no package
resolution and simply looks at names introduced into the current source
file.