### PR TITLE
Add support for Github issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+- Plugin version (or commit hash):
+- IDE name and version:
+- Java version:
+- OS name and version: 
+
+- What are you trying to do?
+
+- What would you expect to happen?
+
+- What happens?
+
+
+Your issue description goes here.
+Please be as detailed as possible
+
+```go
+Please include a go sample to reproduce the issue
+```
+
+Or include a screenshot / video of the issue.


### PR DESCRIPTION
As Github finally added this feature, we should make use of it.
This is the announcement blog post: https://github.com/blog/2111-issue-and-pull-request-templates
Please let me know if we should add anything missing to it.
Thank you.

P.S. Should I also add a PR template to ask if people have a signed CLA?