### PR TITLE
Run tests one package at a time

### DIFF
--- a/src/com/goide/runconfig/testing/GoTestRunningState.java
+++ b/src/com/goide/runconfig/testing/GoTestRunningState.java
@@ -98,6 +98,10 @@ public class GoTestRunningState extends GoRunningState<GoTestRunConfiguration> {
   @Override
   protected GoExecutor patchExecutor(@NotNull GoExecutor executor) throws ExecutionException {
     executor.withParameters("test", "-v");
+    // By default go tool is testing several packages in parallel. That does
+    // not play well with testing progress visualization. Therefore one package
+    // at a time is forced.
+    executor.withParameters("-p", "1");
     executor.withParameterString(myConfiguration.getGoToolParams());
     switch (myConfiguration.getKind()) {
       case DIRECTORY:


### PR DESCRIPTION
By default go tool is testing several packages in parallel. That does not play well with testing progress visualization. Besides if tests use the same test DB or something like that they can affect each other progress resulting in sporadic failures. Fortunately **one package at a time** testing can be forced with `-p 1` flag.