### PR TITLE
Introduce support for builtin function highlighting (fixes #1841)

### DIFF
--- a/src/com/goide/highlighting/GoColorsAndFontsPage.java
+++ b/src/com/goide/highlighting/GoColorsAndFontsPage.java
@@ -50,6 +50,7 @@ public class GoColorsAndFontsPage implements ColorSettingsPage {
     new AttributesDescriptor("Type specification", TYPE_SPECIFICATION),
     new AttributesDescriptor("Type reference", TYPE_REFERENCE),
     new AttributesDescriptor("Builtin type", BUILTIN_TYPE_REFERENCE),
+    new AttributesDescriptor("Builtin function", BUILTIN_FUNCTION),
     new AttributesDescriptor("Exported function", EXPORTED_FUNCTION),
     new AttributesDescriptor("Local function", LOCAL_FUNCTION),
     new AttributesDescriptor("Package exported interface", PACKAGE_EXPORTED_INTERFACE),
@@ -74,6 +75,7 @@ public class GoColorsAndFontsPage implements ColorSettingsPage {
     ATTRIBUTES_KEY_MAP.put("tr", TYPE_REFERENCE);
     ATTRIBUTES_KEY_MAP.put("ts", TYPE_SPECIFICATION);
     ATTRIBUTES_KEY_MAP.put("bt", BUILTIN_TYPE_REFERENCE);
+    ATTRIBUTES_KEY_MAP.put("bf", BUILTIN_FUNCTION);
     ATTRIBUTES_KEY_MAP.put("kw", KEYWORD);
     ATTRIBUTES_KEY_MAP.put("ef", EXPORTED_FUNCTION);
     ATTRIBUTES_KEY_MAP.put("lf", LOCAL_FUNCTION);
@@ -225,6 +227,7 @@ public class GoColorsAndFontsPage implements ColorSettingsPage {
            "    _ = <lf>variableFunc</lf>(1)\n" +
            "    _ = <fp>demo1</fp>\n" +
            "    _ = <lv>demo2</lv>\n" +
+           "    <bf>println</bf>(\"builtin function\")" +
            "\n" +
            "}\n" +
            "\n" +

--- a/src/com/goide/highlighting/GoHighlightingAnnotator.java
+++ b/src/com/goide/highlighting/GoHighlightingAnnotator.java
@@ -92,6 +92,7 @@ public class GoHighlightingAnnotator implements Annotator {
   }
 
   private static TextAttributesKey getColor(GoNamedSignatureOwner o) {
+    if (GoPsiImplUtil.builtin(o)) return BUILTIN_FUNCTION;
     return o.isPublic() ? EXPORTED_FUNCTION : LOCAL_FUNCTION;
   }
 

--- a/src/com/goide/highlighting/GoSyntaxHighlightingColors.java
+++ b/src/com/goide/highlighting/GoSyntaxHighlightingColors.java
@@ -41,6 +41,7 @@ public class GoSyntaxHighlightingColors {
   public static final TextAttributesKey TYPE_SPECIFICATION = createTextAttributesKey("GO_TYPE_SPECIFICATION", DefaultLanguageHighlighterColors.CLASS_NAME);
   public static final TextAttributesKey TYPE_REFERENCE = createTextAttributesKey("GO_TYPE_REFERENCE", DefaultLanguageHighlighterColors.CLASS_REFERENCE);
   public static final TextAttributesKey BUILTIN_TYPE_REFERENCE = createTextAttributesKey("GO_BUILTIN_TYPE_REFERENCE", DefaultLanguageHighlighterColors.CLASS_REFERENCE);
+  public static final TextAttributesKey BUILTIN_FUNCTION = createTextAttributesKey("GO_BUILTIN_FUNCTION", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION);
   public static final TextAttributesKey EXPORTED_FUNCTION = createTextAttributesKey("GO_EXPORTED_FUNCTION", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION);
   public static final TextAttributesKey LOCAL_FUNCTION = createTextAttributesKey("GO_LOCAL_FUNCTION", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION);
   public static final TextAttributesKey PACKAGE_EXPORTED_INTERFACE = createTextAttributesKey("GO_PACKAGE_EXPORTED_INTERFACE", DefaultLanguageHighlighterColors.INTERFACE_NAME);

--- a/testData/colorHighlighting/builtinFunctions.go
+++ b/testData/colorHighlighting/builtinFunctions.go
@@ -1,0 +1,5 @@
+package main
+
+func <info descr="null"><info descr="GO_LOCAL_FUNCTION">main</info></info>() {
+	<info descr="null"><info descr="GO_BUILTIN_FUNCTION">println</info></info>("demo")
+}

--- a/testData/colorHighlighting/funcAndMethod.go
+++ b/testData/colorHighlighting/funcAndMethod.go
@@ -1,7 +1,7 @@
 package main
 
 type <info descr="null"><info descr="GO_PACKAGE_LOCAL_INTERFACE">inner</info></info> interface {
-	<info descr="null"><info descr="GO_EXPORTED_FUNCTION">Inner</info></info>() string
+	<info descr="null"><info descr="GO_EXPORTED_FUNCTION">Inner</info></info>() <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">string</info></info>
 }
 
 type (
@@ -13,7 +13,7 @@ type (
 )
 
 func (<info descr="null"><info descr="GO_METHOD_RECEIVER">a</info></info> <info descr="null"><info descr="GO_TYPE_REFERENCE">dem</info></info>) <info descr="null"><info descr="GO_EXPORTED_FUNCTION">Demo</info></info>() <info descr="null"><info descr="GO_PACKAGE_LOCAL_INTERFACE">inner</info></info> {
-	return error("demo")
+	return <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">error</info></info>("demo")
 }
 
 func <info descr="null"><info descr="GO_LOCAL_FUNCTION">main</info></info>() {

--- a/testData/colorHighlighting/label.go
+++ b/testData/colorHighlighting/label.go
@@ -1,6 +1,6 @@
 package main
 
-func <info descr="null"><info descr="GO_LOCAL_FUNCTION">test</info></info>() int {
+func <info descr="null"><info descr="GO_LOCAL_FUNCTION">test</info></info>() <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info> {
 <info descr="null"><info descr="GO_LABEL">foo</info></info>:
 	for {
 		continue <info descr="null"><info descr="GO_LABEL">foo</info></info>

--- a/testData/colorHighlighting/octAndHex.go
+++ b/testData/colorHighlighting/octAndHex.go
@@ -1,5 +1,5 @@
 package main
 
-var <info descr="null"><info descr="GO_PACKAGE_LOCAL_VARIABLE">a</info></info> int = <info descr="null"><info descr="GO_NUMBER">0112</info></info>
-var <info descr="null"><info descr="GO_PACKAGE_LOCAL_VARIABLE">b</info></info> int = <info descr="null"><info descr="GO_NUMBER">0x112</info></info>
-var <info descr="null"><info descr="GO_PACKAGE_LOCAL_VARIABLE">c</info></info> int = <info descr="null"><info descr="GO_NUMBER">0Xabf112</info></info>
+var <info descr="null"><info descr="GO_PACKAGE_LOCAL_VARIABLE">a</info></info> <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info> = <info descr="null"><info descr="GO_NUMBER">0112</info></info>
+var <info descr="null"><info descr="GO_PACKAGE_LOCAL_VARIABLE">b</info></info> <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info> = <info descr="null"><info descr="GO_NUMBER">0x112</info></info>
+var <info descr="null"><info descr="GO_PACKAGE_LOCAL_VARIABLE">c</info></info> <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info> = <info descr="null"><info descr="GO_NUMBER">0Xabf112</info></info>

--- a/testData/colorHighlighting/simple.go
+++ b/testData/colorHighlighting/simple.go
@@ -3,5 +3,5 @@ package main
 import `fmt`
 
 func <info descr="null"><info descr="GO_LOCAL_FUNCTION">main</info></info>() {
-  fmt.Println("Hello")
+  fmt.<info descr="null"><info descr="GO_EXPORTED_FUNCTION">Println</info></info>("Hello")
 }

--- a/testData/colorHighlighting/types.go
+++ b/testData/colorHighlighting/types.go
@@ -2,25 +2,25 @@ package main
 
 type (
 	<info descr="null"><info descr="GO_PACKAGE_EXPORTED_INTERFACE">PublicInterface</info></info>  interface {
-		<info descr="null"><info descr="GO_EXPORTED_FUNCTION">PublicFunc</info></info>() int
-		<info descr="null"><info descr="GO_LOCAL_FUNCTION">privateFunc</info></info>() int
+		<info descr="null"><info descr="GO_EXPORTED_FUNCTION">PublicFunc</info></info>() <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
+		<info descr="null"><info descr="GO_LOCAL_FUNCTION">privateFunc</info></info>() <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
 	}
 
 	<info descr="null"><info descr="GO_PACKAGE_LOCAL_INTERFACE">private</info></info> interface {
-		<info descr="null"><info descr="GO_EXPORTED_FUNCTION">PublicFunc</info></info>() int
-		<info descr="null"><info descr="GO_LOCAL_FUNCTION">privateFunc</info></info>() int
+		<info descr="null"><info descr="GO_EXPORTED_FUNCTION">PublicFunc</info></info>() <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
+		<info descr="null"><info descr="GO_LOCAL_FUNCTION">privateFunc</info></info>() <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
 	}
 
 	<info descr="null"><info descr="GO_PACKAGE_EXPORTED_STRUCT">PublicStruct</info></info> struct {
 
-		<info descr="null"><info descr="GO_STRUCT_EXPORTED_MEMBER">PublicField</info></info>  int
-		<info descr="null"><info descr="GO_STRUCT_LOCAL_MEMBER">privateField</info></info> int
+		<info descr="null"><info descr="GO_STRUCT_EXPORTED_MEMBER">PublicField</info></info>  <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
+		<info descr="null"><info descr="GO_STRUCT_LOCAL_MEMBER">privateField</info></info> <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
 	}
 
 	<info descr="null"><info descr="GO_PACKAGE_LOCAL_STRUCT">privateStruct</info></info> struct {
-		<info descr="null"><info descr="GO_STRUCT_EXPORTED_MEMBER">PublicField</info></info>  int
-		<info descr="null"><info descr="GO_STRUCT_LOCAL_MEMBER">privateField</info></info> int
+		<info descr="null"><info descr="GO_STRUCT_EXPORTED_MEMBER">PublicField</info></info>  <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
+		<info descr="null"><info descr="GO_STRUCT_LOCAL_MEMBER">privateField</info></info> <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
 	}
 
-	<info descr="null"><info descr="GO_TYPE_SPECIFICATION">demoInt</info></info> int
+	<info descr="null"><info descr="GO_TYPE_SPECIFICATION">demoInt</info></info> <info descr="null"><info descr="GO_BUILTIN_TYPE_REFERENCE">int</info></info>
 )

--- a/tests/com/goide/editor/GoHighlightingAnnotatorTest.java
+++ b/tests/com/goide/editor/GoHighlightingAnnotatorTest.java
@@ -17,12 +17,19 @@
 package com.goide.editor;
 
 import com.goide.GoCodeInsightFixtureTestCase;
+import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.annotations.NotNull;
 
 @TestDataPath("$PROJECT_ROOT/testData/colorHighlighting")
 public class GoHighlightingAnnotatorTest extends GoCodeInsightFixtureTestCase {
-  
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    setUpProjectSdk();
+  }
+
   public void testSimple() {
     doTest();
   }
@@ -47,6 +54,10 @@ public class GoHighlightingAnnotatorTest extends GoCodeInsightFixtureTestCase {
     doTest();
   }
 
+  public void testBuiltinFunctions() {
+    doTest();
+  }
+
   @Override
   protected boolean isWriteActionRequired() {
     return false;
@@ -60,6 +71,11 @@ public class GoHighlightingAnnotatorTest extends GoCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {
     return "colorHighlighting";
+  }
+
+  @Override
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return createMockProjectDescriptor();
   }
 }
 


### PR DESCRIPTION
This introduces support for highlighting builtin functions. However to do this, the test class had to be updated which lead to the noise in the PR.