### PR TITLE
add check that LHS of expr.(T) is interface type

### DIFF
--- a/src/com/goide/highlighting/GoAnnotator.java
+++ b/src/com/goide/highlighting/GoAnnotator.java
@@ -68,5 +68,16 @@ public class GoAnnotator implements Annotator {
         }
       }
     }
+    else if (element instanceof GoTypeAssertionExpr) {
+      GoType type = ((GoTypeAssertionExpr)element).getExpression().getGoType(null);
+      if (type != null) {
+        GoType baseType = GoPsiImplUtil.findBaseTypeFromRef(type.getTypeReferenceExpression());
+        if (baseType instanceof GoSpecType && !(((GoSpecType) baseType).getType() instanceof GoInterfaceType)) {
+          String message =
+            String.format("Invalid type assertion: %s, (non-interface type %s on left).", element.getText(), type.getText());
+          holder.createErrorAnnotation(((GoTypeAssertionExpr)element).getExpression(), message);
+        }
+      }
+    }
   }
 }

--- a/src/com/goide/psi/impl/GoFieldNameReference.java
+++ b/src/com/goide/psi/impl/GoFieldNameReference.java
@@ -39,17 +39,6 @@ public class GoFieldNameReference extends GoCachedReference<GoReferenceExpressio
     }
   }
 
-  @Nullable
-  static GoType findTypeFromRef(@Nullable GoTypeReferenceExpression expression) { // todo: simplify
-    GoType type = GoPsiImplUtil.findTypeFromTypeRef(expression);
-    while (type instanceof GoSpecType && ((GoSpecType)type).getType().getTypeReferenceExpression() != null) {
-      GoType inner = GoPsiImplUtil.findTypeFromTypeRef(((GoSpecType)type).getType().getTypeReferenceExpression());
-      if (inner == null || type.isEquivalentTo(inner) || GoPsiImplUtil.builtin(inner)) return type;
-      type = inner;
-    }
-    return type;
-  }
-
   @Override
   public boolean processResolveVariants(@NotNull final GoScopeProcessor processor) {
     GoScopeProcessor fieldProcessor = processor instanceof GoFieldProcessor ? processor : new GoFieldProcessor(myElement) {
@@ -66,7 +55,7 @@ public class GoFieldNameReference extends GoCachedReference<GoReferenceExpressio
 
     GoType type = lit != null ? lit.getType() : null;
     if (type == null && lit != null) {
-      type = findTypeFromRef(lit.getTypeReferenceExpression());
+      type = GoPsiImplUtil.findBaseTypeFromRef(lit.getTypeReferenceExpression());
     }
 
     type = getType(type);
@@ -108,13 +97,13 @@ public class GoFieldNameReference extends GoCachedReference<GoReferenceExpressio
     }
 
     if (type != null && type.getTypeReferenceExpression() != null) {
-      type = findTypeFromRef(type.getTypeReferenceExpression());
+      type = GoPsiImplUtil.findBaseTypeFromRef(type.getTypeReferenceExpression());
     }
 
     if (type instanceof GoPointerType) {
       GoType inner = ((GoPointerType)type).getType();
       if (inner != null && inner.getTypeReferenceExpression() != null) {
-        type = findTypeFromRef(inner.getTypeReferenceExpression());
+        type = GoPsiImplUtil.findBaseTypeFromRef(inner.getTypeReferenceExpression());
       }
     }
 

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -833,7 +833,21 @@ public class GoPsiImplUtil {
 
   @Nullable
   public static GoType getGoTypeInner(@NotNull GoAnonymousFieldDefinition o, @SuppressWarnings("UnusedParameters") @Nullable ResolveState context) {
-    return GoFieldNameReference.findTypeFromRef(o.getTypeReferenceExpression());
+    return findBaseTypeFromRef(o.getTypeReferenceExpression());
+  }
+
+  /**
+   * Finds the "base" type of {@code expression}, resolving type references iteratively until a type spec is found.
+   */
+  @Nullable
+  public static GoType findBaseTypeFromRef(@Nullable GoTypeReferenceExpression expression) {
+    GoType type = findTypeFromTypeRef(expression);
+    while (type instanceof GoSpecType && ((GoSpecType)type).getType().getTypeReferenceExpression() != null) {
+      GoType inner = findTypeFromTypeRef(((GoSpecType)type).getType().getTypeReferenceExpression());
+      if (inner == null || type.isEquivalentTo(inner) || builtin(inner)) return type;
+      type = inner;
+    }
+    return type;
   }
 
   static class MyFunType extends GoLightType<GoFunctionLit> implements GoFunctionType {

--- a/testData/highlighting/simple.go
+++ b/testData/highlighting/simple.go
@@ -220,7 +220,7 @@ func <warning descr="Unused function 'typeAssert'">typeAssert</warning>() {
   err := nil
   switch err.(type) {
     case ServiceError:
-            ser := err.(ServiceError)
+            ser := <error descr="Invalid type assertion: err.(ServiceError), (non-interface type int on left).">err</error>.(ServiceError)
             Println(ser.Code)
             Println([]byte(ser.Message))
     }
@@ -533,7 +533,7 @@ func (b B2) method() B2 {
 
 func _() {
 	b := B2{a:""}
- 	b.method()
+	b.method()
 }
 
 func z(int) {}
@@ -548,6 +548,55 @@ func _() {
     z(i)
     i = <error descr="Too many arguments to conversion to int: int(3, 4).">int(3, 4)</error>
 }
+
+type myIFace string
+
+func (myIFace) Boo() int {
+    return 444
+}
+
+type someInterface interface {
+    Foo() string
+}
+
+type someStringType string
+
+type anotherStringType someStringType
+
+func (someStringType) Foo() string {
+    return "what"
+}
+
+func (anotherStringType) Foo() string {
+    return "what"
+}
+
+func _() {
+    var x someInterface
+    x = someStringType("something")
+    if z, ok := x.(someStringType); ok {
+        if len(string(z)) > 0 {}
+    }
+
+    x = anotherStringType
+    if z, ok := x.(someStringType); ok {
+        if len(string(z)) > 0 {}
+    }
+}
+
+type interf1 interface{}
+type interf2 interf1
+type interf3 interf2
+
+func _() {
+    var x string
+    if _, ok := <error descr="Invalid type assertion: x.(string), (non-interface type string on left).">x</error>.(string); ok {
+    }
+    var y interf3
+    if _, ok := y.(string); ok {
+    }
+}
+
 func _() {
     var x map[string]string
     x = map[string]string{<error descr="Missing key in map literal">"a"</error>, <error descr="Missing key in map literal">"b"</error>}


### PR DESCRIPTION
A type assertion in the form

expr.(T)

requires that expr is of interface type. This change adds an annotator check
for this requirement.