### PR TITLE
extend assignment count check to short var decl

### DIFF
--- a/src/com/goide/inspections/GoVarDeclarationInspection.java
+++ b/src/com/goide/inspections/GoVarDeclarationInspection.java
@@ -83,7 +83,8 @@ public class GoVarDeclarationInspection extends GoInspectionBase {
 
   @NotNull
   private static Pair<List<? extends GoCompositeElement>, List<GoExpression>> getPair(@NotNull GoVarSpec varDeclaration) {
-    PsiElement assign = varDeclaration.getAssign();
+    PsiElement assign =
+      varDeclaration instanceof GoShortVarDeclaration ? ((GoShortVarDeclaration)varDeclaration).getVarAssign() : varDeclaration.getAssign();
     if (assign == null) {
       return Pair.<List<? extends GoCompositeElement>, List<GoExpression>>create(ContainerUtil.<GoCompositeElement>emptyList(), ContainerUtil.<GoExpression>emptyList());
     }

--- a/testData/highlighting/assignUsages.go
+++ b/testData/highlighting/assignUsages.go
@@ -20,3 +20,11 @@ func main() {
 func f(m func()) {
 	m()
 }
+
+func foo() (int, int) {
+	return 4, 5
+}
+
+func _() {
+	<error descr="Assignment count mismatch: 1 = 2"><error descr="Unused variable 'x'">x</error> := foo(), foo()</error>
+}


### PR DESCRIPTION
Previously the plugin would not complain when doing something like

```go
x := 1, 2
```

whereas

```go
var x int = 1, 2
```

would produce the correct error.