### PR TITLE
Run go install before gotype (fixes #1990)

### DIFF
--- a/src/com/goide/actions/tool/GoTypeFileAction.java
+++ b/src/com/goide/actions/tool/GoTypeFileAction.java
@@ -23,6 +23,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
+
 public class GoTypeFileAction extends GoDownloadableFileAction {
   public GoTypeFileAction() {
     super("gotype", "golang.org/x/tools/cmd/gotype");
@@ -38,6 +40,19 @@ public class GoTypeFileAction extends GoDownloadableFileAction {
   protected GoExecutor createExecutor(@NotNull Project project, @Nullable Module module, @NotNull String title, @NotNull String filePath) {
     VirtualFile executable = getExecutable(project, module);
     assert executable != null;
+
+    File file = new File(filePath);
+    final String dirName;
+    if (file.isDirectory()) {
+      dirName = filePath;
+    }
+    else {
+      dirName = file.getParent();
+    }
+
+    GoExecutor.in(project, module).withPresentableName("go install .")
+      .withParameters("install", ".").withWorkDirectory(dirName)
+      .showNotifications(false).executeWithProgress(false);
     return GoExecutor.in(project, module).withExePath(executable.getPath()).withParameters("-e", "-a", "-v", filePath).showOutputOnError();
   }
 }


### PR DESCRIPTION
In order for `gotype` to work, `go install` has to be run at least once on the package. As such, this PR makes it possible to run it once and then runs `gotype`.