### PR TITLE
Initial support for generating interfaces implementations (fixes #1568)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -335,6 +335,12 @@
             description="Analyze types for current directory with gotype util">
       <add-to-group group-id="CodeMenu" anchor="last"/>
     </action>
+
+    <action id="implementInterface" class="com.goide.actions.GoImplementInterfaceAction"
+            text="Implement interface"
+            description="Implement interface">
+      <add-to-group group-id="GenerateGroup" anchor="last"/>
+    </action>
   </actions>
 
   <application-components>

--- a/src/com/goide/actions/GoImplementInterfaceAction.java
+++ b/src/com/goide/actions/GoImplementInterfaceAction.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.actions;
+
+import com.goide.psi.*;
+import com.goide.psi.impl.GoPsiImplUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GoImplementInterfaceAction extends AnAction {
+  private final static String windowTitle = "Select Interfaces to Implement";
+  private final static String labelText = "Interfaces to be implemented:";
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    PsiElement psiElement = getPsiElementFromContext(e);
+    e.getPresentation().setEnabled(psiElement != null);
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    PsiElement psiElement = getPsiElementFromContext(e);
+    if (psiElement == null || !inCurrentProject(e, psiElement)) return;
+
+    ArrayList<GoTypeSpec> interfaces = getInterfaceList(psiElement);
+    if (interfaces == null || interfaces.size() == 0) return;
+
+    GoTypeSpecListDialog dlg = new GoTypeSpecListDialog(psiElement, interfaces, windowTitle, labelText);
+    dlg.show();
+    if (dlg.isOK()) {
+      implementInterface(psiElement, dlg.getInterfaces());
+    }
+  }
+
+  private static void implementInterface(@NotNull final PsiElement element, @NotNull final List<GoTypeSpec> interfaces) {
+    Project project = element.getProject();
+    WriteCommandAction.runWriteCommandAction(project, new Runnable() {
+      @Override
+      public void run() {
+        GoStructType struct = ((GoStructType)((GoSpecType)element).getType());
+        for (GoTypeSpec goInterface : interfaces) {
+          for (GoMethodSpec method : ((GoInterfaceType)goInterface.getSpecType().getType()).getMethods()) {
+            GoPsiImplUtil.addSpec(struct, method);
+          }
+        }
+      }
+    });
+  }
+
+  @Nullable
+  private static PsiElement getPsiElementFromContext(@NotNull AnActionEvent e) {
+    PsiFile psiFile = e.getData(CommonDataKeys.PSI_FILE);
+    Editor editor = e.getData(CommonDataKeys.EDITOR);
+    if (psiFile == null || editor == null) return null;
+
+    int offset = editor.getCaretModel().getOffset();
+    PsiElement elementAt = psiFile.findElementAt(offset);
+    if (elementAt == null) return null;
+
+    GoType parentElement = PsiTreeUtil.getParentOfType(elementAt, GoSpecType.class, GoStructType.class);
+    if (parentElement == null) {
+      if (elementAt.getParent() instanceof GoReferenceExpression) {
+        parentElement = GoPsiImplUtil.getGoType((GoReferenceExpression)elementAt.getParent(), null);
+      }
+      else if (elementAt.getParent() instanceof GoTypeReferenceExpression) {
+        parentElement = GoPsiImplUtil.findTypeFromTypeRef((GoTypeReferenceExpression)elementAt.getParent());
+      }
+      else {
+        return null;
+      }
+    }
+
+    if (parentElement instanceof GoStructType) return parentElement;
+    if (parentElement instanceof GoSpecType) {
+      return ((GoSpecType)parentElement).getType() instanceof GoStructType ? parentElement : null;
+    }
+
+    return null;
+  }
+
+  private static boolean inCurrentProject(@NotNull AnActionEvent e, @NotNull PsiElement element) {
+    return e.getProject() != null && e.getProject().equals(element.getProject());
+  }
+
+  @Nullable
+  private static ArrayList<GoTypeSpec> getInterfaceList(@NotNull PsiElement element) {
+    PsiFile file = element.getContainingFile();
+    if (!(file instanceof GoFile)) return null;
+    
+    // TODO Get all the private interfaces from the package the struct is defined
+    // TODO Get all the public interfaces from the package the struct is defined
+    // TODO Get all the public interfaces from the project
+    // TODO Get all the public interfaces from the GOPATH
+    // TODO Get all the public interfaces from the Go SDK
+    List<GoTypeSpec> types = ((GoFile)file).getTypes();
+    ArrayList<GoTypeSpec> results = new ArrayList<GoTypeSpec>();
+    for (GoTypeSpec type : types) {
+      if (type.getSpecType().getType() instanceof GoInterfaceType) {
+        results.add(type);
+      }
+    }
+    return results;
+  }
+}

--- a/src/com/goide/actions/GoTypeSpecListDialog.java
+++ b/src/com/goide/actions/GoTypeSpecListDialog.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.actions;
+
+import com.goide.psi.GoTypeSpec;
+import com.intellij.ide.util.DefaultPsiElementCellRenderer;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.LabeledComponent;
+import com.intellij.psi.PsiElement;
+import com.intellij.ui.CollectionListModel;
+import com.intellij.ui.ToolbarDecorator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GoTypeSpecListDialog extends DialogWrapper {
+  @NotNull private CollectionListModel<GoTypeSpec> myFields;
+  @NotNull private final LabeledComponent<JPanel> myComponent;
+
+  public GoTypeSpecListDialog(@NotNull PsiElement psiElement,
+                              @NotNull ArrayList<GoTypeSpec> interfaces,
+                              @NotNull String windowTitle,
+                              @NotNull String labelText) {
+    super(psiElement.getProject());
+
+    setTitle(windowTitle);
+    myFields = new CollectionListModel<GoTypeSpec>(interfaces);
+    JList fieldList = new JList(myFields);
+    fieldList.setCellRenderer(new DefaultPsiElementCellRenderer());
+    ToolbarDecorator decorator = ToolbarDecorator.createDecorator(fieldList);
+    decorator.disableAddAction();
+    JPanel panel = decorator.createPanel();
+    myComponent = LabeledComponent.create(panel, labelText);
+
+    init();
+  }
+
+  @Nullable
+  @Override
+  protected JComponent createCenterPanel() {
+    return myComponent;
+  }
+
+  @NotNull
+  public List<GoTypeSpec> getInterfaces() {
+    return myFields.getItems();
+  }
+}

--- a/src/com/goide/psi/impl/GoElementFactory.java
+++ b/src/com/goide/psi/impl/GoElementFactory.java
@@ -177,4 +177,12 @@ public class GoElementFactory {
     GoVarDeclaration varDeclaration = createVarDeclaration(project, name + type + value);
     return ContainerUtil.getFirstItem(varDeclaration.getVarSpecList());
   }
+
+  @Nullable
+  public static GoMethodDeclaration createMethod(@NotNull Project project, @NotNull GoStructType struct, @NotNull GoMethodSpec method) {
+    String structName = ((GoTypeSpecImpl)struct.getParent().getParent()).getIdentifier().getText();
+    String contents = "package a; func ("+ structName.charAt(0)+" " + structName + ") " + method.getName() + method.getSignature().getText() + " {\n\t\n}";
+    GoFile file = createFileFromText(project, contents);
+    return ContainerUtil.getFirstItem(file.getMethods());
+  }
 }

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -1124,6 +1124,19 @@ public class GoPsiImplUtil {
     return spec;
   }
 
+  public static void addSpec(GoStructType struct, GoMethodSpec method) {
+    PsiFile file = struct.getContainingFile();
+    Project project = struct.getProject();
+    GoMethodDeclaration generatedMethod = GoElementFactory.createMethod(project, struct, method);
+    if (generatedMethod == null) return;
+    PsiElement newLine = GoElementFactory.createNewLine(project);
+    // TODO Better element positioning
+    file.add(newLine);
+    file.add(newLine);
+    file.add(generatedMethod);
+    file.add(newLine);
+  }
+
   public static void deleteSpec(@NotNull GoVarDeclaration declaration, @NotNull GoVarSpec specToDelete) {
     List<GoVarSpec> specList = declaration.getVarSpecList();
     int index = specList.indexOf(specToDelete);


### PR DESCRIPTION
This aims to provide a way to generate the mock implementations for interfaces for a struct.

Things left to do:

- [ ] allow this to run on all local types (Go allows defining methods on any local types, not only structs)
- [ ] gather all the interfaces
- [ ] provide a better way to select which interface should be implemented
- [ ] check which method is already implemented by the type before creating the implementation
 - [ ] ask to rename existing methods that don't have the same signature before continuing
- [ ] better positioning for the newly created methods
- [ ] allow better cursor positioning
- [ ] analyze existing methods on the type in check if the receiver should be a pointer or value
- [ ] tests