### PR TITLE
Add delay after initializing breakpoints (fixes #2360)

### DIFF
--- a/src/com/goide/dlv/DlvDebugProcess.java
+++ b/src/com/goide/dlv/DlvDebugProcess.java
@@ -57,9 +57,7 @@ import org.jetbrains.debugger.Location;
 import org.jetbrains.debugger.StepAction;
 import org.jetbrains.debugger.connection.RemoteVmConnection;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.goide.dlv.protocol.DlvApi.*;
@@ -78,6 +76,7 @@ public final class DlvDebugProcess extends DebugProcessImpl<RemoteVmConnection> 
       LOG.info(throwable);
     }
   };
+  private Timer timer = new Timer();
 
   @NotNull
   private final Consumer<DebuggerState> myStateConsumer = new Consumer<DebuggerState>() {
@@ -180,7 +179,18 @@ public final class DlvDebugProcess extends DebugProcessImpl<RemoteVmConnection> 
 
     if (setBreakpoints) {
       doSetBreakpoints();
-      resume();
+      timer.cancel();
+      timer = new Timer();
+
+      TimerTask action = new TimerTask() {
+        @Override
+        public void run() {
+          resume();
+        }
+
+      };
+
+      timer.schedule(action, 40);
     }
 
     return true;


### PR DESCRIPTION
This aims to fix the issue that we send the breakpoints then the start
command to fast by adding a delay between the moment the breakpoints
are sent to the moment the start command is sent (fixes #2360)

Experimental fix from forked from latest master as of 28/04/2016 00:00 UTC+1: https://www.dropbox.com/s/f5k83l5pcjlna56/Go-0.11.SNAPSHOT-delay.zip?dl=0