### PR TITLE
add definition annotation for const ref

### DIFF
--- a/src/com/goide/GoDocumentationProvider.java
+++ b/src/com/goide/GoDocumentationProvider.java
@@ -189,6 +189,22 @@ public class GoDocumentationProvider extends AbstractDocumentationProvider {
       String name = ((GoTypeSpec)element).getName();
       return StringUtil.isNotEmpty(name) ? "type " + name : "";
     }
+    if (element instanceof GoConstDefinition) {
+      if (element.getParent() instanceof GoConstSpec) {
+        GoConstSpec spec = (GoConstSpec) element.getParent();
+        StringBuilder result = new StringBuilder();
+        result.append(StringUtil.join(spec.getConstDefinitionList(), GoPsiImplUtil.GET_TEXT_FUNCTION, ","));
+        result.append(" ");
+        result.append(getTypePresentation(spec.getType()));
+        if (spec.getAssign() != null) {
+          result.append(" ");
+          result.append(spec.getAssign().getText());
+          result.append(" ");
+        }
+        result.append(StringUtil.join(spec.getExpressionList(), GoPsiImplUtil.GET_TEXT_FUNCTION, ","));
+        return result.toString();
+      }
+    }
     if (!(element instanceof GoSignatureOwner)) return "";
 
     PsiElement identifier = null;

--- a/testData/doc/constants.go
+++ b/testData/doc/constants.go
@@ -1,0 +1,13 @@
+package a
+
+type FooBar string
+
+const (
+	x FooBar = "something"
+)
+
+func foo(FooBar) {}
+
+func _() {
+	foo(x<caret>)
+}

--- a/testData/doc/constants.txt
+++ b/testData/doc/constants.txt
@@ -1,0 +1,6 @@
+<b>x <a href="psi_element://null#FooBar">FooBar</a> = "something"</b>
+
+=====
+x <a href="psi_element://null#FooBar">FooBar</a> = "something"
+=====
+No urls

--- a/tests/com/goide/GoDocumentationProviderTest.java
+++ b/tests/com/goide/GoDocumentationProviderTest.java
@@ -55,7 +55,8 @@ public class GoDocumentationProviderTest extends GoCodeInsightFixtureTestCase {
   public void testTypeSpec()                          { doTest(); }
   public void testTypeTopDefinition()                 { doTest(); }
   public void testTypeInnerDefinitionWithoutComment() { doTest(); }
-  
+  public void testConstants()                         { doTest(); }
+
   public void testMultiBlockDoc()                     { doConverterTest(); }
   public void testIndentedBlock()                     { doConverterTest(); }
   public void testCommentEndsWithIndentedBlock()      { doConverterTest(); }


### PR DESCRIPTION
If a GoReferenceExpression is a reference to a const, an annotation will be
created with the text of the constant's definition.

Fixes https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/1422.