### PR TITLE
Improve completion in struct literals

### DIFF
--- a/src/com/goide/completion/GoKeywordCompletionContributor.java
+++ b/src/com/goide/completion/GoKeywordCompletionContributor.java
@@ -118,6 +118,7 @@ public class GoKeywordCompletionContributor extends CompletionContributor implem
       psiElement(GoReferenceExpression.class)
         .andNot(insideConstSpec())
         .andNot(insideSelectorExpression())
+        .without(new FieldNameInStructLiteral())
         .withParent(not(psiElement(GoSelectorExpr.class))).with(new GoNonQualifiedReference()));
   }
 
@@ -192,6 +193,18 @@ public class GoKeywordCompletionContributor extends CompletionContributor implem
     @Override
     public boolean accepts(@NotNull GoReferenceExpressionBase element, ProcessingContext context) {
       return element.getQualifier() == null;
+    }
+  }
+
+  private static class FieldNameInStructLiteral extends PatternCondition<GoReferenceExpression> {
+    public FieldNameInStructLiteral() {
+      super("field name in struct literal");
+    }
+
+    @Override
+    public boolean accepts(@NotNull GoReferenceExpression expression, ProcessingContext context) {
+      GoStructLiteralCompletion.Variants variants = GoStructLiteralCompletion.allowedVariants(expression);
+      return variants == GoStructLiteralCompletion.Variants.FIELD_NAME_ONLY;
     }
   }
 }

--- a/src/com/goide/completion/GoStructLiteralCompletion.java
+++ b/src/com/goide/completion/GoStructLiteralCompletion.java
@@ -32,7 +32,34 @@ import java.util.List;
 import java.util.Set;
 
 class GoStructLiteralCompletion {
-  enum Variants {FIELD_NAME_ONLY, VALUE_ONLY, BOTH, NONE}
+  /**
+   * Describes struct literal completion variants that should be suggested.
+   */
+  enum Variants {
+    /**
+     * Only struct field names should be suggested.
+     * Indicates that field:value initializers are used in this struct literal.
+     * For example, {@code Struct{field1: "", caret}}.
+     */
+    FIELD_NAME_ONLY,
+    /**
+     * Only values should be suggested.
+     * Indicates that value initializers are used in this struct literal.
+     * For example, {@code Struct{"", caret}}.
+     */
+    VALUE_ONLY,
+    /**
+     * Both struct field names and values should be suggested.
+     * Indicates that there's no reliable way to determine whether field:value or value initializers are used.
+     * Example 1: {@code Struct{caret}}.
+     * Example 2: {@code Struct{field1:"", "", caret}}
+     */
+    BOTH,
+    /**
+     * Indicates that struct literal completion should not be available.
+     */
+    NONE
+  }
 
   @NotNull
   static Variants allowedVariants(@Nullable GoReferenceExpression structFieldReference) {

--- a/src/com/goide/completion/GoStructLiteralCompletion.java
+++ b/src/com/goide/completion/GoStructLiteralCompletion.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.completion;
+
+import com.goide.psi.*;
+import com.goide.psi.impl.GoPsiImplUtil;
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.Conditions;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.Function;
+import com.intellij.util.ObjectUtils;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Set;
+
+class GoStructLiteralCompletion {
+  enum Variants {FIELD_NAME_ONLY, VALUE_ONLY, BOTH, NONE}
+
+  @NotNull
+  static Variants allowedVariants(@Nullable GoReferenceExpression structFieldReference) {
+    GoValue value = parent(structFieldReference, GoValue.class);
+    GoElement element = parent(value, GoElement.class);
+    if (element != null && element.getKey() != null) {
+      return Variants.NONE;
+    }
+
+    GoLiteralValue literalValue = parent(element, GoLiteralValue.class);
+    GoCompositeLit structLiteral = parent(literalValue, GoCompositeLit.class);
+    GoType type = GoPsiImplUtil.getLiteralType(structLiteral);
+    if (!(type instanceof GoStructType)) {
+      return Variants.NONE;
+    }
+
+    boolean hasValueInitializers = false;
+    boolean hasFieldValueInitializers = false;
+
+    List<GoElement> fieldInitializers = literalValue.getElementList();
+    for (GoElement initializer : fieldInitializers) {
+      if (initializer == element) {
+        continue;
+      }
+
+      PsiElement colon = initializer.getColon();
+      hasFieldValueInitializers |= colon != null;
+      hasValueInitializers |= colon == null;
+    }
+
+    return hasFieldValueInitializers && !hasValueInitializers ? Variants.FIELD_NAME_ONLY :
+           !hasFieldValueInitializers && hasValueInitializers ? Variants.VALUE_ONLY :
+           Variants.BOTH;
+  }
+
+  @NotNull
+  static Condition<String> newIsFieldAssignedPredicate(@Nullable GoLiteralValue literal) {
+    if (literal == null) {
+      return Conditions.alwaysFalse();
+    }
+
+    final Set<String> assignedFields = ContainerUtil.map2SetNotNull(literal.getElementList(), new Function<GoElement, String>() {
+      @Override
+      public String fun(GoElement element) {
+        GoKey key = element.getKey();
+        GoFieldName fieldName = key != null ? key.getFieldName() : null;
+        PsiElement identifier = fieldName != null ? fieldName.getIdentifier() : null;
+        return identifier != null ? identifier.getText() : null;
+      }
+    });
+
+    return new Condition<String>() {
+      @Override
+      public boolean value(String fieldName) {
+        return assignedFields.contains(fieldName);
+      }
+    };
+  }
+
+  @Contract("null,_->null")
+  private static <T> T parent(@Nullable PsiElement of, @NotNull Class<T> parentClass) {
+    return ObjectUtils.tryCast(of != null ? of.getParent() : null, parentClass);
+  }
+}

--- a/src/com/goide/psi/impl/GoFieldNameReference.java
+++ b/src/com/goide/psi/impl/GoFieldNameReference.java
@@ -53,7 +53,7 @@ public class GoFieldNameReference extends GoCachedReference<GoReferenceExpressio
     if (key == null && (value == null || PsiTreeUtil.getPrevSiblingOfType(value, GoKey.class) != null)) return true;
 
     GoCompositeLit lit = getLiteral();
-    GoType type = getLiteralType(lit);
+    GoType type = GoPsiImplUtil.getLiteralType(lit);
     
     PsiElement p = PsiTreeUtil.getParentOfType(myElement, GoLiteralValue.class);
     while (lit != null && p != null) {
@@ -64,15 +64,6 @@ public class GoFieldNameReference extends GoCachedReference<GoReferenceExpressio
 
     if (!processStructType(fieldProcessor, type)) return false;
     return !(type instanceof GoPointerType && !processStructType(fieldProcessor, ((GoPointerType)type).getType()));
-  }
-
-  @Nullable
-  private static GoType getLiteralType(@Nullable GoCompositeLit lit) {
-    GoType type = lit != null ? lit.getType() : null;
-    if (type != null) return type;
-    GoTypeReferenceExpression ref = lit != null ? lit.getTypeReferenceExpression() : null;
-    GoType resolve = ref == null ? null : ref.resolveType();
-    return resolve != null ? resolve.getUnderlyingType() : null;
   }
 
   @Nullable
@@ -122,7 +113,7 @@ public class GoFieldNameReference extends GoCachedReference<GoReferenceExpressio
   }
 
   public boolean inStructTypeKey() {
-    return myValue == null && getLiteralType(getLiteral()) instanceof GoStructType;
+    return myValue == null && GoPsiImplUtil.getLiteralType(getLiteral()) instanceof GoStructType;
   }
 
   @Nullable

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -498,6 +498,15 @@ public class GoPsiImplUtil {
     return o.getReference().resolve();
   }
 
+  @Nullable
+  public static GoType getLiteralType(@Nullable GoCompositeLit lit) {
+    GoType type = lit != null ? lit.getType() : null;
+    if (type != null) return type;
+    GoTypeReferenceExpression ref = lit != null ? lit.getTypeReferenceExpression() : null;
+    GoType resolve = ref == null ? null : ref.resolveType();
+    return resolve != null ? resolve.getUnderlyingType() : null;
+  }
+
   public static GoType resolveType(@NotNull GoTypeReferenceExpression expression) {
     PsiElement resolve = expression.resolve();
     if (resolve instanceof GoTypeSpec) return ((GoTypeSpec)resolve).getSpecType();

--- a/tests/com/goide/completion/GoCompletionTest.java
+++ b/tests/com/goide/completion/GoCompletionTest.java
@@ -560,6 +560,42 @@ public class GoCompletionTest extends GoCompletionTestBase {
     myFixture.checkResult("package mytest; func TestSomething() { MyFunction() }");
   }
 
+  public void testFieldNamesInEmptyStructLiteral() {
+    String source = "package test; " +
+                    "type A struct { field_in_a string }; " +
+                    "type B struct { A; field_in_b string }; " +
+                    "func Test() B { a := A{}; s := \"\"; return B{<caret>}; }";
+    doTestInclude(source, "a", "A", "field_in_b");
+  }
+
+  public void testFieldNamesInStructLiteralWithNameValueInitializers() {
+    String source = "package test; " +
+                    "type A struct { field_in_a string }; " +
+                    "type B struct { A; field_in_b string }; " +
+                    "func Test() B { a := A{}; s := \"\"; return B{ A: A{}, <caret>}; }";
+    doTestEquals(source, "field_in_b");
+  }
+
+  public void testNoFieldNamesInStructLiteralWithValueInitializers() {
+    String source = "package test; " +
+                    "type A struct { field_in_a string }; " +
+                    "type B struct { A; field_in_b string }; " +
+                    "func Test() B { a := A{}; s := \"\"; return B{ A{}, <caret>}; }";
+    myFixture.configureByText("test.go", source);
+    myFixture.completeBasic();
+    List<String> variants = myFixture.getLookupElementStrings();
+    assertNotNull(variants);
+    assertContainsElements(variants, "s");
+    assertDoesntContain(variants, "field_in_b");
+  }
+
+  public void testStructFieldValueCompletion() {
+    String source = "package test; " +
+                    "type A struct { field1 string; field2 string }; " +
+                    "func Test() A { s := \"\"; return A{field1: \"\", field2: <caret>}; }";
+    doTestInclude(source, "s");
+  }
+
   private void doTestEmptyCompletion() {
     myFixture.testCompletionVariants(getTestName(true) + ".go");
   }


### PR DESCRIPTION
Do not suggest field names when value initializer is used.
Do not suggest values when field:value initializer is used.
Only show unassigned fields in completion list.