### PR TITLE
add an inspection for StructTag

### DIFF
--- a/gen/com/goide/parser/GoParser.java
+++ b/gen/com/goide/parser/GoParser.java
@@ -3567,14 +3567,13 @@ public class GoParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // string | raw_string
+  // StringLiteral
   public static boolean Tag(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "Tag")) return false;
     if (!nextTokenIs(b, "<tag>", RAW_STRING, STRING)) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, "<tag>");
-    r = consumeToken(b, STRING);
-    if (!r) r = consumeToken(b, RAW_STRING);
+    r = StringLiteral(b, l + 1);
     exit_section_(b, l, m, TAG, r, false, null);
     return r;
   }

--- a/gen/com/goide/psi/GoTag.java
+++ b/gen/com/goide/psi/GoTag.java
@@ -7,10 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface GoTag extends GoCompositeElement {
 
-  @Nullable
-  PsiElement getRawString();
-
-  @Nullable
-  PsiElement getString();
+  @NotNull
+  GoStringLiteral getStringLiteral();
 
 }

--- a/gen/com/goide/psi/impl/GoTagImpl.java
+++ b/gen/com/goide/psi/impl/GoTagImpl.java
@@ -22,15 +22,9 @@ public class GoTagImpl extends GoCompositeElementImpl implements GoTag {
   }
 
   @Override
-  @Nullable
-  public PsiElement getRawString() {
-    return findChildByType(RAW_STRING);
-  }
-
-  @Override
-  @Nullable
-  public PsiElement getString() {
-    return findChildByType(STRING);
+  @NotNull
+  public GoStringLiteral getStringLiteral() {
+    return findNotNullChildByClass(GoStringLiteral.class);
   }
 
 }

--- a/grammars/go.bnf
+++ b/grammars/go.bnf
@@ -138,7 +138,7 @@ AnonymousFieldDefinition ::= '*'? TypeName {
   stubClass="com.goide.stubs.GoAnonymousFieldDefinitionStub"
   methods=[getIdentifier getName getTextOffset getGoTypeInner]
 }
-Tag ::= string | raw_string
+Tag ::= StringLiteral
 
 PointerType ::= '*' Type {pin=1}
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -244,6 +244,9 @@
     <localInspection language="go" displayName="Self import"
                      groupName="Go" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoSelfImportInspection" />
+    <localInspection language="go" displayName="Malformed struct tag"
+                     groupName="Go" enabledByDefault="true" level="WARNING"
+                     implementationClass="com.goide.inspections.GoStructTagInspection"/>
   </extensions>
   <actions>
     <action id="Go.NewGoFile" class="com.goide.actions.GoCreateFileAction"

--- a/resources/inspectionDescriptions/GoStructTag.html
+++ b/resources/inspectionDescriptions/GoStructTag.html
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+<body>
+Verifies that struct tags conform to <a href="https://golang.org/pkg/reflect/#StructTag">Go conventions</a>.
+
+<p>
+According to these conventions, tag strings are a concatenation of optionally space-separated key:"value" pairs. Each
+key is a non-empty string consisting of non-control characters other than space (U+0020 ' '), quote (U+0022 '"'), and
+colon (U+003A ':'). Each value is quoted using U+0022 '"' characters and Go string literal syntax.
+</p>
+</body>
+</html>

--- a/src/com/goide/inspections/GoStructTagInspection.java
+++ b/src/com/goide/inspections/GoStructTagInspection.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.GoFieldDeclaration;
+import com.goide.psi.GoStructType;
+import com.goide.psi.GoTag;
+import com.goide.psi.GoVisitor;
+import com.goide.psi.impl.GoPsiImplUtil;
+import com.goide.util.GoStringLiteralEscaper;
+import com.intellij.codeInspection.LocalInspectionToolSession;
+import com.intellij.codeInspection.ProblemsHolder;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Implements <a href="https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/1983"/>, an
+ * inspector that warns if a go StructTag is not well-formed according to Go language conventions.
+ */
+public class GoStructTagInspection extends GoInspectionBase {
+  @NotNull
+  @Override
+  protected GoVisitor buildGoVisitor(@NotNull final ProblemsHolder holder,
+                                     @SuppressWarnings({"UnusedParameters", "For future"}) @NotNull LocalInspectionToolSession session) {
+    return new GoVisitor() {
+      @Override
+      public void visitStructType(@NotNull GoStructType o) {
+        for (GoFieldDeclaration field : o.getFieldDeclarationList()) {
+          if (field.getTag() == null) {
+            continue;
+          }
+          if (!isValidTag(field.getTag())) {
+            holder.registerProblem(field.getTag(), "Bad syntax for struct tag value");
+          }
+        }
+      }
+    };
+  }
+
+  // Implementation based on validateStructTag from the go vet tool:
+  // https://github.com/golang/tools/blob/master/cmd/vet/structtag.go.
+  private boolean isValidTag(GoTag tag) {
+    StringBuilder tagText = new StringBuilder(GoPsiImplUtil.unquote(tag.getText()));
+    if (tagText.length() != tag.getText().length() - 2) {
+      // In this case, the tag was not quoted and therefore is invalid.
+      return false;
+    }
+    while (tagText.length() > 0) {
+      int i;
+      i = 0;
+
+      // Skip leading spaces.
+      while (i < tagText.length() && tagText.charAt(i) == ' ') {
+        i++;
+      }
+
+      tagText.delete(0, i);
+      if (tagText.length() == 0) {
+        return true;
+      }
+
+      // Scan to colon. A space, a quote or a control character is a syntax error.
+      // Strictly speaking, control chars include the range [0x7f, 0x9f], not just
+      // [0x00, 0x1f], but in practice, we ignore the multi-byte control characters
+      // as it is simpler to inspect the tag's bytes than the tag's runes.
+      i = 0;
+      while (i < tagText.length() &&
+             tagText.charAt(i) > ' ' &&
+             tagText.charAt(i) != ':' &&
+             tagText.charAt(i) != '"' &&
+             tagText.charAt(i) != 0x7f) {
+        i++;
+      }
+      if (i == 0 || (i + 1) > tagText.length() || tagText.charAt(i) != ':') {
+        return false;
+      }
+      tagText.delete(0, i + 1);
+
+      // Scan quoted string to find value.
+      i = 1;
+      while (i < tagText.length() && tagText.charAt(i) != '"') {
+        if (tagText.charAt(i) == '\\') {
+          i++;
+        }
+        i++;
+      }
+
+      if (i >= tagText.length()) {
+        return false;
+      }
+
+      String unquotedValue = GoPsiImplUtil.unquote(tagText.substring(0, i + 1));
+      if (unquotedValue.length() != i - 1) {
+        // The value was not correctly quoted (two quote chars were not removed by unquote).
+        // TODO(sjr): this check is not equivalent to strconv.Unquote, so this inspector is
+        // more lenient than the go vet tool.
+        return false;
+      }
+
+      tagText.delete(0, i + 1);
+    }
+
+    return true;
+  }
+}

--- a/testData/highlighting/structTags.go
+++ b/testData/highlighting/structTags.go
@@ -1,0 +1,15 @@
+package demo
+
+type demoBrokenTags struct {
+	CorrectMultipleTags string `json:"demo,something,something" dark:"side"`
+	CorrectSingleTag    string `json:"demo,something,something"`
+	WrongTag1           string <warning>`json: "demo"`</warning>
+	WrongTag2           string <warning>`json:"demo`</warning>
+	WrongTag3           string <warning>`json:demo`</warning>
+	WrongTag4           string <warning>` json:demo`</warning>
+	WrongTag5           string <warning>"json:demo"</warning>
+	WrongTag6           string <warning>"json:'demo'"</warning>
+	WrongTag7           string <warning>`json:"demo"; bson:"demo"`</warning>
+	WrongTag8			string <warning>`
+}
+</warning><EOLError></EOLError>

--- a/testData/parser/Simple.txt
+++ b/testData/parser/Simple.txt
@@ -1571,7 +1571,8 @@ GO_FILE
               TYPE_REFERENCE_EXPRESSION
                 PsiElement(identifier)('string')
             TAG
-              PsiElement(raw_string)('`xml:""`')
+              STRING_LITERAL
+                PsiElement(raw_string)('`xml:""`')
           PsiElement(})('}')
   FUNCTION_DECLARATION
     PsiElement(func)('func')

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -54,7 +54,8 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
       GoMultiplePackagesInspection.class,
       GoCgoInTestInspection.class,
       GoTestSignaturesInspection.class,
-      GoAssignmentNilWithoutExplicitTypeInspection.class
+      GoAssignmentNilWithoutExplicitTypeInspection.class,
+      GoStructTagInspection.class
     );
   }
 
@@ -111,6 +112,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testMethodExpr()  { doTest(); }
   public void testVarToImport() { doTest(); }
   public void testCgotest()     { doTest(); }
+  public void testStructTags()  { doTest(); }
 
   public void testRelativeImportIgnoringDirectories() throws IOException {
     myFixture.getTempDirFixture().findOrCreateDir("to_import/testdata");


### PR DESCRIPTION
This is an incomplete implementation of
https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/1983. It will
raise warnings if it detects a tag value that does not conform to the Go
StructTag convention described by https://golang.org/pkg/reflect/#StructTag.

Currently, the inspector does not validate that the tag value strings are valid
and is therefore overly permissive.

Its implementation is essentially ported from validateStructTag in
https://github.com/golang/tools/blob/master/cmd/vet/structtag.go.