### PR TITLE
squid:S2162, squid:S2063 -  equals methods should be symmetric and wo…

### DIFF
--- a/src/com/goide/actions/file/GoCreateFileAction.java
+++ b/src/com/goide/actions/file/GoCreateFileAction.java
@@ -94,6 +94,9 @@ public class GoCreateFileAction extends CreateFileFromTemplateAction implements 
 
   @Override
   public boolean equals(Object obj) {
-    return obj instanceof GoCreateFileAction;
+    if (obj != null) {
+      return this.getClass() == obj.getClass();
+    }
+    return false;
   }
 }

--- a/src/com/goide/codeInsight/imports/GoImportPackageQuickFix.java
+++ b/src/com/goide/codeInsight/imports/GoImportPackageQuickFix.java
@@ -54,6 +54,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -236,7 +237,9 @@ public class GoImportPackageQuickFix extends LocalQuickFixAndIntentionActionOnPs
     }
   }
 
-  private static class MyImportsComparator implements Comparator<String> {
+  private static class MyImportsComparator implements Comparator<String>, Serializable {
+    private static final long serialVersionUID = 1L;
+
     @Nullable
     private final String myContextImportPath;
 

--- a/src/com/goide/runconfig/testing/coverage/GoCoverageProjectData.java
+++ b/src/com/goide/runconfig/testing/coverage/GoCoverageProjectData.java
@@ -90,7 +90,9 @@ public class GoCoverageProjectData extends ProjectData {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof GoCoverageProjectData)) return false;
+    if (o != null && this.getClass() != o.getClass()) {
+      return false;
+    }
 
     GoCoverageProjectData data = (GoCoverageProjectData)o;
 
@@ -122,7 +124,9 @@ public class GoCoverageProjectData extends ProjectData {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof FileData)) return false;
+      if (o != null && this.getClass() != o.getClass()) {
+        return false;
+      }
 
       FileData fileData = (FileData)o;
 
@@ -160,7 +164,11 @@ public class GoCoverageProjectData extends ProjectData {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (!(o instanceof RangeData)) return false;
+      if (o != null) {
+        if (this.getClass() != o.getClass()) {
+          return false;
+        }
+      }
 
       RangeData data = (RangeData)o;
 

--- a/src/com/goide/tree/ExportabilityComparator.java
+++ b/src/com/goide/tree/ExportabilityComparator.java
@@ -20,9 +20,12 @@ import com.goide.psi.GoNamedElement;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class ExportabilityComparator implements Comparator {
+public class ExportabilityComparator implements Comparator, Serializable {
+  private static final long serialVersionUID = 1L;
+
   public static final Comparator INSTANCE = new ExportabilityComparator();
 
   @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 and squid:S2063
"equals" methods should be symmetric and work for subclasses and Comparators should be "Serializable"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063
Please let me know if you have any questions.
M-Ezzat