### PR TITLE
Split unused function inspection (fixes #2374)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -192,6 +192,9 @@
     <localInspection language="go" displayName="Unused global variable inspection" groupPath="Go"
                      groupName="Declaration redundancy" enabledByDefault="true" level="WARNING"
                      implementationClass="com.goide.inspections.unresolved.GoUnusedGlobalVariableInspection"/>
+    <localInspection language="go" displayName="Unused exported function inspection" groupPath="Go"
+                     groupName="Declaration redundancy" enabledByDefault="true" level="WARNING"
+                     implementationClass="com.goide.inspections.unresolved.GoUnusedExportedFunctionInspection"/>
     <localInspection language="go" displayName="Unused function inspection" groupPath="Go"
                      groupName="Declaration redundancy" enabledByDefault="true" level="WARNING"
                      implementationClass="com.goide.inspections.unresolved.GoUnusedFunctionInspection"/>

--- a/resources/inspectionDescriptions/GoUnusedExportedFunction.html
+++ b/resources/inspectionDescriptions/GoUnusedExportedFunction.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Checks unused exported functions.
+</body>
+</html>

--- a/resources/inspectionDescriptions/GoUnusedFunction.html
+++ b/resources/inspectionDescriptions/GoUnusedFunction.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Checks unused functions.
+Checks unused unexported functions.
 </body>
 </html>

--- a/src/com/goide/inspections/unresolved/GoUnusedExportedFunctionInspection.java
+++ b/src/com/goide/inspections/unresolved/GoUnusedExportedFunctionInspection.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections.unresolved;
+
+import com.intellij.openapi.util.text.StringUtil;
+
+public class GoUnusedExportedFunctionInspection extends GoUnusedFunctionInspection {
+  @Override
+  protected boolean canRun(String name) {
+    return StringUtil.isCapitalized(name);
+  }
+}

--- a/src/com/goide/inspections/unresolved/GoUnusedFunctionInspection.java
+++ b/src/com/goide/inspections/unresolved/GoUnusedFunctionInspection.java
@@ -29,6 +29,7 @@ import com.intellij.codeInspection.LocalInspectionToolSession;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.searches.ReferencesSearch;
 import org.jetbrains.annotations.NotNull;
@@ -43,6 +44,7 @@ public class GoUnusedFunctionInspection extends GoInspectionBase {
         if (o.isBlank()) return;
         GoFile file = o.getContainingFile();
         String name = o.getName();
+        if (!canRun(name)) return;
         if (GoConstants.MAIN.equals(file.getPackageName()) && GoConstants.MAIN.equals(name)) return;
         if (GoConstants.INIT.equals(name)) return;
         if (GoTestFinder.isTestFile(file) && GoTestFunctionType.fromName(name) != null) return;
@@ -54,5 +56,9 @@ public class GoUnusedFunctionInspection extends GoInspectionBase {
         }
       }
     };
+  }
+
+  protected boolean canRun(String name) {
+    return !StringUtil.isCapitalized(name);
   }
 }

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -43,6 +43,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
       GoUnusedConstInspection.class,
       GoUnusedGlobalVariableInspection.class,
       GoUnusedFunctionInspection.class,
+      GoUnusedExportedFunctionInspection.class,
       GoAssignmentToConstantInspection.class,
       GoDuplicateFunctionOrMethodInspection.class,
       GoDuplicateArgumentInspection.class,


### PR DESCRIPTION
Following the chat here: https://github.com/go-lang-plugin-org/go-lang-idea-plugin/pull/2515#issuecomment-218720494 this splits the unused function inspection