### PR TITLE
Added custom theme

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -302,6 +302,10 @@
                      groupName="General" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoUnderscoreUsedAsValueInspection"/>
     <!-- /general -->
+
+    <!-- color schemes -->
+    <bundledColorScheme path="colorscheme/Darcula - dlsniper"/>
+    <!-- /color schemes -->
   </extensions>
   <actions>
     <action id="Go.NewGoFile" class="com.goide.actions.file.GoCreateFileAction"

--- a/resources/colorscheme/Darcula - dlsniper.xml
+++ b/resources/colorscheme/Darcula - dlsniper.xml
@@ -1,0 +1,107 @@
+<scheme name="Darcula - dlsniper" version="142" parent_scheme="Darcula">
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="14" />
+  <option name="EDITOR_FONT_NAME" value="Source Code Pro" />
+  <attributes>
+    <option name="GO_EXPORTED_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="ffe37b" />
+      </value>
+    </option>
+    <option name="GO_FUNCTION_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="9077c6" />
+      </value>
+    </option>
+    <option name="GO_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="9077c6" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="9876aa" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="ff7b00" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="6598c6" />
+      </value>
+    </option>
+    <option name="GO_METHOD_RECEIVER">
+      <value>
+        <option name="FOREGROUND" value="ffff00" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="9876aa" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="c6a469" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_STRUCT">
+      <value>
+        <option name="FOREGROUND" value="c67f58" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="9077c6" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="be93d0" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="7d91c6" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_STRUCT">
+      <value>
+        <option name="FOREGROUND" value="8996a5" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="816093" />
+      </value>
+    </option>
+    <option name="GO_SCOPE_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="c6c0" />
+      </value>
+    </option>
+    <option name="GO_STRING">
+      <value>
+        <option name="FOREGROUND" value="30be47" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_EXPORTED_MEMBER">
+      <value>
+        <option name="FOREGROUND" value="5bc600" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_LOCAL_MEMBER">
+      <value>
+        <option name="FOREGROUND" value="c62b" />
+      </value>
+    </option>
+    <option name="GO_TYPE_SPECIFICATION">
+      <value>
+        <option name="FOREGROUND" value="51c688" />
+      </value>
+    </option>
+  </attributes>
+</scheme>


### PR DESCRIPTION
I'd like to add the theme that I'm using daily since about a year now, see below. I've spoke briefly about this on Gitter, so hope it's ok.

There are some people that agree we could ship better default themes but I'm not sure how to achieve that right now.

I've looked at a few themes on http://color-themes.com/ (lovely website btw) and I have a few suggestions to add:
- white backgrounds:
 - [Relax Your Eyes](http://color-themes.com/?view=theme&id=563a1a6e80b4acf11273ae76)
 - [Classic Eclipse](http://color-themes.com/?view=theme&id=563a1a6b80b4acf11273ae67)
 - [Codding Horror](http://color-themes.com/?view=theme&id=563a1a6a80b4acf11273ae63)
- dark backgrounds:
 - [Monokai Sublime Text 3](http://color-themes.com/?view=theme&id=563a1a7680b4acf11273ae94) *
 - [Base16 Ocean](http://color-themes.com/?view=theme&id=563a1a7880b4acf11273ae9b) *
 - [Programmer](http://color-themes.com/?view=theme&id=563a1a6880b4acf11273ae5a)

I've marked with * those that some gophers in the slack channel indicated as being most used by them.

I've looked a bit into them and I don't have a full grasp on how to embed them just yet. A possible issue that I can see is that IntelliJ doesn't support color schemes that apply only to certain languages so if we ship a theme it will go out for everyone. This leads to the problem that once we ship a theme as part of the plugin then I'm not sure what will happen to existing themes with the same name and, from what I can see, in order to get it modified it will have to be saved first (which again goes against how this will work for people already using these themes?)

Thank you.

Color scheme preview:
![Darcula - dlsniper](https://cloud.githubusercontent.com/assets/607868/14582595/c05d7264-0401-11e6-8105-49ed53efe203.png)