### PR TITLE
Added copyright note for the icons (fixes #2371)

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright 2013-2015 Sergey Ignatov, Alexander Zolotov, Mihai Toader, Florin Patan
+Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ functionality that you'd like to see. In order to get started, see the
 [contribution](CONTRIBUTING.md) guide.
 
 ## [People who helped](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/graphs/contributors)
+
+## License
+
+The Gopher icons are based on the Go mascot designed by [Renée French](http://reneefrench.blogspot.com/) and copyrighted under the [Creative Commons Attribution 3.0 license](http://creativecommons.org/licenses/by/3.0/us/).
+
+The plugin is distributed under Apache License, version 2.0. For full license terms, see [LICENCE](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/master/LICENCE).

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,6 +23,10 @@
 
   <description><![CDATA[
     Support for Go programming language.
+    
+    The Gopher icons are based on the Go mascot designed by Renée French, http://reneefrench.blogspot.com/, and copyrighted under the Creative Commons Attribution 3.0 license, http://creativecommons.org/licenses/by/3.0/us/.
+
+    The plugin is distributed under Apache License, version 2.0. For full license terms, see https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/master/LICENCE
     ]]></description>
 
   <change-notes>


### PR DESCRIPTION
This adds the copyright for the Gopher icons to the plugin as per requirements.
Also it updates the copyright notice in the LICENCE file.

Fixes #2371