### PR TITLE
Run go get for test packages and sub-packages

### DIFF
--- a/src/com/goide/codeInsight/imports/GoGetPackageFix.java
+++ b/src/com/goide/codeInsight/imports/GoGetPackageFix.java
@@ -36,7 +36,7 @@ public class GoGetPackageFix extends LocalQuickFixBase implements HighPriorityAc
   @NotNull private final String myPackage;
 
   public GoGetPackageFix(@NotNull String packageName) {
-    super("Go get '" + packageName + "'");
+    super("go get -t " + packageName + "/...");
     myPackage = packageName;
   }
 
@@ -63,8 +63,8 @@ public class GoGetPackageFix extends LocalQuickFixBase implements HighPriorityAc
             VirtualFileManager.getInstance().asyncRefresh(null);
           }
         };
-        GoExecutor.in(project, module).withPresentableName("go get " + packageName)
-          .withParameters("get", packageName).showNotifications(false).showOutputOnError()
+        GoExecutor.in(project, module).withPresentableName("go get -t " + packageName + "/...")
+          .withParameters("get", "-t", packageName+"/...").showNotifications(false).showOutputOnError()
           .executeWithProgress(!startInBackground, consumer);
       }
     });


### PR DESCRIPTION
As a start for fixing https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/2053, this allows for running `go get` for test packages and sub-packages as well.