### PR TITLE
Added inspection for mixed named and unnamed parameters (fixes #2494)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -328,9 +328,11 @@
                      groupName="General" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoUnderscoreUsedAsValueInspection"/>
     <localInspection language="go" displayName="Invalid strings and runes" groupPath="Go"
-                     groupName="General" enabledByDefault="true" level="ERROR" 
+                     groupName="General" enabledByDefault="true" level="ERROR"
                      implementationClass="com.goide.inspections.GoInvalidStringOrCharInspection"/>
-
+    <localInspection language="go" displayName="Mixed named and unnamed parameters" groupPath="Go"
+                     groupName="General" enabledByDefault="true" level="ERROR"
+                     implementationClass="com.goide.inspections.GoMixedNamedUnnamedParametersInspection"/>
     <!-- /general -->
 
     <!-- color schemes -->

--- a/resources/inspectionDescriptions/GoMixedNamedUnnamedParameters.html
+++ b/resources/inspectionDescriptions/GoMixedNamedUnnamedParameters.html
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+<body>
+Check if the function declares named and unnamed return parameters for
+</body>
+</html>

--- a/src/com/goide/inspections/GoMixedNamedUnnamedParametersInspection.java
+++ b/src/com/goide/inspections/GoMixedNamedUnnamedParametersInspection.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.*;
+import com.goide.runconfig.testing.GoTestFinder;
+import com.goide.runconfig.testing.GoTestFunctionType;
+import com.intellij.codeInspection.LocalInspectionToolSession;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.progress.ProgressManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class GoMixedNamedUnnamedParametersInspection extends GoInspectionBase {
+  @NotNull
+  @Override
+  protected GoVisitor buildGoVisitor(@NotNull final ProblemsHolder holder, @NotNull LocalInspectionToolSession session) {
+    return new GoVisitor() {
+      @Override
+      public void visitMethodDeclaration(@NotNull GoMethodDeclaration o) {
+        super.visitMethodDeclaration(o);
+        visitDeclaration(holder, o.getSignature(), "Method");
+      }
+
+      @Override
+      public void visitFunctionDeclaration(@NotNull GoFunctionDeclaration o) {
+        super.visitFunctionDeclaration(o);
+        visitDeclaration(holder, o.getSignature(), "Function");
+      }
+
+      @Override
+      public void visitFunctionLit(@NotNull GoFunctionLit o) {
+        super.visitFunctionLit(o);
+        visitDeclaration(holder, o.getSignature(), "Closure");
+      }
+    };
+  }
+
+  private static void visitDeclaration(@NotNull ProblemsHolder holder, @Nullable GoSignature signature, String ownerType) {
+    if (signature == null) return;
+    GoParameters parameters = signature.getParameters();
+    visitParameterList(holder, parameters, ownerType, "parameters");
+
+    GoResult result = signature.getResult();
+    parameters = result != null ? result.getParameters() : null;
+    visitParameterList(holder, parameters, ownerType, "return parameters");
+  }
+
+  private static void visitParameterList(
+    @NotNull ProblemsHolder holder,
+    @Nullable GoParameters parameters,
+    String ownerType,
+    String what) {
+
+    if (parameters == null || parameters.getParameterDeclarationList().isEmpty()) return;
+    ProgressManager.checkCanceled();
+    boolean hasNamed = false;
+    boolean hasUnnamed = false;
+    for (GoParameterDeclaration parameterDeclaration : parameters.getParameterDeclarationList()) {
+      if (parameterDeclaration.getParamDefinitionList().isEmpty()) {
+        hasUnnamed = true;
+      }
+      else {
+        hasNamed = true;
+      }
+
+      if (hasNamed && hasUnnamed) {
+        holder.registerProblem(
+          parameters,
+          ownerType + " has both named and unnamed " + what + " <code>#ref</code> #loc",
+          ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+
+        return;
+      }
+    }
+  }
+}

--- a/testData/highlighting/mixedNamedUnnamedParameters.go
+++ b/testData/highlighting/mixedNamedUnnamedParameters.go
@@ -1,0 +1,43 @@
+package main
+
+func _(<warning descr="Unused parameter 'int1'">int1</warning>, <warning descr="Unused parameter 'string1'">string1</warning>, <warning descr="Unused parameter 'a1'">a1</warning> error) (<warning descr="Unused named return parameter 'int'">int</warning>, <warning descr="Unused named return parameter 'string'">string</warning>, <warning descr="Unused named return parameter 'a'">a</warning> error) {
+	return 1, "a", nil
+}
+
+func _(int, string, error) (int, string, error) {
+	return 1, "a", nil
+}
+
+func _<error descr="Function has both named and unnamed parameters '(a1, b1 int, string, error)'">(a1, b1 int, string, error)</error> (<error descr="Unresolved type 'a'">a</error>, <error descr="Unresolved type 'b'">b</error>, int, string, error) {
+	return 1, 2, "a", nil
+}
+
+type d int
+
+func (d) _(int1, string1, a1 error) (<warning descr="Unused named return parameter 'int'">int</warning>, <warning descr="Unused named return parameter 'string'">string</warning>, <warning descr="Unused named return parameter 'a'">a</warning> error) {
+	return 1, "a", nil
+}
+
+func (d) _(int, string, error) (int, string, error) {
+	return 1, "a", nil
+}
+
+func (d) _<error descr="Method has both named and unnamed parameters '(a1, b1 int, string, error)'">(a1, b1 int, string, error)</error> <error descr="Method has both named and unnamed return parameters '(a, b int, string, error)'">(a, b int, string, error)</error> {
+	return 1, 2, "a", nil
+}
+
+func main() {
+	x := func(int1, string1, a1 error) (int, string, a error) {
+		return 1, "a", nil
+	}
+
+	y := func(int, string, error) (int, string, error) {
+		return 1, "a", nil
+	}
+
+	z := func<error descr="Closure has both named and unnamed parameters '(a1, b1 int, string, error)'">(a1, b1 int, string, error)</error> <error descr="Closure has both named and unnamed return parameters '(a, b int, string, error)'">(a, b int, string, error)</error> {
+		return 1, 2, "a", nil
+	}
+
+	_, _, _ = x, y, z
+}

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -70,7 +70,8 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
       GoUnderscoreUsedAsValueInspection.class,
       GoRangeIterationOnIllegalTypeInspection.class,
       GoUnusedParameterInspection.class,
-      GoInvalidStringOrCharInspection.class
+      GoInvalidStringOrCharInspection.class,
+      GoMixedNamedUnnamedParametersInspection.class
     );
   }
 
@@ -82,6 +83,11 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {
     return "highlighting";
+  }
+
+  @Override
+  protected boolean isWriteActionRequired() {
+    return false;
   }
 
   public void testSimple()                    { doTest(); }
@@ -153,6 +159,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testStringSliceWithThirdIndex() { doTest(); }
   public void testSliceWithThirdIndex()       { doTest(); }
   public void testStringInStructSliceWithThirdIndex() { doTest(); }
+  public void testMixedNamedUnnamedParameters() { doTest(); }
 
   public void testAvoidDuplicatedUnusedImportReports() {
     myFixture.addFileToProject("pack1/a.go", "package foo;");


### PR DESCRIPTION
The inspection might need a better reporting target. As for a quick fix, I'm not sure how to proceed on this as there are different issues with each approach (make everything named, make everything unnamed).