### PR TITLE
Use symlinked path for breakpoints (fix #1880)

### DIFF
--- a/src/com/goide/dlv/DlvDebugProcess.java
+++ b/src/com/goide/dlv/DlvDebugProcess.java
@@ -264,7 +264,7 @@ public final class DlvDebugProcess extends DebugProcessImpl<RemoteVmConnection> 
       if (breakpointPosition == null) return;
       VirtualFile file = breakpointPosition.getFile();
       int line = breakpointPosition.getLine();
-      send(new DlvRequest.CreateBreakpoint(file.getCanonicalPath(), line + 1))
+      send(new DlvRequest.CreateBreakpoint(file.getPath(), line + 1))
         .done(new Consumer<Breakpoint>() {
           @Override
           public void consume(@NotNull Breakpoint b) {


### PR DESCRIPTION
Go won't store the target path of the symlink, so for example if the file is in `/home/florin/golang/src/github.com/dlsniper/u/demo/dbg/demo1/demo1.go` and the project is under `/home/florin/demo1` which points to `/home/florin/golang/src/github.com/dlsniper/u/demo/dbg/demo1` then when building `/home/florin/demo1` then the Go compiler will store the `/home/florin/demo1/demo1.go` not `/home/florin/golang/src/github.com/dlsniper/u/demo/dbg/demo1/demo1.go`. I'm sorry I can't explain it better, but this PR fixes the issue described in #1880 (I've tested locally for it). Thank you.