### PR TITLE
Add 'replace with return' quick fix

### DIFF
--- a/src/com/goide/psi/impl/GoElementFactory.java
+++ b/src/com/goide/psi/impl/GoElementFactory.java
@@ -39,6 +39,12 @@ public class GoElementFactory {
   }
 
   @NotNull
+  public static PsiElement createReturnStatement(@NotNull Project project) {
+    GoFile file = createFileFromText(project, "package main\nfunc _() { return; }");
+    return PsiTreeUtil.findChildOfType(file, GoReturnStatement.class);
+  }
+
+  @NotNull
   public static PsiElement createIdentifierFromText(@NotNull Project project, String text) {
     GoFile file = createFileFromText(project, "package " + text);
     return file.getPackage().getIdentifier();

--- a/testData/quickfixes/continue-outside-loop/simple-after.go
+++ b/testData/quickfixes/continue-outside-loop/simple-after.go
@@ -1,0 +1,5 @@
+package continue_outside_loop
+
+func _() {
+	return
+}

--- a/testData/quickfixes/continue-outside-loop/simple.go
+++ b/testData/quickfixes/continue-outside-loop/simple.go
@@ -1,0 +1,5 @@
+package continue_outside_loop
+
+func _() {
+	c<caret>ontinue
+}

--- a/tests/com/goide/quickfix/GoContinueNotInLoopQuickFixTest.java
+++ b/tests/com/goide/quickfix/GoContinueNotInLoopQuickFixTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.quickfix;
+
+import com.goide.inspections.GoContinueNotInLoopInspection;
+import com.goide.inspections.GoRenameToBlankQuickFix;
+import org.jetbrains.annotations.NotNull;
+
+public class GoContinueNotInLoopQuickFixTest extends GoQuickFixTestBase {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    myFixture.enableInspections(GoContinueNotInLoopInspection.class);
+  }
+
+  @NotNull
+  @Override
+  protected String getBasePath() {
+    return "quickfixes/continue-outside-loop";
+  }
+
+  public void testSimple()      { doTest(GoContinueNotInLoopInspection.QUICK_FIX_NAME);      }
+}


### PR DESCRIPTION
This change adds a 'replace with return' quick fix and addresses
https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/2002.

Not sure if this is a worthwhile quickfix (not hard to just type 'return')...