### PR TITLE
fix spurious "redeclared import" warnings

### DIFF
--- a/src/com/goide/psi/GoFile.java
+++ b/src/com/goide/psi/GoFile.java
@@ -432,7 +432,12 @@ public class GoFile extends PsiFileBase {
   }
 
   public boolean hasCPathImport() {
-    return getImportMap().containsKey(GoConstants.C_PATH);
+    for (GoImportSpec importSpec : getImports()) {
+      if (GoConstants.C_PATH.equals(importSpec.getPath())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public void deleteImport(@NotNull GoImportSpec importSpec) {

--- a/src/com/goide/util/GoUtil.java
+++ b/src/com/goide/util/GoUtil.java
@@ -216,7 +216,7 @@ public class GoUtil {
       public Result<Collection<String>> compute() {
         Collection<String> set = ContainerUtil.newLinkedHashSet();
         for (PsiFile file : dir.getFiles()) {
-          if (file instanceof GoFile && !directoryToIgnore(file.getName())) {
+          if (file instanceof GoFile && !directoryToIgnore(file.getName()) && allowed(file)) {
             String name = ((GoFile)file).getPackageName();
             if (StringUtil.isNotEmpty(name)) {
               set.add(trimTestSuffices && GoTestFinder.isTestFile(file) ? StringUtil.trimEnd(name, GoConstants.TEST_SUFFIX) : name);

--- a/tests/com/goide/util/GoUtilTest.java
+++ b/tests/com/goide/util/GoUtilTest.java
@@ -26,6 +26,7 @@ public class GoUtilTest extends GoCodeInsightFixtureTestCase {
     myFixture.configureByText("docs.go", "package documentation");
     myFixture.configureByText("bar_test.go", "package tricky_package_name");
     myFixture.configureByText("non_test_file.go", "package non_test");
+    myFixture.configureByText("ignored.go", "// +build ignored\n\npackage ignored");
     
     assertSameElements(GoUtil.getAllPackagesInDirectory(myFixture.getFile().getContainingDirectory(), true), 
                        "foo", "main", "non_test", "documentation", "tricky_package_name");


### PR DESCRIPTION
This patch modifies GoUtil.getAllPackagesInDirectory to test for build tags
when evaluating whether a file should be scanned for packages.

This also modifies GoFile.hasCPathImport to simply look for 'import "C"'
rather than getImportMap. This avoids an infinite recursion
(getImportMap depends on getAllPackagesInDirectory).

This fixes the bug identified in
https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/1858

Read on for a brief description of the bug:

In the Go source distribution, you have situations like

src/runtime/mkduff.go -> package main, // build +ignore
src/runtime/trace.go -> package runtime, no build tag

src/strconv/makeisprint.go -> package main, // build +ignore
src/strconv/itoa.go -> package strconv, no build tag

In your program, you do

import "runtime"
import "strconv" <--- redeclared import error

This is because GoUtil.getImportMap returns

main -> [runtime, strconv] <--- two imports with the same name,
                                spurious "redeclared import"
runtime -> [runtime]
strconv -> [strconv]