### PR TITLE
Ignore embedded types when finding duplicate methods

### DIFF
--- a/src/com/goide/inspections/GoDuplicateFieldsOrMethodsInspection.java
+++ b/src/com/goide/inspections/GoDuplicateFieldsOrMethodsInspection.java
@@ -72,6 +72,10 @@ public class GoDuplicateFieldsOrMethodsInspection extends GoInspectionBase {
   private static void check(@NotNull List<? extends GoNamedElement> fields, @NotNull ProblemsHolder problemsHolder, @NotNull String what) {
     Set<String> names = ContainerUtil.newHashSet();
     for (GoCompositeElement field : fields) {
+      if (field instanceof GoMethodSpec && ((GoMethodSpec) field).getSignature() == null) {
+        // It's an embedded type, not a method or a field.
+        continue;
+      }
       if (field instanceof GoNamedElement) {
         String name = ((GoNamedElement)field).getName();
         if (names.contains(name)) {

--- a/testData/highlighting/githubIssue2099.go
+++ b/testData/highlighting/githubIssue2099.go
@@ -1,0 +1,12 @@
+package main
+
+// Tests https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/2099.
+
+type Interf interface {
+	Hello()
+}
+
+type demo interface {
+	Interf
+	Interf()
+}

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -125,6 +125,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testEqualinif()                 { doTest(); }
   public void testSpecTypes()                 { doTest(); }
   public void testFunctionTypes()             { doTest(); }
+  public void testGithubIssue2099()           { doTest(); }
 
   public void testRelativeImportIgnoringDirectories() throws IOException {
     myFixture.getTempDirFixture().findOrCreateDir("to_import/testdata");


### PR DESCRIPTION
Fixes https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/2099.

This should be considered a short-term fix until general embedded type support is implemented.