### PR TITLE
squid:S1197 - Array designators [] should be on the type, not the var…

### DIFF
--- a/gen/com/goide/lexer/_GoLexer.java
+++ b/gen/com/goide/lexer/_GoLexer.java
@@ -30,7 +30,7 @@ public class _GoLexer implements FlexLexer, GoTypes {
    *                  at the beginning of a line
    * l is of the form l = 2*k, k a non negative integer
    */
-  private static final int ZZ_LEXSTATE[] = { 
+  private static final int[] ZZ_LEXSTATE = { 
      0,  0,  1, 1
   };
 
@@ -452,7 +452,7 @@ public class _GoLexer implements FlexLexer, GoTypes {
   private static java.io.Reader zzReader = null; // Fake
 
   /* error messages for the codes above */
-  private static final String ZZ_ERROR_MSG[] = {
+  private static final String[] ZZ_ERROR_MSG = {
     "Unkown internal scanner error",
     "Error: could not match input",
     "Error: pushback value was too large"

--- a/plan9/src/com/plan9/intel/ide/highlighting/AsmIntelHighlightingLexer.java
+++ b/plan9/src/com/plan9/intel/ide/highlighting/AsmIntelHighlightingLexer.java
@@ -27,7 +27,7 @@ class AsmIntelHighlightingLexer implements FlexLexer {
    *                  at the beginning of a line
    * l is of the form l = 2*k, k a non negative integer
    */
-  private static final int ZZ_LEXSTATE[] = { 
+  private static final int[] ZZ_LEXSTATE = { 
      0, 0
   };
 
@@ -1060,7 +1060,7 @@ class AsmIntelHighlightingLexer implements FlexLexer {
   private static java.io.Reader zzReader = null; // Fake
 
   /* error messages for the codes above */
-  private static final String ZZ_ERROR_MSG[] = {
+  private static final String[] ZZ_ERROR_MSG = {
     "Unkown internal scanner error",
     "Error: could not match input",
     "Error: pushback value was too large"

--- a/plan9/src/com/plan9/intel/lang/core/lexer/AsmIntelLexer.java
+++ b/plan9/src/com/plan9/intel/lang/core/lexer/AsmIntelLexer.java
@@ -28,7 +28,7 @@ class AsmIntelLexer implements FlexLexer, AsmIntelTypes {
    *                  at the beginning of a line
    * l is of the form l = 2*k, k a non negative integer
    */
-  private static final int ZZ_LEXSTATE[] = { 
+  private static final int[] ZZ_LEXSTATE = { 
      0, 0
   };
 
@@ -868,7 +868,7 @@ class AsmIntelLexer implements FlexLexer, AsmIntelTypes {
   private static java.io.Reader zzReader = null; // Fake
 
   /* error messages for the codes above */
-  private static final String ZZ_ERROR_MSG[] = {
+  private static final String[] ZZ_ERROR_MSG = {
     "Unkown internal scanner error",
     "Error: could not match input",
     "Error: pushback value was too large"


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule Array designators [] should be on the type, not the variable and squid:S1197
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197
Please let me know if you have any questions.
M-Ezzat