### PR TITLE
Improve coverage support for packages (fixes #2276)

### DIFF
--- a/src/com/goide/runconfig/testing/GoTestRunningState.java
+++ b/src/com/goide/runconfig/testing/GoTestRunningState.java
@@ -40,6 +40,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
+import com.intellij.util.PathUtil;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -83,11 +84,14 @@ public class GoTestRunningState extends GoRunningState<GoTestRunConfiguration> {
         String relativePath = FileUtil.getRelativePath(myConfiguration.getWorkingDirectory(),
                                                        myConfiguration.getDirectoryPath(),
                                                        File.separatorChar);
+        // TODO Once Go gets support for covering multiple packages the ternary condition should be reverted
+        // See https://golang.org/issues/6909
+        String pathSuffix = (myCoverageFilePath == null) ? "..." : ".";
         if (relativePath != null) {
-          executor.withParameters("./" + relativePath + "/...");
+          executor.withParameters("./" + relativePath + "/" + pathSuffix);
         }
         else {
-          executor.withParameters("./...");
+          executor.withParameters("./" + pathSuffix);
           executor.withWorkDirectory(myConfiguration.getDirectoryPath());
         }
         addFilterParameter(executor, myConfiguration.getPattern());


### PR DESCRIPTION
Technically only directory run configs have this issue (package running doesn't support specifying `...` yet, I'll do a different PR for that if it's deemed of interested, so far no such request tho).