### PR TITLE
When running build by TeamCity don't fail build if tests fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,9 @@ test {
     exceptionFormat = 'full'
   }
 }
+if (System.getenv("TEAMCITY_VERSION") != null) {
+    test.ignoreFailures = true
+}
 
 task preparePerformanceTestData << {
   downloadAndUnzip('https://storage.googleapis.com/golang/go1.4.2.src.tar.gz', 'go', 'go')


### PR DESCRIPTION
Since failed tests would be reported as problems, there would not be 'exit code 1' problem, and build artifacts (plugin.zip) would be build and published as artifact.
So it would be possible to download plugin even if some tests failed.