### PR TITLE
Go 1.6 SDK detection

### DIFF
--- a/src/com/goide/sdk/GoSdkUtil.java
+++ b/src/com/goide/sdk/GoSdkUtil.java
@@ -59,9 +59,9 @@ import java.util.regex.Pattern;
 import static com.intellij.util.containers.ContainerUtil.newLinkedHashSet;
 
 public class GoSdkUtil {
-  private static final Pattern GO_VERSION_PATTERN = Pattern.compile("theVersion\\s*=\\s*`go([\\d.]+\\w+(\\d+)?)`");
-  private static final Pattern GAE_VERSION_PATTERN = Pattern.compile("theVersion\\s*=\\s*`go([\\d.]+)( \\(appengine-[\\d.]+\\))?`");
-  private static final Pattern GO_DEVEL_VERSION_PATTERN = Pattern.compile("theVersion\\s*=\\s*`(devel.*)`");
+  private static final Pattern GO_VERSION_PATTERN = Pattern.compile("(?:t|T)heVersion\\s*=\\s*`go([\\d.]+\\w+(\\d+)?)`");
+  private static final Pattern GAE_VERSION_PATTERN = Pattern.compile("(?:t|T)heVersion\\s*=\\s*`go([\\d.]+)( \\(appengine-[\\d.]+\\))?`");
+  private static final Pattern GO_DEVEL_VERSION_PATTERN = Pattern.compile("(?:t|T)heVersion\\s*=\\s*`(devel.*)`");
 
   @Nullable
   private static VirtualFile getSdkSrcDir(@NotNull Project project, @Nullable Module module) {
@@ -307,9 +307,10 @@ public class GoSdkUtil {
   @Nullable
   public static String retrieveGoVersion(@NotNull String sdkPath) {
     try {
-      String oldStylePath = new File(sdkPath, "src/pkg/" + GoConstants.GO_VERSION_FILE_PATH).getPath();
-      String newStylePath = new File(sdkPath, "src/" + GoConstants.GO_VERSION_FILE_PATH).getPath();
-      File zVersionFile = FileUtil.findFirstThatExist(oldStylePath, newStylePath);
+      String legacyStylePath = new File(sdkPath, "src/pkg/" + GoConstants.GO_VERSION_FILE_PATH).getPath();
+      String oldStylePath = new File(sdkPath, "src/" + GoConstants.GO_VERSION_FILE_PATH).getPath();
+      String newStylePath = new File(sdkPath, "src/" + GoConstants.GO_VERSION_NEW_FILE_PATH).getPath();
+      File zVersionFile = FileUtil.findFirstThatExist(legacyStylePath, oldStylePath, newStylePath);
       if (zVersionFile == null) {
         GoSdkService.LOG.debug("Cannot find zVersion file at sdk path: " + sdkPath);
         return null;

--- a/src/com/goide/sdk/GoSmallIDEsSdkService.java
+++ b/src/com/goide/sdk/GoSmallIDEsSdkService.java
@@ -109,6 +109,10 @@ public class GoSmallIDEsSdkService extends GoSdkService {
   }
 
   public static boolean isGoSdkLibRoot(@NotNull VirtualFile root) {
-    return root.isInLocalFileSystem() && root.isDirectory() && VfsUtilCore.findRelativeFile(GoConstants.GO_VERSION_FILE_PATH, root) != null;
+    return root.isInLocalFileSystem() &&
+           root.isDirectory() &&
+           (VfsUtilCore.findRelativeFile(GoConstants.GO_VERSION_FILE_PATH, root) != null ||
+            VfsUtilCore.findRelativeFile(GoConstants.GO_VERSION_NEW_FILE_PATH, root) != null
+           );
   }
 }

--- a/utils/src/com/goide/GoConstants.java
+++ b/utils/src/com/goide/GoConstants.java
@@ -52,6 +52,7 @@ public class GoConstants {
 
   @NonNls public static final String LIB_EXEC_DIRECTORY = "libexec";
   @NonNls public static final String GO_VERSION_FILE_PATH = "runtime/zversion.go";
+  @NonNls public static final String GO_VERSION_NEW_FILE_PATH = "runtime/internal/sys/zversion.go";
   public static final String BUILTIN_FILE_NAME = "builtin.go";
   public static final String BUILTIN_PACKAGE_NAME = "builtin";
   public static final String BUILTIN_FILE_PATH = BUILTIN_PACKAGE_NAME + "/" + BUILTIN_FILE_NAME;


### PR DESCRIPTION
As reported by @stuartcarnie on Gitter, Go 1.6 has moved `zversion.go`; now found in `runtime/internal/sys/zversion.go`

This PR addresses that.

May I also suggest releasing the plugin on all channels (nightly, alpha and stable) with this change? I know from previous experience about the number of tickets that the old plugin didn't supported Go 1.4 (or was it 1.5?) when that appeared and changed the way this works.