### PR TITLE
add go bench framework

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -166,6 +166,7 @@
     <!-- test -->
     <runConfigurationProducer implementation="com.goide.runconfig.testing.frameworks.gotest.GotestRunConfigurationProducer"/>
     <runConfigurationProducer implementation="com.goide.runconfig.testing.frameworks.gocheck.GocheckRunConfigurationProducer"/>
+    <runConfigurationProducer implementation="com.goide.runconfig.testing.frameworks.gobench.GobenchRunConfigurationProducer"/>
     <configurationType implementation="com.goide.runconfig.testing.GoTestRunConfigurationType"/>
     <testFinder implementation="com.goide.runconfig.testing.GoTestFinder"/>
     <testSrcLocator implementation="com.goide.runconfig.testing.GoTestLocationProvider"/>

--- a/src/com/goide/runconfig/testing/GoTestFinder.java
+++ b/src/com/goide/runconfig/testing/GoTestFinder.java
@@ -51,6 +51,11 @@ public class GoTestFinder implements TestFinder {
     return type == GoTestFunctionType.EXAMPLE || type == GoTestFunctionType.TEST;
   }
 
+  public static boolean isBenchmarkFunction(@NotNull GoFunctionOrMethodDeclaration function) {
+    GoTestFunctionType type = GoTestFunctionType.fromName(function.getName());
+    return type == GoTestFunctionType.BENCHMARK;
+  }
+
   public static boolean isTestFileWithTestPackage(@Nullable PsiFile file) {
     return getTestTargetPackage(file) != null;
   }

--- a/src/com/goide/runconfig/testing/GoTestFramework.java
+++ b/src/com/goide/runconfig/testing/GoTestFramework.java
@@ -16,6 +16,7 @@
 
 package com.goide.runconfig.testing;
 
+import com.goide.runconfig.testing.frameworks.gobench.GobenchFramework;
 import com.goide.runconfig.testing.frameworks.gocheck.GocheckFramework;
 import com.goide.runconfig.testing.frameworks.gotest.GotestFramework;
 import com.intellij.execution.runners.ExecutionEnvironment;
@@ -29,6 +30,9 @@ import org.jetbrains.annotations.Nullable;
 public abstract class GoTestFramework {
   @NotNull
   public static GoTestFramework fromName(@Nullable String name) {
+    if (GobenchFramework.NAME.equals(name)) {
+      return GobenchFramework.INSTANCE;
+    }
     if (GocheckFramework.NAME.equals(name)) {
       return GocheckFramework.INSTANCE;
     }

--- a/src/com/goide/runconfig/testing/GoTestRunConfigurationProducerBase.java
+++ b/src/com/goide/runconfig/testing/GoTestRunConfigurationProducerBase.java
@@ -94,8 +94,6 @@ public abstract class GoTestRunConfigurationProducerBase extends RunConfiguratio
         }
         else {
           GoFunctionOrMethodDeclaration function = findTestFunctionInContext(contextElement);
-          if (shouldSkipContext(function)) return false;
-
           if (function != null) {
             configuration.setName(getFunctionConfigurationName(function, getFileConfigurationName(file.getName())));
             configuration.setPattern("^" + function.getName() + "$");
@@ -115,8 +113,6 @@ public abstract class GoTestRunConfigurationProducerBase extends RunConfiguratio
 
     return false;
   }
-
-  protected abstract boolean shouldSkipContext(@Nullable GoFunctionOrMethodDeclaration context);
 
   @NotNull
   protected String getFileConfigurationName(@NotNull String fileName) {
@@ -167,7 +163,7 @@ public abstract class GoTestRunConfigurationProducerBase extends RunConfiguratio
   }
 
   @Nullable
-  private static GoFunctionOrMethodDeclaration findTestFunctionInContext(@NotNull PsiElement contextElement) {
+  protected GoFunctionOrMethodDeclaration findTestFunctionInContext(@NotNull PsiElement contextElement) {
     GoFunctionOrMethodDeclaration function = PsiTreeUtil.getNonStrictParentOfType(contextElement, GoFunctionOrMethodDeclaration.class);
     return function != null && GoTestFinder.isTestOrExampleFunction(function) ? function : null;
   }

--- a/src/com/goide/runconfig/testing/GoTestRunningState.java
+++ b/src/com/goide/runconfig/testing/GoTestRunningState.java
@@ -113,7 +113,7 @@ public class GoTestRunningState extends GoRunningState<GoTestRunConfiguration> {
         }
 
         executor.withParameters(importPath);
-        addFilterParameter(executor, buildFilePattern((GoFile)file));
+        addFilterParameter(executor, buildFilterPatternForFile((GoFile)file));
         break;
     }
 
@@ -125,7 +125,7 @@ public class GoTestRunningState extends GoRunningState<GoTestRunConfiguration> {
   }
 
   @NotNull
-  protected String buildFilePattern(GoFile file) {
+  protected String buildFilterPatternForFile(GoFile file) {
     Collection<String> testNames = ContainerUtil.newLinkedHashSet();
     for (GoFunctionDeclaration function : file.getFunctions()) {
       ContainerUtil.addIfNotNull(testNames, GoTestFinder.isTestOrExampleFunction(function) ? function.getName() : null);

--- a/src/com/goide/runconfig/testing/frameworks/gobench/GobenchEventsConverter.java
+++ b/src/com/goide/runconfig/testing/frameworks/gobench/GobenchEventsConverter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.runconfig.testing.frameworks.gobench;
+
+import com.goide.runconfig.testing.GoTestLocationProvider;
+import com.google.common.base.Stopwatch;
+import com.intellij.execution.testframework.TestConsoleProperties;
+import com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter;
+import com.intellij.execution.testframework.sm.runner.events.TestFailedEvent;
+import com.intellij.execution.testframework.sm.runner.events.TestFinishedEvent;
+import com.intellij.execution.testframework.sm.runner.events.TestOutputEvent;
+import com.intellij.execution.testframework.sm.runner.events.TestStartedEvent;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
+import jetbrains.buildServer.messages.serviceMessages.TestFailed;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GobenchEventsConverter extends OutputToGeneralTestEventsConverter {
+  private static final Pattern RUN = Pattern.compile("^(Benchmark[^ (\n\t\r]+)");
+  private static final Pattern FAIL = Pattern.compile("^--- FAIL: (Benchmark[^ (\n\t\r]+)");
+  private static final Pattern OK = Pattern.compile("^ok  \t");
+
+  public GobenchEventsConverter(TestConsoleProperties properties) {
+    super(GobenchFramework.NAME, properties);
+  }
+  private Stopwatch testStopwatch = Stopwatch.createUnstarted();
+  private String currentBenchmark = "<benchmark>";
+  private boolean benchmarkFailing = false;
+
+  @Override
+  public void process(String text, Key outputType) {
+    Matcher matcher;
+
+    if (OK.matcher(text).find()) {
+      maybeFinishCurrentTest();
+    } else if ((matcher = RUN.matcher(text)).find()) {
+      maybeFinishCurrentTest();
+      testStopwatch.start();
+      currentBenchmark = StringUtil.notNullize(matcher.group(1), "<benchmark>");
+      TestStartedEvent event = new TestStartedEvent(currentBenchmark, testUrl(currentBenchmark));
+      getProcessor().onTestStarted(event);
+    } else if ((matcher = FAIL.matcher(text)).find()) {
+      currentBenchmark = StringUtil.notNullize(matcher.group(1), "<benchmark>");
+      benchmarkFailing = true;
+    }
+
+    super.process(text, outputType);
+  }
+
+  private void maybeFinishCurrentTest() {
+    if (testStopwatch.isRunning()) {
+      testStopwatch.stop();
+      if (benchmarkFailing) {
+        TestFailedEvent event = new TestFailedEvent(currentBenchmark, "", null, true, null, null);
+        getProcessor().onTestFailure(event);
+        benchmarkFailing = false;
+      }
+
+      TestFinishedEvent event = new TestFinishedEvent(currentBenchmark, testStopwatch.elapsed(TimeUnit.MILLISECONDS));
+      testStopwatch.reset();
+      getProcessor().onTestFinished(event);
+    }
+  }
+
+  @NotNull
+  private static String testUrl(@NotNull String testName) {
+    return GoTestLocationProvider.PROTOCOL + "://" + testName;
+  }
+}

--- a/src/com/goide/runconfig/testing/frameworks/gobench/GobenchFramework.java
+++ b/src/com/goide/runconfig/testing/frameworks/gobench/GobenchFramework.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.runconfig.testing.frameworks.gobench;
+
+import com.goide.runconfig.testing.GoTestFinder;
+import com.goide.runconfig.testing.GoTestFramework;
+import com.goide.runconfig.testing.GoTestRunConfiguration;
+import com.goide.runconfig.testing.GoTestRunningState;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.testframework.TestConsoleProperties;
+import com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter;
+import com.intellij.openapi.module.Module;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GobenchFramework extends GoTestFramework {
+  public static final String NAME = "gobench";
+  public static final GobenchFramework INSTANCE = new GobenchFramework();
+
+  @NotNull
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public boolean isAvailable(@Nullable Module module) {
+    return true;
+  }
+
+  @Override
+  public boolean isAvailableOnFile(@Nullable PsiFile file) {
+    return GoTestFinder.isTestFile(file);
+  }
+
+  @NotNull
+  @Override
+  protected GoTestRunningState newRunningState(@NotNull ExecutionEnvironment env,
+                                               @NotNull Module module,
+                                               @NotNull GoTestRunConfiguration runConfiguration) {
+    return new GobenchRunningState(env, module, runConfiguration);
+  }
+
+  @NotNull
+  @Override
+  public OutputToGeneralTestEventsConverter createTestEventsConverter(@NotNull TestConsoleProperties consoleProperties) {
+    return new GobenchEventsConverter(consoleProperties);
+  }
+}

--- a/src/com/goide/runconfig/testing/frameworks/gobench/GobenchRunConfigurationProducer.java
+++ b/src/com/goide/runconfig/testing/frameworks/gobench/GobenchRunConfigurationProducer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.runconfig.testing.frameworks.gobench;
+
+import com.goide.psi.GoFunctionDeclaration;
+import com.goide.psi.GoFunctionOrMethodDeclaration;
+import com.goide.runconfig.testing.GoTestFinder;
+import com.goide.runconfig.testing.GoTestRunConfigurationProducerBase;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GobenchRunConfigurationProducer extends GoTestRunConfigurationProducerBase implements Cloneable {
+  public GobenchRunConfigurationProducer() {
+    super(GobenchFramework.INSTANCE);
+  }
+
+  @NotNull
+  @Override
+  protected String getPackageConfigurationName(@NotNull String packageName) {
+    return "gobench package '" + packageName + "'";
+  }
+
+  @NotNull
+  @Override
+  protected String getFileConfigurationName(@NotNull String fileName) {
+    return "gobench " + super.getFileConfigurationName(fileName);
+  }
+
+  @NotNull
+  @Override
+  protected String getFunctionConfigurationName(@NotNull GoFunctionOrMethodDeclaration function, @NotNull String fileName) {
+    return "gobench " + super.getFunctionConfigurationName(function, fileName);
+  }
+
+  @Nullable
+  @Override
+  protected GoFunctionDeclaration findTestFunctionInContext(@NotNull PsiElement contextElement) {
+    GoFunctionDeclaration function = PsiTreeUtil.getNonStrictParentOfType(contextElement, GoFunctionDeclaration.class);
+    return function != null && GoTestFinder.isBenchmarkFunction(function) ? function : null;
+  }
+}

--- a/src/com/goide/runconfig/testing/frameworks/gocheck/GocheckRunConfigurationProducer.java
+++ b/src/com/goide/runconfig/testing/frameworks/gocheck/GocheckRunConfigurationProducer.java
@@ -20,9 +20,9 @@ import com.goide.psi.GoFunctionDeclaration;
 import com.goide.psi.GoFunctionOrMethodDeclaration;
 import com.goide.psi.GoMethodDeclaration;
 import com.goide.runconfig.testing.GoTestRunConfigurationProducerBase;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 
 public class GocheckRunConfigurationProducer extends GoTestRunConfigurationProducerBase implements Cloneable {
   public GocheckRunConfigurationProducer() {
@@ -43,14 +43,19 @@ public class GocheckRunConfigurationProducer extends GoTestRunConfigurationProdu
            : super.getFunctionConfigurationName(function, fileName);
   }
 
-  @Override
-  protected boolean shouldSkipContext(@Nullable GoFunctionOrMethodDeclaration context) {
-    return context != null && context instanceof GoFunctionDeclaration;
-  }
-
   @NotNull
   @Override
   protected String getFileConfigurationName(@NotNull String fileName) {
     return "gocheck " + super.getFileConfigurationName(fileName);
+  }
+
+  @Nullable
+  @Override
+  protected GoFunctionOrMethodDeclaration findTestFunctionInContext(@NotNull PsiElement contextElement) {
+    GoFunctionOrMethodDeclaration functionOrMethodDecl = super.findTestFunctionInContext(contextElement);
+    if (functionOrMethodDecl instanceof GoFunctionDeclaration) {
+      return null;
+    }
+    return functionOrMethodDecl;
   }
 }

--- a/src/com/goide/runconfig/testing/frameworks/gotest/GotestRunConfigurationProducer.java
+++ b/src/com/goide/runconfig/testing/frameworks/gotest/GotestRunConfigurationProducer.java
@@ -19,16 +19,22 @@ package com.goide.runconfig.testing.frameworks.gotest;
 import com.goide.psi.GoFunctionOrMethodDeclaration;
 import com.goide.psi.GoMethodDeclaration;
 import com.goide.runconfig.testing.GoTestRunConfigurationProducerBase;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 
 public class GotestRunConfigurationProducer extends GoTestRunConfigurationProducerBase implements Cloneable {
   public GotestRunConfigurationProducer() {
     super(GotestFramework.INSTANCE);
   }
-  
+
+  @Nullable
   @Override
-  protected boolean shouldSkipContext(@Nullable GoFunctionOrMethodDeclaration context) {
-    return context != null && context instanceof GoMethodDeclaration;
+  protected GoFunctionOrMethodDeclaration findTestFunctionInContext(@NotNull PsiElement contextElement) {
+    GoFunctionOrMethodDeclaration functionOrMethodDecl = super.findTestFunctionInContext(contextElement);
+    if (functionOrMethodDecl instanceof GoMethodDeclaration) {
+      return null;
+    }
+    return functionOrMethodDecl;
   }
 }

--- a/src/com/goide/runconfig/testing/ui/GoTestRunConfigurationEditorForm.form
+++ b/src/com/goide/runconfig/testing/ui/GoTestRunConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.goide.runconfig.testing.ui.GoTestRunConfigurationEditorForm">
-  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="9" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="9" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="657" height="425"/>
@@ -10,7 +10,7 @@
     <children>
       <vspacer id="632bf">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="4" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="c65ef" class="javax.swing.JComboBox" binding="myTestKindComboBox">
@@ -52,7 +52,7 @@
       </component>
       <component id="c2258" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myDirectoryField">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -72,7 +72,7 @@
       </component>
       <component id="d8a73" class="com.intellij.ui.EditorTextField" binding="myPackageField" custom-create="true">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="1" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -92,7 +92,7 @@
       </component>
       <component id="b2116" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myFileField">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -100,12 +100,12 @@
       </component>
       <hspacer id="e93e6">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
       <component id="5d2fe" class="com.intellij.ui.EditorTextField" binding="myPatternEditor" custom-create="true">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="1" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -122,13 +122,13 @@
       </component>
       <component id="8d39e" class="javax.swing.JSeparator">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="6" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="4" vsize-policy="6" hsize-policy="6" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <nested-form id="78da9" form-file="com/goide/runconfig/ui/GoCommonSettingsPanel.form" binding="myCommonSettingsPanel">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="4" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
       <component id="87b6" class="javax.swing.JLabel">
@@ -155,12 +155,21 @@
           <text value="go&amp;check"/>
         </properties>
       </component>
+      <component id="f0312" class="javax.swing.JRadioButton" binding="myGobenchRadioButton" default-binding="true">
+        <constraints>
+          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="go&amp;bench"/>
+        </properties>
+      </component>
     </children>
   </grid>
   <buttonGroups>
     <group name="myTestFramework">
       <member id="f8e3f"/>
       <member id="90783"/>
+      <member id="f0312"/>
     </group>
   </buttonGroups>
 </form>

--- a/src/com/goide/runconfig/testing/ui/GoTestRunConfigurationEditorForm.java
+++ b/src/com/goide/runconfig/testing/ui/GoTestRunConfigurationEditorForm.java
@@ -17,7 +17,9 @@
 package com.goide.runconfig.testing.ui;
 
 import com.goide.runconfig.GoRunUtil;
+import com.goide.runconfig.testing.GoTestFramework;
 import com.goide.runconfig.testing.GoTestRunConfiguration;
+import com.goide.runconfig.testing.frameworks.gobench.GobenchFramework;
 import com.goide.runconfig.testing.frameworks.gocheck.GocheckFramework;
 import com.goide.runconfig.testing.frameworks.gotest.GotestFramework;
 import com.goide.runconfig.ui.GoCommonSettingsPanel;
@@ -54,6 +56,7 @@ public class GoTestRunConfigurationEditorForm extends SettingsEditor<GoTestRunCo
   private GoCommonSettingsPanel myCommonSettingsPanel;
   private JRadioButton myGotestFrameworkRadioButton;
   private JRadioButton myGocheckFrameworkRadioButton;
+  private JRadioButton myGobenchRadioButton;
 
   public GoTestRunConfigurationEditorForm(@NotNull Project project) {
     super(null);
@@ -87,6 +90,7 @@ public class GoTestRunConfigurationEditorForm extends SettingsEditor<GoTestRunCo
   protected void resetEditorFrom(@NotNull GoTestRunConfiguration configuration) {
     myGotestFrameworkRadioButton.setSelected(configuration.getTestFramework() == GotestFramework.INSTANCE);
     myGocheckFrameworkRadioButton.setSelected(configuration.getTestFramework() == GocheckFramework.INSTANCE);
+    myGobenchRadioButton.setSelected(configuration.getTestFramework() == GobenchFramework.INSTANCE);
     myTestKindComboBox.setSelectedItem(configuration.getKind());
     myPackageField.setText(configuration.getPackage());
 
@@ -103,7 +107,13 @@ public class GoTestRunConfigurationEditorForm extends SettingsEditor<GoTestRunCo
 
   @Override
   protected void applyEditorTo(@NotNull GoTestRunConfiguration configuration) throws ConfigurationException {
-    configuration.setTestFramework(myGocheckFrameworkRadioButton.isSelected() ? GocheckFramework.INSTANCE : GotestFramework.INSTANCE);
+    if (myGocheckFrameworkRadioButton.isSelected()) {
+      configuration.setTestFramework(GocheckFramework.INSTANCE);
+    } else if (myGobenchRadioButton.isSelected()) {
+      configuration.setTestFramework(GobenchFramework.INSTANCE);
+    } else {
+      configuration.setTestFramework(GotestFramework.INSTANCE);
+    }
     configuration.setKind((GoTestRunConfiguration.Kind)myTestKindComboBox.getSelectedItem());
     configuration.setPackage(myPackageField.getText());
     configuration.setDirectoryPath(myDirectoryField.getText());
@@ -136,7 +146,14 @@ public class GoTestRunConfigurationEditorForm extends SettingsEditor<GoTestRunCo
   }
 
   private String getSelectedFramework() {
-    return myGocheckFrameworkRadioButton.isSelected() ? GocheckFramework.NAME : GotestFramework.NAME;
+    GoTestFramework framework = GotestFramework.INSTANCE;
+    if (myGocheckFrameworkRadioButton.isSelected()) {
+      framework = GocheckFramework.INSTANCE;
+    } else if (myGobenchRadioButton.isSelected()) {
+      framework = GobenchFramework.INSTANCE;
+    }
+
+    return framework.getName();
   }
   
   @Nullable


### PR DESCRIPTION
Fixes https://github.com/go-lang-plugin-org/go-lang-idea-plugin/issues/1995.

Please take a look at the event converter class. It's not complete but I don't want to keep working on it if there's an easier way. The main reason I can't use `processServiceMessage` is that the go test -bench output is not line-delimited. 