### PR TITLE
Add an annotator check for type ref used as expr

### DIFF
--- a/src/com/goide/highlighting/GoAnnotator.java
+++ b/src/com/goide/highlighting/GoAnnotator.java
@@ -26,6 +26,7 @@ import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class GoAnnotator implements Annotator {
 
@@ -57,6 +58,14 @@ public class GoAnnotator implements Annotator {
           holder.createErrorAnnotation(element, "Use of package " + element.getText() + " without selector");
         }
       }
+      if (resolvedReference instanceof GoTypeSpec && isIllegalUseOfTypeAsExpression(reference)) {
+        holder.createErrorAnnotation(element, "Type " + element.getText() + " is not an expression.");
+      }
+    }
+    else if (element instanceof GoLiteralTypeExpr) {
+      if (isIllegalUseOfTypeAsExpression(element)) {
+        holder.createErrorAnnotation(element, "Type " + element.getText() + " is not an expression.");
+      }
     }
     else if (element instanceof GoCompositeLit) {
       GoCompositeLit literal = (GoCompositeLit)element;
@@ -68,5 +77,32 @@ public class GoAnnotator implements Annotator {
         }
       }
     }
+  }
+
+  /**
+   * Returns {@code true} if the given element is in an invalid location for a type literal or type reference.
+   */
+  private static boolean isIllegalUseOfTypeAsExpression(@NotNull PsiElement element) {
+    PsiElement parent = getParentSkippingParensAndUnaryExpr(element);
+
+    if (parent instanceof GoReferenceExpression || parent instanceof GoSelectorExpr) {
+      // Part of a selector such as T.method
+      return false;
+    }
+
+    if (parent instanceof GoCallExpr) {
+      // A situation like T("foo").
+      return false;
+    }
+
+    return true;
+  }
+
+  private static @Nullable PsiElement getParentSkippingParensAndUnaryExpr(PsiElement element) {
+    PsiElement parent = element.getParent();
+    while (parent instanceof GoParenthesesExpr || parent instanceof GoUnaryExpr) {
+      parent = parent.getParent();
+    }
+    return parent;
   }
 }

--- a/testData/highlighting/ranges.go
+++ b/testData/highlighting/ranges.go
@@ -3,7 +3,6 @@ package main
 import "fmt"
 
 func append1(slice []Type, elems ...Type) []Type
-func make1(Type, size int) Type
 type Type int
 type int int
 type string string
@@ -60,7 +59,7 @@ func main() {
     for _, <error descr="Unused variable 'd'">d</error> := range <error descr="Unresolved reference 'd'">d</error>.Packets {
     }
 }
-func create() []*Person {return make1([]*Person, 0)}
+func create() []*Person {return make([]*Person, 0)}
 
 type myStruct struct {
     MyVal bool

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -5,7 +5,16 @@ import fmt "<error descr="Cannot resolve file ''"></error>"
 import "net/http"
 import "io"
 
+func x(string) {}
+
 func  main() {
+    println(<error descr="Type []string is not an expression.">[]string</error>)
+    ((<error descr="Type string is not an expression.">string</error>))
+    x((string)("foo"))
+    x(<error descr="Type string is not an expression.">string</error> + <error descr="Type string is not an expression.">string</error>)
+    var b Boom
+    Boom.Run(b, aaa{})
+    <error descr="Type string is not an expression.">string</error>
 	test := <error descr="Unresolved reference 'test'">test</error>
 	Println(test)
 	test.<EOLError descr="'(', <expression> or identifier expected, got '}'"></EOLError>
@@ -540,4 +549,21 @@ func _() {
     var x map[string]string
     x = map[string]string{<error descr="Missing key in map literal">"a"</error>, <error descr="Missing key in map literal">"b"</error>}
     if len(x) > 2 {}
+}
+
+type someInterface interface{}
+
+func _() {
+    var x Boom
+    var y someInterface
+    y = x
+    if _, ok := y.(Boom); ok {
+
+    }
+    switch z := y.(type) {
+    case Boom:
+        z.Run(aaa{})
+    case *Boom:
+        z.Run(aaa{})
+    }
 }


### PR DESCRIPTION
Checks the following scenario:

```go
func foo() {
    string     // error: Type string is not an expression.
}
```

Partially addresses https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/1588.