### PR TITLE
Use covermode atomic for tests coverage (fixes #2037)

### DIFF
--- a/src/com/goide/runconfig/testing/GoTestRunningState.java
+++ b/src/com/goide/runconfig/testing/GoTestRunningState.java
@@ -118,7 +118,7 @@ public class GoTestRunningState extends GoRunningState<GoTestRunConfiguration> {
     }
 
     if (myCoverageFilePath != null) {
-      executor.withParameters("-coverprofile=" + myCoverageFilePath, "-covermode=count");
+      executor.withParameters("-coverprofile=" + myCoverageFilePath, "-covermode=atomic");
     }
 
     return executor;


### PR DESCRIPTION
I've tested this using `-race` both on and off and things still look ok.