### PR TITLE
Add inspection for using defer in a for loop (fixes #1776)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -226,6 +226,9 @@
     <localInspection language="go" displayName="Used as value in condition"
                      groupName="Control flow issues" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoUsedAsValueInCondition"/>
+    <localInspection language="go" displayName="Defer in loop"
+                     groupName="Control flow issues" enabledByDefault="true" level="WEAK WARNING"
+                     implementationClass="com.goide.inspections.GoDeferInLoop"/>
     <!-- /control flow issues -->
 
     <!-- general -->

--- a/resources/inspectionDescriptions/GoDeferInLoop.html
+++ b/resources/inspectionDescriptions/GoDeferInLoop.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+<body>
+Checks if there are no calls to defer in loops
+</body>
+</html>

--- a/src/com/goide/inspections/GoDeferInLoop.java
+++ b/src/com/goide/inspections/GoDeferInLoop.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.*;
+import com.intellij.codeInspection.LocalInspectionToolSession;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class GoDeferInLoop extends GoInspectionBase {
+  @NotNull
+  @Override
+  protected GoVisitor buildGoVisitor(@NotNull final ProblemsHolder holder, @NotNull LocalInspectionToolSession session) {
+    return new GoVisitor() {
+      @Override
+      public void visitDeferStatement(@NotNull GoDeferStatement o) {
+        PsiElement parent = PsiTreeUtil
+          .getParentOfType(o, GoForStatement.class, GoFunctionLit.class);
+
+        if (parent instanceof GoForStatement) {
+          holder.registerProblem(o, "Possible resource leak, \"defer\" is called in a for loop.", ProblemHighlightType.WEAK_WARNING);
+        }
+      }
+    };
+  }
+}

--- a/testData/highlighting/deferInLoop.go
+++ b/testData/highlighting/deferInLoop.go
@@ -1,0 +1,33 @@
+package deferinloop
+
+func noop() {}
+
+func (a int) meth() {
+	for {
+		<weak_warning descr="Possible resource leak, \"defer\" is called in a for loop.">defer noop()</weak_warning>
+	}
+}
+
+func _() {
+	for {
+		func (){
+			defer noop()
+		}()
+	}
+
+	func (){
+		defer noop()
+	}()
+
+	for {
+		switch 1 {
+		case 2: <weak_warning descr="Possible resource leak, \"defer\" is called in a for loop.">defer noop()</weak_warning>;
+		}
+	}
+
+	defer noop();
+	for {
+		<weak_warning descr="Possible resource leak, \"defer\" is called in a for loop.">defer noop()</weak_warning>
+	}
+}
+

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -57,7 +57,8 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
       GoRedeclareImportAsFunctionInspection.class,
       GoStructTagInspection.class,
       GoContinueNotInLoopInspection.class,
-      GoUsedAsValueInCondition.class
+      GoUsedAsValueInCondition.class,
+      GoDeferInLoop.class
     );
   }
 
@@ -286,6 +287,10 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testCGOImportInTestFile() {
     myFixture.configureByText("a_test.go", "package a; import<error>\"C\"</error>; import<error>\"C\"</error>;");
     myFixture.checkHighlighting();
+  }
+
+  public void testDeferInLoop() {
+    myFixture.testHighlighting(true, false, true, getTestName(true) + ".go");
   }
 
   public void testCGOImportInNonTestFile() {


### PR DESCRIPTION
This adds the inspection that checks if a defer is called inside a for loop (which could potentially cause a resource leak).