### PR TITLE
Highlight exit points of a function when cursor is on `func`

### DIFF
--- a/src/com/goide/highlighting/GoHighlightExitPointsHandlerFactory.java
+++ b/src/com/goide/highlighting/GoHighlightExitPointsHandlerFactory.java
@@ -99,9 +99,7 @@ public class GoHighlightExitPointsHandlerFactory extends HighlightUsagesHandlerF
         LeafPsiElement leaf = (LeafPsiElement)element;
         return leaf.getElementType() == GoTypes.RETURN || leaf.getElementType() == GoTypes.FUNC || isPanicCall(leaf);
       }
-      else {
-        return false;
-      }
+      return false;
     }
 
     private static boolean isPanicCall(@NotNull PsiElement e) {

--- a/src/com/goide/highlighting/GoHighlightExitPointsHandlerFactory.java
+++ b/src/com/goide/highlighting/GoHighlightExitPointsHandlerFactory.java
@@ -63,6 +63,9 @@ public class GoHighlightExitPointsHandlerFactory extends HighlightUsagesHandlerF
 
     @Override
     public void computeUsages(List<PsiElement> targets) {
+      if (myTarget instanceof LeafPsiElement && ((LeafPsiElement)myTarget).getElementType() == GoTypes.FUNC) {
+        addOccurrence(myTarget);
+      }
       new GoRecursiveVisitor() {
         @Override
         public void visitFunctionLit(@NotNull GoFunctionLit literal) {
@@ -85,10 +88,20 @@ public class GoHighlightExitPointsHandlerFactory extends HighlightUsagesHandlerF
     public static MyHandler createForElement(@NotNull Editor editor, PsiFile file, PsiElement element) {
       GoTypeOwner function = PsiTreeUtil.getParentOfType(element, GoFunctionLit.class, GoFunctionOrMethodDeclaration.class);
       if (function == null) return null;
-      if (element instanceof LeafPsiElement && ((LeafPsiElement)element).getElementType() == GoTypes.RETURN || isPanicCall(element)) {
+      if (shouldCreateMyHandler(element)) {
         return new MyHandler(editor, file, element, function);
       }
       return null;
+    }
+
+    private static boolean shouldCreateMyHandler(PsiElement element) {
+      if (element instanceof LeafPsiElement) {
+        LeafPsiElement leaf = (LeafPsiElement)element;
+        return leaf.getElementType() == GoTypes.RETURN || leaf.getElementType() == GoTypes.FUNC || isPanicCall(leaf);
+      }
+      else {
+        return false;
+      }
     }
 
     private static boolean isPanicCall(@NotNull PsiElement e) {

--- a/tests/com/goide/editor/GoExitPointsHighlightingTest.java
+++ b/tests/com/goide/editor/GoExitPointsHighlightingTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.editor;
+
+import com.goide.GoCodeInsightFixtureTestCase;
+import com.intellij.codeInsight.highlighting.HighlightUsagesHandler;
+import com.intellij.codeInsight.highlighting.HighlightUsagesHandlerBase;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.testFramework.LightProjectDescriptor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class GoExitPointsHighlightingTest extends GoCodeInsightFixtureTestCase {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    setUpProjectSdk();
+  }
+
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return createMockProjectDescriptor();
+  }
+
+  public void testBasicExitPoints() {
+    String text = "package main;\n" +
+                  "func bar(x int) int {\n" +
+                  "  if (x < 10) {\n" +
+                  "    retur<caret>n -1" +
+                  "  }" +
+                  "  return x\n" +
+                  "}";
+    doTest(text, "return -1", "return x");
+  }
+
+  public void testCaretOnFuncWithReturnAndPanic() {
+    String text = "package main;\n" +
+                  "fun<caret>c bar(x int) int {\n" +
+                  "  if (9 < 10) {\n" +
+                  "    return -1" +
+                  "  }" +
+                  "  panic(x)\n" +
+                  "}";
+    doTest(text, "func", "return -1", "panic(x)");
+  }
+
+  public void testCaretOnFuncWithNoExitPoints() {
+    String text = "package main\n" +
+                  "import \"fmt\"\n" +
+                  "f<caret>unc main() {\n" +
+                  "  fmt.Println(\"Hello, world!\"\n" +
+                  "}";
+    doTest(text, "func");
+  }
+
+  public void testCaretOnFuncOnType() {
+    String text = "package main\n" +
+                  "\n" +
+                  "type Demo struct {}\n" +
+                  "\n" +
+                  "f<caret>unc (a Demo) demo() int {\n" +
+                  "    return -1\n" +
+                  "}";
+    doTest(text, "func", "return -1");
+  }
+
+  private void doTest(@NotNull String text, String... usages) {
+    myFixture.configureByText("foo.go", text);
+    @SuppressWarnings("unchecked")
+    HighlightUsagesHandlerBase<PsiElement> handler = HighlightUsagesHandler.createCustomHandler(myFixture.getEditor(), myFixture.getFile());
+    assertNotNull(handler);
+    List<PsiElement> targets = handler.getTargets();
+    assertEquals(1, targets.size());
+
+    handler.computeUsages(targets);
+    List<TextRange> readUsages = handler.getReadUsages();
+    assertEquals(usages.length, readUsages.size());
+
+    List<String> textUsages = new ArrayList<String>();
+    for (TextRange usage : readUsages) {
+      String usageText = myFixture.getFile().getText().substring(usage.getStartOffset(), usage.getEndOffset());
+      textUsages.add(usageText);
+    }
+    assertSameElements(textUsages, Arrays.asList(usages));
+  }
+}


### PR DESCRIPTION
If cursor is on func keyword highlight all the exit points of this function (return and panic statements)

I don't know if this feature is really needed, it is up to you whether to accept this PR.
However, such highlighting is supported in Scala plugin for IDEA, and I find it to be really useful.

![func-cursor-screenshot](https://cloud.githubusercontent.com/assets/5924452/11322977/1e80aa84-9114-11e5-81c3-24ebfe3e0993.png)