### PR TITLE
Fix decls in case clause "leaking" to next clauses

### DIFF
--- a/src/com/goide/psi/impl/GoCompositeElementImpl.java
+++ b/src/com/goide/psi/impl/GoCompositeElementImpl.java
@@ -58,7 +58,8 @@ public class GoCompositeElementImpl extends ASTWrapperPsiElement implements GoCo
           o instanceof GoIfStatement ||
           o instanceof GoForStatement ||
           o instanceof GoCommClause ||
-          o instanceof GoBlock
+          o instanceof GoBlock ||
+          o instanceof GoCaseClause
         ) 
         && processor instanceof GoScopeProcessorBase) {
       if (!PsiTreeUtil.isAncestor(o, ((GoScopeProcessorBase)processor).myOrigin, false)) return true;

--- a/testData/highlighting/typeConversion.go
+++ b/testData/highlighting/typeConversion.go
@@ -1,0 +1,26 @@
+package main
+
+type (
+       int64Val int64
+       boolVal  bool
+       Value    interface {
+               Demo()
+       }
+)
+
+func (int64Val) Demo() {}
+func (boolVal) Demo() {}
+
+func _(x, y Value) {
+       switch x := x.(type) {
+       case boolVal:
+               y := y.(boolVal)
+               _, _ = x, y
+       case int64Val:
+               b := int64(y.(int64Val))
+               _ = b
+       }
+
+}
+
+func main() {}

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -132,6 +132,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testCyclicDefinition()          { doTest(); }
   public void testEmbeddedInterfacePointer()  { doTest(); }
   public void testPlaceholderCount()          { doTest(); }
+  public void testTypeConversion()            { doTest(); }
 
   public void testRelativeImportIgnoringDirectories() throws IOException {
     myFixture.getTempDirFixture().findOrCreateDir("to_import/testdata");


### PR DESCRIPTION
Previously, the plugin did not consider a case statement to be a separate scope
for reference resolution purposes.

Fixes https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/2139.