### PR TITLE
fix 'continue not in a loop' inspector

### DIFF
--- a/src/com/goide/inspections/GoContinueNotInLoopInspection.java
+++ b/src/com/goide/inspections/GoContinueNotInLoopInspection.java
@@ -18,6 +18,7 @@ package com.goide.inspections;
 
 import com.goide.psi.GoContinueStatement;
 import com.goide.psi.GoForStatement;
+import com.goide.psi.GoFunctionLit;
 import com.goide.psi.GoVisitor;
 import com.goide.psi.impl.GoElementFactory;
 import com.intellij.codeInspection.*;
@@ -39,9 +40,9 @@ public class GoContinueNotInLoopInspection extends GoInspectionBase {
     return new GoVisitor() {
       @Override
       public void visitContinueStatement(@NotNull GoContinueStatement o) {
-        if (PsiTreeUtil.getParentOfType(o, GoForStatement.class) == null) {
-          holder.registerProblem(o, "Continue statement not inside a for loop.", ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
-                                 new ReplaceWithReturnQuickFix());
+        if (!(PsiTreeUtil.getParentOfType(o, GoForStatement.class, GoFunctionLit.class) instanceof GoForStatement)) {
+          holder.registerProblem(o, "Continue statement not inside a for loop.",
+                                 ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new ReplaceWithReturnQuickFix());
         }
       }
     };

--- a/testData/highlighting/continue.go
+++ b/testData/highlighting/continue.go
@@ -5,6 +5,10 @@ import "fmt"
 func _() {
 	for i := 0; i < 10; i++ {
 		fmt.Printf("%d\n", i)
+		f := func() {
+			<error>continue</error>
+		}
+        f()
 		continue
 	}
 
@@ -12,5 +16,17 @@ func _() {
 
 	if 1 > 0 {
 		<error>continue</error>
+	}
+
+    for i := 0; i < 10; i++ {
+		defer func() {
+			<error>continue</error>
+		}()
+
+		go func() {
+			<error>continue</error>
+		}()
+
+		continue
 	}
 }


### PR DESCRIPTION
Previously the inspector would look for the presence of a GoForStatement
parent of a continue statement. This did not take into account the
presence of 'go' or 'defer' calls, e.g.

```go
for {
    defer func() {
        continue // no error was raised, should be an error
    }()
}
```

The discussion at
https://github.com/go-lang-plugin-org/go-lang-idea-plugin/pull/2024
reminded me that the continue inspection suffers from this problem.