### PR TITLE
Change libraries to Go Packages. Fix some typos

### DIFF
--- a/jps-plugin/src/com/goide/jps/model/JpsGoApplicationLibrariesSerializer.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoApplicationLibrariesSerializer.java
@@ -17,7 +17,7 @@
 package com.goide.jps.model;
 
 import com.goide.GoConstants;
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import com.intellij.util.xmlb.XmlSerializer;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +31,7 @@ public class JpsGoApplicationLibrariesSerializer extends JpsGlobalExtensionSeria
 
   @Override
   public void loadExtension(@NotNull JpsGlobal global, @NotNull Element componentTag) {
-    GoLibrariesState librariesState = XmlSerializer.deserialize(componentTag, GoLibrariesState.class);
+    GoPathState librariesState = XmlSerializer.deserialize(componentTag, GoPathState.class);
     JpsGoLibrariesExtensionService.getInstance().setApplicationLibrariesState(global, librariesState);
   }
 

--- a/jps-plugin/src/com/goide/jps/model/JpsGoLibraries.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoLibraries.java
@@ -16,7 +16,7 @@
 
 package com.goide.jps.model;
 
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,23 +24,23 @@ import org.jetbrains.jps.model.ex.JpsElementBase;
 
 public class JpsGoLibraries extends JpsElementBase<JpsGoLibraries> {
   @NotNull
-  private GoLibrariesState myState = new GoLibrariesState();
+  private GoPathState myState = new GoPathState();
 
-  public JpsGoLibraries(@Nullable GoLibrariesState state) {
+  public JpsGoLibraries(@Nullable GoPathState state) {
     if (state != null) {
       myState = state;
     }
   }
 
   @NotNull
-  public GoLibrariesState getState() {
+  public GoPathState getState() {
     return myState;
   }
 
   @NotNull
   @Override
   public JpsGoLibraries createCopy() {
-    GoLibrariesState newState = new GoLibrariesState();
+    GoPathState newState = new GoPathState();
     XmlSerializerUtil.copyBean(myState, newState);
     return new JpsGoLibraries(newState);
   }

--- a/jps-plugin/src/com/goide/jps/model/JpsGoLibrariesExtensionService.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoLibrariesExtensionService.java
@@ -16,7 +16,7 @@
 
 package com.goide.jps.model;
 
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.JpsGlobal;
@@ -30,20 +30,20 @@ public abstract class JpsGoLibrariesExtensionService {
     return JpsServiceManager.getInstance().getService(JpsGoLibrariesExtensionService.class);
   }
 
-  public abstract void setModuleLibrariesState(@NotNull JpsGoModuleProperties properties, @Nullable GoLibrariesState state);
+  public abstract void setModuleLibrariesState(@NotNull JpsGoModuleProperties properties, @Nullable GoPathState state);
   
   @NotNull
-  public abstract GoLibrariesState getModuleLibrariesState(@NotNull JpsSimpleElement<JpsGoModuleProperties> properties);
+  public abstract GoPathState getModuleLibrariesState(@NotNull JpsSimpleElement<JpsGoModuleProperties> properties);
 
-  public abstract void setProjectLibrariesState(@NotNull JpsProject project, @Nullable GoLibrariesState state);
-
-  @NotNull
-  public abstract GoLibrariesState getProjectLibrariesState(@NotNull JpsProject project);
-
-  public abstract void setApplicationLibrariesState(@NotNull JpsGlobal global, @Nullable GoLibrariesState state);
+  public abstract void setProjectLibrariesState(@NotNull JpsProject project, @Nullable GoPathState state);
 
   @NotNull
-  public abstract GoLibrariesState getApplicationLibrariesState(@NotNull JpsGlobal global);
+  public abstract GoPathState getProjectLibrariesState(@NotNull JpsProject project);
+
+  public abstract void setApplicationLibrariesState(@NotNull JpsGlobal global, @Nullable GoPathState state);
+
+  @NotNull
+  public abstract GoPathState getApplicationLibrariesState(@NotNull JpsGlobal global);
 
   @NotNull
   public abstract String retrieveGoPath(@NotNull JpsTypedModule<JpsSimpleElement<JpsGoModuleProperties>> module);

--- a/jps-plugin/src/com/goide/jps/model/JpsGoLibrariesExtensionServiceImpl.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoLibrariesExtensionServiceImpl.java
@@ -17,7 +17,7 @@
 package com.goide.jps.model;
 
 import com.goide.GoEnvironmentUtil;
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.util.Function;
@@ -38,38 +38,38 @@ public class JpsGoLibrariesExtensionServiceImpl extends JpsGoLibrariesExtensionS
   private static final JpsElementChildRole<JpsGoLibraries> LIBRARIES_ROLE = JpsElementChildRoleBase.create("go.libraries.role");
 
   @Override
-  public void setModuleLibrariesState(@NotNull JpsGoModuleProperties properties, @Nullable GoLibrariesState state) {
+  public void setModuleLibrariesState(@NotNull JpsGoModuleProperties properties, @Nullable GoPathState state) {
     properties.setLibrariesState(state);
   }
 
   @NotNull
   @Override
-  public GoLibrariesState getModuleLibrariesState(@NotNull JpsSimpleElement<JpsGoModuleProperties> properties) {
+  public GoPathState getModuleLibrariesState(@NotNull JpsSimpleElement<JpsGoModuleProperties> properties) {
     return properties.getData().getLibrariesState();
   }
 
   @Override
-  public void setProjectLibrariesState(@NotNull JpsProject project, @Nullable GoLibrariesState state) {
+  public void setProjectLibrariesState(@NotNull JpsProject project, @Nullable GoPathState state) {
     project.getContainer().setChild(LIBRARIES_ROLE, new JpsGoLibraries(state));
   }
 
   @NotNull
   @Override
-  public GoLibrariesState getProjectLibrariesState(@NotNull JpsProject project) {
+  public GoPathState getProjectLibrariesState(@NotNull JpsProject project) {
     final JpsGoLibraries child = project.getContainer().getChild(LIBRARIES_ROLE);
-    return child != null ? child.getState() : new GoLibrariesState();
+    return child != null ? child.getState() : new GoPathState();
   }
 
   @Override
-  public void setApplicationLibrariesState(@NotNull JpsGlobal global, @Nullable GoLibrariesState state) {
+  public void setApplicationLibrariesState(@NotNull JpsGlobal global, @Nullable GoPathState state) {
     global.getContainer().setChild(LIBRARIES_ROLE, new JpsGoLibraries(state));
   }
 
   @NotNull
   @Override
-  public GoLibrariesState getApplicationLibrariesState(@NotNull JpsGlobal global) {
+  public GoPathState getApplicationLibrariesState(@NotNull JpsGlobal global) {
     final JpsGoLibraries child = global.getContainer().getChild(LIBRARIES_ROLE);
-    return child != null ? child.getState() : new GoLibrariesState();
+    return child != null ? child.getState() : new GoPathState();
   }
 
   @NotNull

--- a/jps-plugin/src/com/goide/jps/model/JpsGoModuleProperties.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoModuleProperties.java
@@ -16,20 +16,20 @@
 
 package com.goide.jps.model;
 
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class JpsGoModuleProperties {
   @NotNull
-  private GoLibrariesState myLibrariesState = new GoLibrariesState();
+  private GoPathState myLibrariesState = new GoPathState();
 
   @NotNull
-  public GoLibrariesState getLibrariesState() {
+  public GoPathState getLibrariesState() {
     return myLibrariesState;
   }
 
-  public void setLibrariesState(@Nullable GoLibrariesState librariesState) {
-    myLibrariesState = librariesState != null ? librariesState : new GoLibrariesState();
+  public void setLibrariesState(@Nullable GoPathState librariesState) {
+    myLibrariesState = librariesState != null ? librariesState : new GoPathState();
   }
 }

--- a/jps-plugin/src/com/goide/jps/model/JpsGoModuleType.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoModuleType.java
@@ -17,7 +17,7 @@
 package com.goide.jps.model;
 
 import com.goide.GoConstants;
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import com.intellij.util.xmlb.XmlSerializer;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +44,7 @@ public class JpsGoModuleType extends JpsElementTypeBase<JpsSimpleElement<JpsGoMo
       public JpsSimpleElement<JpsGoModuleProperties> loadProperties(@Nullable Element componentElement) {
         JpsSimpleElement<JpsGoModuleProperties> result = INSTANCE.createDefaultProperties();
         if (componentElement != null) {
-          GoLibrariesState librariesState = XmlSerializer.deserialize(componentElement, GoLibrariesState.class);
+          GoPathState librariesState = XmlSerializer.deserialize(componentElement, GoPathState.class);
           JpsGoLibrariesExtensionService.getInstance().setModuleLibrariesState(result.getData(), librariesState);
         }
         return result;

--- a/jps-plugin/src/com/goide/jps/model/JpsGoProjectLibrariesSerializer.java
+++ b/jps-plugin/src/com/goide/jps/model/JpsGoProjectLibrariesSerializer.java
@@ -17,7 +17,7 @@
 package com.goide.jps.model;
 
 import com.goide.GoConstants;
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import com.intellij.util.xmlb.XmlSerializer;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -31,12 +31,12 @@ public class JpsGoProjectLibrariesSerializer extends JpsProjectExtensionSerializ
 
   @Override
   public void loadExtension(@NotNull JpsProject project, @NotNull Element componentTag) {
-    GoLibrariesState librariesState = XmlSerializer.deserialize(componentTag, GoLibrariesState.class);
+    GoPathState librariesState = XmlSerializer.deserialize(componentTag, GoPathState.class);
     JpsGoLibrariesExtensionService.getInstance().setProjectLibrariesState(project, librariesState);
   }
 
   public void loadExtensionWithDefaultSettings(@NotNull JpsProject project) {
-    JpsGoLibrariesExtensionService.getInstance().setProjectLibrariesState(project, new GoLibrariesState());
+    JpsGoLibrariesExtensionService.getInstance().setProjectLibrariesState(project, new GoPathState());
   }
 
   @Override

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -48,7 +48,7 @@
 
   <module-components>
     <component>
-      <implementation-class>com.goide.project.GoModuleLibrariesInitializer</implementation-class>
+      <implementation-class>com.goide.project.GoModulePackagesInitializer</implementation-class>
     </component>
   </module-components>
 
@@ -67,9 +67,9 @@
     <internalFileTemplate name="Go File"/>
 
     <!-- project -->
-    <applicationService serviceImplementation="com.goide.project.GoApplicationLibrariesService"/>
-    <projectService serviceImplementation="com.goide.project.GoProjectLibrariesService"/>
-    <moduleService serviceImplementation="com.goide.project.GoModuleLibrariesService"/>
+    <applicationService serviceImplementation="com.goide.project.GoApplicationPackagesService"/>
+    <projectService serviceImplementation="com.goide.project.GoProjectPackagesService"/>
+    <moduleService serviceImplementation="com.goide.project.GoModulePackagesService"/>
     <projectConfigurable groupId="language" provider="com.goide.configuration.GoConfigurableProvider" dynamic="true"
                          bundle="do.not.touch.this.attribute"/>
 

--- a/src/com/goide/configuration/GoConfigurableProvider.java
+++ b/src/com/goide/configuration/GoConfigurableProvider.java
@@ -37,15 +37,15 @@ public class GoConfigurableProvider extends ConfigurableProvider {
   @Nullable
   @Override
   public Configurable createConfigurable() {
-    Configurable librariesConfigurable = new GoLibrariesConfigurableProvider(myProject).createConfigurable();
+    Configurable gopathConfigurable = new GoPathConfigurableProvider(myProject).createConfigurable();
     Configurable sdkConfigurable = GoSdkService.getInstance(myProject).createSdkConfigurable();
     Configurable buildFlagsConfigurable = new GoBuildTargetConfigurable(myProject, false);
     Configurable autoImportConfigurable = new GoAutoImportConfigurable(myProject, false);
     if (sdkConfigurable != null) {
-      return new GoCompositeConfigurable(sdkConfigurable, buildFlagsConfigurable, librariesConfigurable, autoImportConfigurable);
+      return new GoCompositeConfigurable(sdkConfigurable, gopathConfigurable, buildFlagsConfigurable, autoImportConfigurable);
     }
     else {
-      return new GoCompositeConfigurable(buildFlagsConfigurable, librariesConfigurable, autoImportConfigurable);
+      return new GoCompositeConfigurable(gopathConfigurable, buildFlagsConfigurable, autoImportConfigurable);
     }
   }
 

--- a/src/com/goide/configuration/GoPathConfigurable.java
+++ b/src/com/goide/configuration/GoPathConfigurable.java
@@ -16,8 +16,8 @@
 
 package com.goide.configuration;
 
-import com.goide.project.GoApplicationLibrariesService;
-import com.goide.project.GoLibrariesService;
+import com.goide.project.GoApplicationPackagesService;
+import com.goide.project.GoPathService;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileChooser.FileChooserDialog;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
@@ -46,17 +46,17 @@ import java.util.Set;
 
 import static com.intellij.openapi.fileChooser.FileChooserDescriptorFactory.createMultipleFoldersDescriptor;
 
-public class GoLibrariesConfigurable implements SearchableConfigurable, Configurable.NoScroll {
+public class GoPathConfigurable implements SearchableConfigurable, Configurable.NoScroll {
   @NotNull private final String myDisplayName;
-  private final GoLibrariesService<?> myLibrariesService;
+  private final GoPathService<?> myGoPathService;
   private final String[] myReadOnlyPaths;
   private final JBCheckBox myUseEnvGoPathCheckBox = new JBCheckBox("Use GOPATH that's defined in system environment");
   private final JPanel myPanel = new JPanel(new BorderLayout());
   private final CollectionListModel<ListItem> myListModel = new CollectionListModel<ListItem>();
 
-  public GoLibrariesConfigurable(@NotNull String displayName, @NotNull GoLibrariesService librariesService, String... readOnlyPaths) {
+  public GoPathConfigurable(@NotNull String displayName, @NotNull GoPathService gopathService, String... readOnlyPaths) {
     myDisplayName = displayName;
-    myLibrariesService = librariesService;
+    myGoPathService = gopathService;
     myReadOnlyPaths = readOnlyPaths;
 
     final JBList filesList = new JBList(myListModel);
@@ -134,7 +134,7 @@ public class GoLibrariesConfigurable implements SearchableConfigurable, Configur
       })
       .disableUpDownActions();
     myPanel.add(decorator.createPanel(), BorderLayout.CENTER);
-    if (librariesService instanceof GoApplicationLibrariesService) {
+    if (gopathService instanceof GoApplicationPackagesService) {
       myUseEnvGoPathCheckBox.addActionListener(new ActionListener() {
         @Override
         public void actionPerformed(@NotNull ActionEvent event) {
@@ -165,17 +165,17 @@ public class GoLibrariesConfigurable implements SearchableConfigurable, Configur
 
   @Override
   public boolean isModified() {
-    return !getUserDefinedUrls().equals(ContainerUtil.newHashSet(myLibrariesService.getLibraryRootUrls())) ||
-           ((myLibrariesService instanceof GoApplicationLibrariesService) &&
-            (((GoApplicationLibrariesService)myLibrariesService).isUseGoPathFromSystemEnvironment() !=
+    return !getUserDefinedUrls().equals(ContainerUtil.newHashSet(myGoPathService.getLibraryRootUrls())) ||
+           ((myGoPathService instanceof GoApplicationPackagesService) &&
+            (((GoApplicationPackagesService)myGoPathService).isUseGoPathFromSystemEnvironment() !=
              myUseEnvGoPathCheckBox.isSelected()));
   }
 
   @Override
   public void apply() throws ConfigurationException {
-    myLibrariesService.setLibraryRootUrls(getUserDefinedUrls());
-    if (myLibrariesService instanceof GoApplicationLibrariesService) {
-      ((GoApplicationLibrariesService)myLibrariesService).setUseGoPathFromSystemEnvironment(myUseEnvGoPathCheckBox.isSelected());
+    myGoPathService.setLibraryRootUrls(getUserDefinedUrls());
+    if (myGoPathService instanceof GoApplicationPackagesService) {
+      ((GoApplicationPackagesService)myGoPathService).setUseGoPathFromSystemEnvironment(myUseEnvGoPathCheckBox.isSelected());
     }
   }
 
@@ -183,15 +183,15 @@ public class GoLibrariesConfigurable implements SearchableConfigurable, Configur
   public void reset() {
     myListModel.removeAll();
     resetLibrariesFromEnvironment();
-    for (String url : myLibrariesService.getLibraryRootUrls()) {
+    for (String url : myGoPathService.getLibraryRootUrls()) {
       myListModel.add(new ListItem(url, false));
     }
   }
 
   private void resetLibrariesFromEnvironment() {
-    if (myLibrariesService instanceof GoApplicationLibrariesService) {
-      myUseEnvGoPathCheckBox.setSelected(((GoApplicationLibrariesService)myLibrariesService).isUseGoPathFromSystemEnvironment());
-      if (((GoApplicationLibrariesService)myLibrariesService).isUseGoPathFromSystemEnvironment()) {
+    if (myGoPathService instanceof GoApplicationPackagesService) {
+      myUseEnvGoPathCheckBox.setSelected(((GoApplicationPackagesService)myGoPathService).isUseGoPathFromSystemEnvironment());
+      if (((GoApplicationPackagesService)myGoPathService).isUseGoPathFromSystemEnvironment()) {
         addReadOnlyPaths();
       }
       else {

--- a/src/com/goide/configuration/GoPathConfigurableProvider.java
+++ b/src/com/goide/configuration/GoPathConfigurableProvider.java
@@ -16,9 +16,9 @@
 
 package com.goide.configuration;
 
-import com.goide.project.GoApplicationLibrariesService;
-import com.goide.project.GoModuleLibrariesService;
-import com.goide.project.GoProjectLibrariesService;
+import com.goide.project.GoApplicationPackagesService;
+import com.goide.project.GoModulePackagesService;
+import com.goide.project.GoProjectPackagesService;
 import com.goide.sdk.GoSdkService;
 import com.goide.sdk.GoSdkUtil;
 import com.intellij.application.options.ModuleAwareProjectConfigurable;
@@ -47,10 +47,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-public class GoLibrariesConfigurableProvider extends ConfigurableProvider {
+public class GoPathConfigurableProvider extends ConfigurableProvider {
   @NotNull private final Project myProject;
 
-  public GoLibrariesConfigurableProvider(@NotNull Project project) {
+  public GoPathConfigurableProvider(@NotNull Project project) {
     myProject = project;
   }
 
@@ -116,10 +116,10 @@ public class GoLibrariesConfigurableProvider extends ConfigurableProvider {
               return file.getUrl();
             }
           });
-        result.add(new GoLibrariesConfigurable("Global libraries", GoApplicationLibrariesService.getInstance(), urlsFromEnv));
+        result.add(new GoPathConfigurable("Global GOPATH", GoApplicationPackagesService.getInstance(), urlsFromEnv));
         if (!myProject.isDefault()) {
-          result.add(new GoLibrariesConfigurable("Project libraries", GoProjectLibrariesService.getInstance(myProject)));
-          result.add(new ModuleAwareProjectConfigurable(myProject, "Module libraries", "Module libraries") {
+          result.add(new GoPathConfigurable("Project GOPATH", GoProjectPackagesService.getInstance(myProject)));
+          result.add(new ModuleAwareProjectConfigurable(myProject, "Module GOPATH", "Module GOPATH") {
             @Override
             protected boolean isSuitableForModule(@NotNull Module module) {
               return !myProject.isDisposed() && GoSdkService.getInstance(myProject).isGoModule(module);
@@ -128,7 +128,7 @@ public class GoLibrariesConfigurableProvider extends ConfigurableProvider {
             @NotNull
             @Override
             protected UnnamedConfigurable createModuleConfigurable(@NotNull Module module) {
-              return new GoLibrariesConfigurable("Module libraries", GoModuleLibrariesService.getInstance(module));
+              return new GoPathConfigurable("Module GOPATH", GoModulePackagesService.getInstance(module));
             }
           });
         }
@@ -139,7 +139,7 @@ public class GoLibrariesConfigurableProvider extends ConfigurableProvider {
       @Nls
       @Override
       public String getDisplayName() {
-        return "Go Libraries";
+        return "Gopath";
       }
 
       @Nullable

--- a/src/com/goide/inspections/WrongSdkConfigurationNotificationProvider.java
+++ b/src/com/goide/inspections/WrongSdkConfigurationNotificationProvider.java
@@ -18,8 +18,8 @@ package com.goide.inspections;
 
 import com.goide.GoFileType;
 import com.goide.GoLanguage;
-import com.goide.project.GoLibrariesService;
-import com.goide.project.GoModuleLibrariesInitializer;
+import com.goide.project.GoPathService;
+import com.goide.project.GoModulePackagesInitializer;
 import com.goide.sdk.GoSdkService;
 import com.goide.sdk.GoSdkUtil;
 import com.intellij.ProjectTopics;
@@ -57,7 +57,7 @@ public class WrongSdkConfigurationNotificationProvider extends EditorNotificatio
         notifications.updateAllNotifications();
       }
     });
-    connection.subscribe(GoLibrariesService.LIBRARIES_TOPIC, new GoLibrariesService.LibrariesListener() {
+    connection.subscribe(GoPathService.GOPATH_TOPIC, new GoPathService.LibrariesListener() {
       @Override
       public void librariesChanged(@NotNull Collection<String> newRootUrls) {
         notifications.updateAllNotifications();
@@ -113,10 +113,10 @@ public class WrongSdkConfigurationNotificationProvider extends EditorNotificatio
   private static EditorNotificationPanel createEmptyGoPathPanel(@NotNull final Project project) {
     EditorNotificationPanel panel = new EditorNotificationPanel();
     panel.setText("GOPATH is empty");
-    panel.createActionLabel("Configure Go Libraries", new Runnable() {
+    panel.createActionLabel("Configure Go Packages", new Runnable() {
       @Override
       public void run() {
-        GoModuleLibrariesInitializer.showModulesConfigurable(project);
+        GoModulePackagesInitializer.showModulesConfigurable(project);
       }
     });
     return panel;

--- a/src/com/goide/project/GoApplicationPackagesService.java
+++ b/src/com/goide/project/GoApplicationPackagesService.java
@@ -17,7 +17,7 @@
 package com.goide.project;
 
 import com.goide.GoConstants;
-import com.goide.GoLibrariesState;
+import com.goide.GoPathState;
 import com.goide.sdk.GoSdkUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
@@ -30,15 +30,15 @@ import org.jetbrains.annotations.NotNull;
   name = GoConstants.GO_LIBRARIES_SERVICE_NAME,
   storages = @Storage(file = StoragePathMacros.APP_CONFIG + "/" + GoConstants.GO_LIBRARIES_CONFIG_FILE)
 )
-public class GoApplicationLibrariesService extends GoLibrariesService<GoApplicationLibrariesService.GoApplicationLibrariesState> {
+public class GoApplicationPackagesService extends GoPathService<GoApplicationPackagesService.GoApplicationPathState> {
   @NotNull
   @Override
-  protected GoApplicationLibrariesState createState() {
-    return new GoApplicationLibrariesState();
+  protected GoApplicationPathState createState() {
+    return new GoApplicationPathState();
   }
 
-  public static GoApplicationLibrariesService getInstance() {
-    return ServiceManager.getService(GoApplicationLibrariesService.class);
+  public static GoApplicationPackagesService getInstance() {
+    return ServiceManager.getService(GoApplicationPackagesService.class);
   }
 
   public boolean isUseGoPathFromSystemEnvironment() {
@@ -50,12 +50,12 @@ public class GoApplicationLibrariesService extends GoLibrariesService<GoApplicat
       myState.setUseGoPathFromSystemEnvironment(useGoPathFromSystemEnvironment);
       if (!GoSdkUtil.getGoPathsRootsFromEnvironment().isEmpty()) {
         incModificationCount();
-        ApplicationManager.getApplication().getMessageBus().syncPublisher(LIBRARIES_TOPIC).librariesChanged(getLibraryRootUrls());
+        ApplicationManager.getApplication().getMessageBus().syncPublisher(GOPATH_TOPIC).librariesChanged(getLibraryRootUrls());
       }
     }
   }
 
-  public static class GoApplicationLibrariesState extends GoLibrariesState {
+  public static class GoApplicationPathState extends GoPathState {
     private boolean myUseGoPathFromSystemEnvironment = true;
 
     public boolean isUseGoPathFromSystemEnvironment() {

--- a/src/com/goide/project/GoModulePackagesService.java
+++ b/src/com/goide/project/GoModulePackagesService.java
@@ -17,20 +17,20 @@
 package com.goide.project;
 
 import com.goide.GoConstants;
-import com.goide.GoLibrariesState;
-import com.intellij.openapi.components.*;
-import com.intellij.openapi.project.Project;
+import com.goide.GoPathState;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.components.StoragePathMacros;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleServiceManager;
 import org.jetbrains.annotations.NotNull;
 
 @State(
   name = GoConstants.GO_LIBRARIES_SERVICE_NAME,
-  storages = {
-    @Storage(id = "default", file = StoragePathMacros.PROJECT_FILE),
-    @Storage(id = "dir", file = StoragePathMacros.PROJECT_CONFIG_DIR + "/" + GoConstants.GO_LIBRARIES_CONFIG_FILE, scheme = StorageScheme.DIRECTORY_BASED)
-  }
+  storages = @Storage(file = StoragePathMacros.MODULE_FILE)
 )
-public class GoProjectLibrariesService extends GoLibrariesService<GoLibrariesState> {
-  public static GoProjectLibrariesService getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, GoProjectLibrariesService.class);
+public class GoModulePackagesService extends GoPathService<GoPathState> {
+  public static GoModulePackagesService getInstance(@NotNull Module module) {
+    return ModuleServiceManager.getService(module, GoModulePackagesService.class);
   }
 }

--- a/src/com/goide/project/GoProjectPackagesService.java
+++ b/src/com/goide/project/GoProjectPackagesService.java
@@ -17,20 +17,20 @@
 package com.goide.project;
 
 import com.goide.GoConstants;
-import com.goide.GoLibrariesState;
-import com.intellij.openapi.components.State;
-import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.components.StoragePathMacros;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleServiceManager;
+import com.goide.GoPathState;
+import com.intellij.openapi.components.*;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 @State(
   name = GoConstants.GO_LIBRARIES_SERVICE_NAME,
-  storages = @Storage(file = StoragePathMacros.MODULE_FILE)
+  storages = {
+    @Storage(id = "default", file = StoragePathMacros.PROJECT_FILE),
+    @Storage(id = "dir", file = StoragePathMacros.PROJECT_CONFIG_DIR + "/" + GoConstants.GO_LIBRARIES_CONFIG_FILE, scheme = StorageScheme.DIRECTORY_BASED)
+  }
 )
-public class GoModuleLibrariesService extends GoLibrariesService<GoLibrariesState> {
-  public static GoModuleLibrariesService getInstance(@NotNull Module module) {
-    return ModuleServiceManager.getService(module, GoModuleLibrariesService.class);
+public class GoProjectPackagesService extends GoPathService<GoPathState> {
+  public static GoProjectPackagesService getInstance(@NotNull Project project) {
+    return ServiceManager.getService(project, GoProjectPackagesService.class);
   }
 }

--- a/src/com/goide/sdk/GoSdkUtil.java
+++ b/src/com/goide/sdk/GoSdkUtil.java
@@ -19,8 +19,8 @@ package com.goide.sdk;
 import com.goide.GoConstants;
 import com.goide.GoEnvironmentUtil;
 import com.goide.appengine.YamlFilesModificationTracker;
-import com.goide.project.GoApplicationLibrariesService;
-import com.goide.project.GoLibrariesService;
+import com.goide.project.GoApplicationPackagesService;
+import com.goide.project.GoPathService;
 import com.goide.psi.GoFile;
 import com.goide.util.GoUtil;
 import com.intellij.execution.configurations.PathEnvironmentVariableUtil;
@@ -129,10 +129,10 @@ public class GoSdkUtil {
   @NotNull
   private static Collection<VirtualFile> getGoPathRoots(@NotNull Project project, @Nullable Module module) {
     Collection<VirtualFile> roots = ContainerUtil.newArrayList();
-    if (GoApplicationLibrariesService.getInstance().isUseGoPathFromSystemEnvironment()) {
+    if (GoApplicationPackagesService.getInstance().isUseGoPathFromSystemEnvironment()) {
       roots.addAll(getGoPathsRootsFromEnvironment());
     }
-    roots.addAll(module != null ? GoLibrariesService.getUserDefinedLibraries(module) : GoLibrariesService.getUserDefinedLibraries(project));
+    roots.addAll(module != null ? GoPathService.getUserDefinedLibraries(module) : GoPathService.getUserDefinedLibraries(project));
     return roots;
   }
 
@@ -370,7 +370,7 @@ public class GoSdkUtil {
 
   @NotNull
   public static Collection<Object> getSdkAndLibrariesCacheDependencies(@NotNull Project project, @Nullable Module module, Object... extra) {
-    Collection<Object> dependencies = ContainerUtil.<Object>newArrayList(GoLibrariesService.getModificationTrackers(project, module));
+    Collection<Object> dependencies = ContainerUtil.<Object>newArrayList(GoPathService.getModificationTrackers(project, module));
     ContainerUtil.addAllNotNull(dependencies, GoSdkService.getInstance(project));
     ContainerUtil.addAllNotNull(dependencies, extra);
     return dependencies;

--- a/tests/com/goide/GoCodeInsightFixtureTestCase.java
+++ b/tests/com/goide/GoCodeInsightFixtureTestCase.java
@@ -16,7 +16,7 @@
 
 package com.goide;
 
-import com.goide.project.GoApplicationLibrariesService;
+import com.goide.project.GoApplicationPackagesService;
 import com.goide.sdk.GoSdkType;
 import com.goide.sdk.GoSdkUtil;
 import com.intellij.openapi.application.ApplicationManager;
@@ -41,7 +41,7 @@ abstract public class GoCodeInsightFixtureTestCase extends LightPlatformCodeInsi
   @Override
   protected void tearDown() throws Exception {
     try {
-      GoApplicationLibrariesService.getInstance().setLibraryRootUrls();
+      GoApplicationPackagesService.getInstance().setLibraryRootUrls();
     }
     finally {
       super.tearDown();

--- a/tests/com/goide/codeInsight/imports/GoImportOptimizerTest.java
+++ b/tests/com/goide/codeInsight/imports/GoImportOptimizerTest.java
@@ -17,7 +17,7 @@
 package com.goide.codeInsight.imports;
 
 import com.goide.GoCodeInsightFixtureTestCase;
-import com.goide.project.GoModuleLibrariesService;
+import com.goide.project.GoModulePackagesService;
 import com.intellij.codeInsight.actions.OptimizeImportsAction;
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.application.ApplicationManager;
@@ -58,7 +58,7 @@ public class GoImportOptimizerTest extends GoCodeInsightFixtureTestCase {
         return pack;
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getUrl());
     doTest(); 
   }
 

--- a/tests/com/goide/completion/GoCompletionTestBase.java
+++ b/tests/com/goide/completion/GoCompletionTestBase.java
@@ -17,7 +17,7 @@
 package com.goide.completion;
 
 import com.goide.GoCodeInsightFixtureTestCase;
-import com.goide.project.GoModuleLibrariesService;
+import com.goide.project.GoModulePackagesService;
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.codeInsight.lookup.Lookup;
 import com.intellij.codeInsight.lookup.LookupElement;
@@ -36,7 +36,7 @@ public abstract class GoCompletionTestBase extends GoCodeInsightFixtureTestCase 
   protected void setUp() throws Exception {
     super.setUp();
     String url = myFixture.getTempDirFixture().getFile("..").getUrl();
-    GoModuleLibrariesService.getInstance(myModule).setLibraryRootUrls(url);
+    GoModulePackagesService.getInstance(myModule).setLibraryRootUrls(url);
   }
 
   @Override

--- a/tests/com/goide/coverage/GoCoverageCalculationTest.java
+++ b/tests/com/goide/coverage/GoCoverageCalculationTest.java
@@ -17,7 +17,7 @@
 package com.goide.coverage;
 
 import com.goide.GoCodeInsightFixtureTestCase;
-import com.goide.project.GoModuleLibrariesService;
+import com.goide.project.GoModulePackagesService;
 import com.goide.runconfig.testing.coverage.GoCoverageAnnotator;
 import com.goide.runconfig.testing.coverage.GoCoverageProjectData;
 import com.goide.runconfig.testing.coverage.GoCoverageRunner;
@@ -33,7 +33,7 @@ public class GoCoverageCalculationTest extends GoCodeInsightFixtureTestCase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    GoModuleLibrariesService.getInstance(myModule).setLibraryRootUrls(getRoot().getUrl());
+    GoModulePackagesService.getInstance(myModule).setLibraryRootUrls(getRoot().getUrl());
   }
 
   public void testCoverage() throws IOException {

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -18,7 +18,7 @@ package com.goide.inspections;
 
 import com.goide.GoCodeInsightFixtureTestCase;
 import com.goide.inspections.unresolved.*;
-import com.goide.project.GoModuleLibrariesService;
+import com.goide.project.GoModulePackagesService;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -121,7 +121,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
     myFixture.getTempDirFixture().createFile("root1/src/to_import/unique/foo.go", "package unique; func Foo() {}");
     myFixture.getTempDirFixture().findOrCreateDir("root1/src/to_import/shared");
     myFixture.getTempDirFixture().findOrCreateDir("root2/src/to_import/shared");
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(root1.getUrl(), root2.getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(root1.getUrl(), root2.getUrl());
     doTest();
   }
 
@@ -223,7 +223,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                         "package pack2_test; import \"testing\"; func TestTest(t *testing.T) {<error>pack1_test</error>.Test()}");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }
@@ -237,7 +237,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                         "package pack2_test; import `pack1`; import \"testing\"; func TestTest(t *testing.T) {pack1_test.Test()}");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }
@@ -289,7 +289,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                  "package main; import p \"pack1\"; import <error>p \"pack2\"</error>; func main() { p.Foo() }");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }
@@ -303,7 +303,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                         "package main; import \"pack\"; import <error>\"pack\"</error>; func main() { pack.Foo() }");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }
@@ -318,7 +318,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                         "package main; import \"a/pack\"; import <error>\"b/pack\"</error>; func main() { pack.Foo() }");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }
@@ -339,7 +339,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                         "package main; import \"a\"; import \"b\"; func main() { a.Foo(); b.Bar(); }");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }
@@ -356,7 +356,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
                                                         "package main; import _ \"a/pack\"; import _ \"b/pack\"; import . \"c/pack\"; import . \"d/pack\"; func main() { Bar(); Baz() }");
       }
     });
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(file.getParent().getParent().getUrl());
     myFixture.configureFromExistingVirtualFile(file);
     myFixture.checkHighlighting();
   }

--- a/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
+++ b/tests/com/goide/psi/legacy/GoLegacyResolveTestBase.java
@@ -17,7 +17,7 @@
 package com.goide.psi.legacy;
 
 import com.goide.GoCodeInsightFixtureTestCase;
-import com.goide.project.GoModuleLibrariesService;
+import com.goide.project.GoModulePackagesService;
 import com.goide.psi.GoFile;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.vfs.VfsUtilCore;
@@ -69,7 +69,7 @@ public abstract class GoLegacyResolveTestBase extends GoCodeInsightFixtureTestCa
       }
     }
     VirtualFile dirToTest = myFixture.getTempDirFixture().getFile(".");
-    GoModuleLibrariesService.getInstance(myFixture.getModule()).setLibraryRootUrls(dirToTest.getUrl());
+    GoModulePackagesService.getInstance(myFixture.getModule()).setLibraryRootUrls(dirToTest.getUrl());
     doDirectoryTest(dirToTest);
   }
 

--- a/tests/com/goide/runconfig/GoConsoleFilterTest.java
+++ b/tests/com/goide/runconfig/GoConsoleFilterTest.java
@@ -17,7 +17,7 @@
 package com.goide.runconfig;
 
 import com.goide.GoCodeInsightFixtureTestCase;
-import com.goide.project.GoApplicationLibrariesService;
+import com.goide.project.GoApplicationPackagesService;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
@@ -39,7 +39,7 @@ public class GoConsoleFilterTest extends GoCodeInsightFixtureTestCase {
     super.setUp();
     VirtualFile workingDirectory = createTestRoot("workingDirectory");
     VirtualFile goPath = createTestRoot("goPath");
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(goPath.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(goPath.getUrl());
     myFilter = new GoConsoleFilter(myFixture.getProject(), myFixture.getModule(), workingDirectory.getUrl());
   }
 

--- a/tests/com/goide/sdk/GoPathLibraryTest.java
+++ b/tests/com/goide/sdk/GoPathLibraryTest.java
@@ -18,8 +18,8 @@ package com.goide.sdk;
 
 import com.goide.GoCodeInsightFixtureTestCase;
 import com.goide.GoModuleType;
-import com.goide.project.GoApplicationLibrariesService;
-import com.goide.project.GoModuleLibrariesInitializer;
+import com.goide.project.GoApplicationPackagesService;
+import com.goide.project.GoModulePackagesInitializer;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -54,7 +54,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    GoModuleLibrariesInitializer.setTestingMode(getTestRootDisposable());
+    GoModulePackagesInitializer.setTestingMode(getTestRootDisposable());
   }
 
   /**
@@ -66,7 +66,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
   public void testAddGoPathAsLibrary() throws IOException {
     VirtualFile goPath = VfsUtil.findFileByIoFile(FileUtil.createTempDirectory("go", "path"), true);
     VirtualFile goPathContent = goPath.createChildDirectory(this, "src").createChildData(this, "test.go");
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(goPath.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(goPath.getUrl());
     assertLibrary(Collections.singletonList(goPathContent.getUrl()), "temp:///src");
   }
 
@@ -83,7 +83,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
     VirtualFile contentRoot = src.createChildDirectory(this, "contentRoot");
     VirtualFile notContentRoot = src.createChildDirectory(this, "notContentRoot");
     addContentRoot(contentRoot);
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(goPath.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(goPath.getUrl());
     assertLibrary(Collections.singletonList(notContentRoot.getUrl()), "temp:///src", contentRoot.getUrl());
   }
 
@@ -106,7 +106,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
     VirtualFile otherGoPathContent = otherGoPath.createChildDirectory(this, "src").createChildData(this, "test.go");
 
     addContentRoot(contentRoot);
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(goPath.getUrl(), otherGoPath.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(goPath.getUrl(), otherGoPath.getUrl());
     assertLibrary(Collections.singletonList(otherGoPathContent.getUrl()), "temp:///src", contentRoot.getUrl());
   }
 
@@ -122,7 +122,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
     VirtualFile src = goPath.createChildDirectory(this, "src");
     VirtualFile testData = src.createChildDirectory(this, "testdata");
     VirtualFile notTestData = src.createChildDirectory(this, "notTestdata");
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(goPath.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(goPath.getUrl());
     assertLibrary(Arrays.asList(testData.getUrl(), notTestData.getUrl()), "temp:///src", testData.getUrl());
   }
 
@@ -137,7 +137,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
     VirtualFile goPath = VfsUtil.findFileByIoFile(FileUtil.createTempDirectory("go", "path"), true);
     VirtualFile goPathContent = goPath.createChildDirectory(this, "src").createChildDirectory(this, "subdir");
 
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(goPath.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(goPath.getUrl());
     assertLibrary(Collections.singletonList(goPathContent.getUrl()), "temp:///src");
 
     VirtualFile contentRoot = goPathContent.createChildDirectory(this, "contentRoot");
@@ -155,7 +155,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
   public void testUpdateLibraryOnAddingDataToExistingGoPath() throws IOException {
     VirtualFile file = VfsUtil.findFileByIoFile(FileUtil.createTempDirectory("go", "test"), true);
     VirtualFile subdir = file.createChildDirectory(this, "src").createChildDirectory(this, "subdir");
-    GoApplicationLibrariesService.getInstance().setLibraryRootUrls(file.getUrl());
+    GoApplicationPackagesService.getInstance().setLibraryRootUrls(file.getUrl());
     assertLibrary(Collections.singletonList(subdir.getUrl()), "temp:///src");
 
     VirtualFile newDirectory = subdir.createChildDirectory(this, "testdata");
@@ -176,7 +176,7 @@ public class GoPathLibraryTest extends GoCodeInsightFixtureTestCase {
   private void assertLibrary(Collection<String> libUrls, String... exclusionUrls) {
     UIUtil.dispatchAllInvocationEvents();
 
-    GoModuleLibrariesInitializer initializer = myModule.getComponent(GoModuleLibrariesInitializer.class);
+    GoModulePackagesInitializer initializer = myModule.getComponent(GoModulePackagesInitializer.class);
     ModuleRootManager model = ModuleRootManager.getInstance(myModule);
     LibraryOrderEntry libraryOrderEntry = OrderEntryUtil.findLibraryOrderEntry(model, initializer.getLibraryName());
     if (libUrls.isEmpty()) {

--- a/utils/src/com/goide/GoPathState.java
+++ b/utils/src/com/goide/GoPathState.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
-public class GoLibrariesState {
+public class GoPathState {
   @NotNull private Collection<String> myUrls = ContainerUtil.newArrayList();
 
   @NotNull


### PR DESCRIPTION
In the interest of not confusing people, I think we should call these `Go packages` rather that `libraries` as the term is better suited for the end-user.