### PR TITLE
Rework placeholder count inspection (fixes #2188)

### DIFF
--- a/src/com/goide/inspections/GoPlaceholderChecker.java
+++ b/src/com/goide/inspections/GoPlaceholderChecker.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.GoFunctionOrMethodDeclaration;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+import static com.goide.GoConstants.TESTING_PATH;
+import static com.goide.inspections.GoPlaceholderChecker.PrintfArgumentType.*;
+
+public class GoPlaceholderChecker {
+
+  // This holds the name of the known formatting functions and position of the string to be formatted
+  private static final Map<String, Integer> FORMATTING_FUNCTIONS = ContainerUtil.newHashMap(
+    Pair.pair("errorf", 0),
+    Pair.pair("fatalf", 0),
+    Pair.pair("fprintf", 1),
+    Pair.pair("fscanf", 1),
+    Pair.pair("logf", 0),
+    Pair.pair("panicf", 0),
+    Pair.pair("printf", 0),
+    Pair.pair("scanf", 0),
+    Pair.pair("skipf", 0),
+    Pair.pair("sprintf", 0),
+    Pair.pair("sscanf", 1));
+
+  private static final Set<String> PRINTING_FUNCTIONS = ContainerUtil.newHashSet(
+    "error",
+    "error",
+    "fatal",
+    "fprint",
+    "fprintln",
+    "log",
+    "panic",
+    "panicln",
+    "print",
+    "println",
+    "sprint",
+    "sprintln"
+  );
+
+  protected enum PrintfArgumentType {
+    ANY(-1),
+    BOOL(1),
+    INT(2),
+    RUNE(3),
+    STRING(4),
+    FLOAT(5),
+    COMPLEX(6),
+    POINTER(7);
+
+    private int myMask;
+
+    PrintfArgumentType(int mask) {
+      myMask = mask;
+    }
+
+    public int getValue() {
+      return myMask;
+    }
+  }
+
+  enum PrintVerb {
+    Percent('%', "", 0),
+    b('b', " -+.0", INT.getValue() | FLOAT.getValue() | COMPLEX.getValue()),
+    c('c', "-", RUNE.getValue() | INT.getValue()),
+    d('d', " -+.0", INT.getValue()),
+    e('e', " -+.0", FLOAT.getValue() | COMPLEX.getValue()),
+    E('E', " -+.0", FLOAT.getValue() | COMPLEX.getValue()),
+    f('f', " -+.0", FLOAT.getValue() | COMPLEX.getValue()),
+    F('F', " -+.0", FLOAT.getValue() | COMPLEX.getValue()),
+    g('g', " -+.0", FLOAT.getValue() | COMPLEX.getValue()),
+    G('G', " -+.0", FLOAT.getValue() | COMPLEX.getValue()),
+    o('o', " -+.0#", INT.getValue()),
+    p('p', "-#", POINTER.getValue()),
+    q('q', " -+.0#", RUNE.getValue() | INT.getValue() | STRING.getValue()),
+    s('s', " -+.0", STRING.getValue()),
+    t('t', "-", BOOL.getValue()),
+    T('T', "-", ANY.getValue()),
+    U('U', "-#", RUNE.getValue() | INT.getValue()),
+    V('v', " -+.0#", ANY.getValue()),
+    x('x', " -+.0#", RUNE.getValue() | INT.getValue() | STRING.getValue()),
+    X('X', " -+.0#", RUNE.getValue() | INT.getValue() | STRING.getValue());
+
+    private char myVerb;
+    private String myFlags;
+    private int myMask;
+
+    PrintVerb(char verb, String flags, int mask) {
+      myVerb = verb;
+      myFlags = flags;
+      myMask = mask;
+    }
+
+    public char getVerb() {
+      return myVerb;
+    }
+
+    @NotNull
+    public String getFlags() {
+      return myFlags;
+    }
+
+    public int getMask() {
+      return myMask;
+    }
+
+    @Nullable
+    public static PrintVerb getByVerb(char verb) {
+      for (PrintVerb v : values()) {
+        if (verb == v.getVerb()) return v;
+      }
+      return null;
+    }
+  }
+
+  public static boolean isFormattingFunction(String functionName) {
+    return FORMATTING_FUNCTIONS.containsKey(functionName);
+  }
+
+  public static boolean isPrintingFunction(String functionName) {
+    return PRINTING_FUNCTIONS.contains(functionName);
+  }
+
+  static class Placeholder {
+    private final String placeholder;
+    private final int startPos;
+    private final State state;
+    private final PrintVerb verb;
+    private final List<Integer> arguments;
+    private final String flags;
+
+    enum State {
+      OK,
+      MISSING_VERB_AT_END,
+      ARGUMENT_INDEX_NOT_NUMERIC
+    }
+
+    Placeholder(State state, int startPos, String placeholder, String flags, List<Integer> arguments, PrintVerb verb) {
+      this.placeholder = placeholder;
+      this.startPos = startPos;
+      this.verb = verb;
+      this.state = state;
+      this.arguments = arguments;
+      this.flags = flags;
+    }
+
+    public String getPlaceholder() {
+      return placeholder;
+    }
+
+    public int getPosition() {
+      return arguments.get(arguments.size() - 1);
+    }
+
+    public State getState() {
+      return state;
+    }
+
+    public PrintVerb getVerb() {
+      return verb;
+    }
+
+    public List<Integer> getArguments() {
+      return arguments;
+    }
+
+    public String getFlags() {
+      return flags;
+    }
+
+    public int getStartPos() {
+      return startPos;
+    }
+  }
+
+  @NotNull
+  public static List<Placeholder> parsePrintf(@NotNull String placeholderText) {
+    List<Placeholder> placeholders = new ArrayList<Placeholder>();
+    int argNum = 1;
+    int w;
+    for (int i = 0; i < placeholderText.length(); i += w) {
+      w = 1;
+      if (placeholderText.charAt(i) == '%') {
+        FormatState state = parsePrintfVerb(placeholderText.substring(i), i, argNum);
+        w = state.format.length();
+
+        // We are not interested in %% which prints %
+        if (state.state == Placeholder.State.OK && state.verb == PrintVerb.Percent) {
+          // Special magic case for allowing things like %*% to pass (which are sadly valid expressions)
+          if (state.format.length() == 2) continue;
+        }
+
+        placeholders.add(state.toPlaceholder());
+
+        // We only consider ok states as valid to increase the number of arguments. Should we?
+        if (state.state != Placeholder.State.OK) continue;
+
+        if (!state.indexed) {
+          if (!state.argNums.isEmpty()) {
+            int maxArgNum = Collections.max(state.argNums);
+            if (argNum < maxArgNum) {
+              argNum = maxArgNum;
+            }
+          }
+        }
+        else {
+          argNum = state.argNums.get(state.argNums.size() - 1);
+        }
+        argNum++;
+      }
+    }
+
+    return placeholders;
+  }
+
+  protected static int getPlaceholderPosition(@NotNull GoFunctionOrMethodDeclaration function) {
+    Integer position = FORMATTING_FUNCTIONS.get(StringUtil.toLowerCase(function.getName()));
+    if (position != null) {
+      String importPath = function.getContainingFile().getImportPath(false);
+      if ("fmt".equals(importPath) || "log".equals(importPath) || TESTING_PATH.equals(importPath)) {
+        return position;
+      }
+    }
+    return -1;
+  }
+
+  private static class FormatState {
+    @Nullable private PrintVerb verb;   // the format verb: 'd' for "%d"
+    private String format;              // the full format directive from % through verb, "%.3d"
+    @NotNull private String flags = ""; // the list of # + etc
+    private boolean indexed;            // whether an indexing expression appears: %[1]d
+    private final int startPos;         // index of the first character of the placeholder in the formatting string
+
+    // the successive argument numbers that are consumed, adjusted to refer to actual arg in call
+    private final List<Integer> argNums = new ArrayList<Integer>();
+
+    // Keep track of the parser state
+    private Placeholder.State state;
+
+    // Used only during parse.
+    private int argNum;           // Which argument we're expecting to format now
+    private int nBytes = 1;       // number of bytes of the format string consumed
+
+    FormatState(String format, int startPos, int argNum) {
+      this.format = format;
+      this.startPos = startPos;
+      this.argNum = argNum;
+    }
+
+    @NotNull
+    private Placeholder toPlaceholder() {
+      return new Placeholder(state, startPos, format, flags, argNums, verb);
+    }
+  }
+
+  @NotNull
+  private static FormatState parsePrintfVerb(@NotNull String format, int startPos, int argNum) {
+    FormatState state = new FormatState(format, startPos, argNum);
+
+    parseFlags(state);
+
+    if (!parseIndex(state)) return state;
+
+    // There may be a width
+    if (!parseNum(state)) return state;
+
+    if (!parsePrecision(state)) return state;
+
+    // Now a verb, possibly prefixed by an index (which we may already have)
+    if (!parseIndex(state)) return state;
+
+    if (state.nBytes == format.length()) {
+      state.state = Placeholder.State.MISSING_VERB_AT_END;
+      return state;
+    }
+
+    state.verb = PrintVerb.getByVerb(state.format.charAt(state.nBytes));
+    if (state.verb != null && state.verb != PrintVerb.Percent) state.argNums.add(state.argNum);
+    state.nBytes++;
+    state.format = state.format.substring(0, state.nBytes);
+    state.state = Placeholder.State.OK;
+
+    return state;
+  }
+
+  public static boolean hasPlaceholder(@NotNull String formatString) {
+    return StringUtil.containsChar(formatString, '%');
+  }
+
+  private static void parseFlags(@NotNull FormatState state) {
+    String knownFlags = "#0+- ";
+    StringBuilder flags = new StringBuilder(state.flags);
+    while (state.nBytes < state.format.length()) {
+      if (StringUtil.containsChar(knownFlags, state.format.charAt(state.nBytes))) {
+        flags.append(state.format.charAt(state.nBytes));
+      }
+      else {
+        state.flags = flags.toString();
+        return;
+      }
+      state.nBytes++;
+    }
+    state.flags = flags.toString();
+  }
+
+  private static void scanNum(@NotNull FormatState state) {
+    while (state.nBytes < state.format.length()) {
+      if (!StringUtil.isDecimalDigit(state.format.charAt(state.nBytes))) {
+        return;
+      }
+      state.nBytes++;
+    }
+  }
+
+  private static boolean parseIndex(@NotNull FormatState state) {
+    if (state.nBytes == state.format.length() || state.format.charAt(state.nBytes) != '[') return true;
+
+    state.indexed = true;
+    state.nBytes++;
+    int start = state.nBytes;
+    scanNum(state);
+    if (state.nBytes == state.format.length() || state.nBytes == start || state.format.charAt(state.nBytes) != ']') {
+      state.state = Placeholder.State.ARGUMENT_INDEX_NOT_NUMERIC;
+      return false;
+    }
+
+    int arg;
+    try {
+      arg = Integer.parseInt(state.format.substring(start, state.nBytes));
+    }
+    catch (NumberFormatException ignored) {
+      state.state = Placeholder.State.ARGUMENT_INDEX_NOT_NUMERIC;
+      return false;
+    }
+
+    state.nBytes++;
+    state.argNum = arg;
+
+    return true;
+  }
+
+  private static boolean parseNum(@NotNull FormatState state) {
+    if (state.nBytes < state.format.length() && state.format.charAt(state.nBytes) == '*') {
+      state.nBytes++;
+      state.argNums.add(state.argNum);
+      state.argNum++;
+    }
+    else {
+      scanNum(state);
+    }
+
+    return true;
+  }
+
+  private static boolean parsePrecision(@NotNull FormatState state) {
+    if (state.nBytes < state.format.length() && state.format.charAt(state.nBytes) == '.') {
+      state.flags += '.';
+      state.nBytes++;
+      if (!parseIndex(state)) return false;
+      if (!parseNum(state)) return false;
+    }
+
+    return true;
+  }
+}

--- a/src/com/goide/psi/impl/GoPsiImplUtil.java
+++ b/src/com/goide/psi/impl/GoPsiImplUtil.java
@@ -562,6 +562,10 @@ public class GoPsiImplUtil {
     return stub != null ? stub.isVariadic() : o.getTripleDot() != null;
   }
 
+  public static boolean hasVariadic(@NotNull GoArgumentList argumentList) {
+    return argumentList.getTripleDot() != null;
+  }
+
   @Nullable
   public static GoType getGoTypeInner(@NotNull GoTypeSpec o, @SuppressWarnings("UnusedParameters") @Nullable ResolveState context) {
     return o.getSpecType();

--- a/src/com/goide/psi/impl/GoTypeUtil.java
+++ b/src/com/goide/psi/impl/GoTypeUtil.java
@@ -61,7 +61,9 @@ public class GoTypeUtil {
   private static boolean isBuiltinType(@Nullable GoType type, @Nullable String builtinTypeName) {
     if (builtinTypeName == null) return false;
     type = type != null ? type.getUnderlyingType() : null;
-    return type != null && type.textMatches(builtinTypeName) && GoPsiImplUtil.builtin(type);
+    return type != null &&
+           !(type instanceof GoCType) &&
+           type.textMatches(builtinTypeName) && GoPsiImplUtil.builtin(type);
   }
 
   @NotNull
@@ -118,7 +120,7 @@ public class GoTypeUtil {
     if (statement == null) {
       return Collections.singletonList(getInterfaceIfNull(GoPsiImplUtil.getBuiltinType("bool", exprCaseClause), exprCaseClause));
     }
-    
+
     GoLeftHandExprList leftHandExprList = statement instanceof GoSimpleStatement ? ((GoSimpleStatement)statement).getLeftHandExprList() : null;
     GoExpression expr = leftHandExprList != null ? ContainerUtil.getFirstItem(leftHandExprList.getExpressionList()) : null;
     return Collections.singletonList(getGoType(expr, exprCaseClause));
@@ -237,7 +239,7 @@ public class GoTypeUtil {
       }
       return result;
     }
-    
+
     int position = assignment.getExpressionList().indexOf(expression);
     GoType leftExpression = leftExpressions.size() > position ? leftExpressions.get(position).getGoType(null) : null;
     return Collections.singletonList(getInterfaceIfNull(leftExpression, assignment));
@@ -264,5 +266,9 @@ public class GoTypeUtil {
   @NotNull
   private static GoType getGoType(@Nullable GoTypeOwner element, @NotNull PsiElement context) {
     return getInterfaceIfNull(element != null ? element.getGoType(null) : null, context);
+  }
+
+  public static boolean isFunction(@Nullable GoType goType) {
+    return goType != null && goType.getUnderlyingType() instanceof GoFunctionType;
   }
 }

--- a/testData/highlighting/funcCall.go
+++ b/testData/highlighting/funcCall.go
@@ -78,7 +78,7 @@ func <warning>Test23</warning>() (err error) {
 }
 
 func Demo() error {
-    return fmt.Errorf("err")
+    return fmt.Errorf("err %s", "a")
 }
 
 func <warning>main</warning>() {

--- a/testData/highlighting/methodExpr.go
+++ b/testData/highlighting/methodExpr.go
@@ -31,8 +31,8 @@ func _() {
 	(T).Mv(t, 7)
 	f1 := T.Mv; f1(t, 7)
 	f2 := (T).Mv; f2(t, 7)
-	fmt.Println((*T).Mp)
-	fmt.Println((*T).Mv)
+	fmt.Println((*T).Mp())
+	fmt.Println((*T).Mv())
 }
 
 type Type interface {
@@ -50,5 +50,5 @@ func (t ArrayType) Size() int64 {
 func _(t *Type) {
     at, _ := (*t).(*ArrayType)
     println(at.Type)
-    println(at.Type.Size)
+    println(at.Type.Size())
 }

--- a/testData/highlighting/placeholderCount.go
+++ b/testData/highlighting/placeholderCount.go
@@ -3,6 +3,8 @@ package placeholderCount
 import "fmt"
 import "log"
 import "testing"
+import "unsafe"
+import "C"
 
 const (
 	myFormatConst      = "%d %d %#[1]x %#x %2.f %d %2.2f %.f %.3f %[9]*.[2]*[3]f %d %f %#[1]x %#x %[2]d %v % d"
@@ -107,4 +109,20 @@ func _(t *testing.T) {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
 	)
 	fmt.Sprintf(<warning descr="Got 1 placeholder(s) for 2 arguments(s)">"%d"</warning>, 1, 2)
+
+	fmt.Print(<warning descr="Possible formatting directive in '\"%[2]*.[1]*[3]d\"'">"%[2]*.[1]*[3]d"</warning>, 2, 3, myNonFormatFunc)
+	fmt.Print(<warning descr="Possible formatting directive in '\"%[2]*.[1]*[3]d\"'">"%[2]*.[1]*[3]d"</warning>, 2, 3, printf)
+
+	fmt.Println("demo<warning descr="Function already ends with new line">\n</warning>", 2, 3, <warning descr="Argument 'myNonFormatFunc' is not a function call">myNonFormatFunc</warning>)
+	fmt.Println("demo<warning descr="Function already ends with new line">\n</warning>", 2, 3, <warning descr="Argument 'printf' is not a function call">printf</warning>)
+
+	fmt.Print("demo\n", 2, 3, <warning descr="Argument 'myNonFormatFunc' is not a function call">myNonFormatFunc</warning>)
+	fmt.Print("demo\n", 2, 3, <warning descr="Argument 'printf' is not a function call">printf</warning>)
+
+	type X struct{ Y, Z int32 }
+	a := &X{5, 7}
+	fmt.Println(a, "->", C.sum(*((*C.struct_x)(unsafe.Pointer(a)))))
+
+	fmt.Sprintf("asdadad <warning descr="Unrecognized formatting verb '%O' call">%O</warning> asdadad", "demo")
+	fmt.Printf("%[<warning descr="Index value [0] is not allowed">0</warning>]d", 1)
 }

--- a/testData/highlighting/placeholderCountVet.go
+++ b/testData/highlighting/placeholderCountVet.go
@@ -1,0 +1,356 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file contains tests for the printf checker.
+
+package testdata
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"unsafe" // just for test case printing unsafe.Pointer
+)
+
+func <warning descr="Unused function 'UnsafePointerPrintfTest'">UnsafePointerPrintfTest</warning>() {
+	var up unsafe.Pointer
+	fmt.Printf("%p, %x %X", up, up, up)
+}
+
+// Error methods that do not satisfy the Error interface and should be checked.
+type errorTest1 int
+
+func (errorTest1) Error(...interface{}) string {
+	return "hi"
+}
+
+type errorTest2 int // Analogous to testing's *T type.
+func (errorTest2) Error(...interface{}) {
+}
+
+type errorTest3 int
+
+func (errorTest3) Error() { // No return value.
+}
+
+type errorTest4 int
+
+func (errorTest4) Error() int { // Different return type.
+	return 3
+}
+
+type errorTest5 int
+
+func (errorTest5) error() { // niladic; don't complain if no args (was bug)
+}
+
+// This function never executes, but it serves as a simple test for the program.
+// Test with make test.
+func <warning descr="Unused function 'PrintfTests'">PrintfTests</warning>() {
+	var b bool
+	var i int
+	var r rune
+	var s string
+	var x float64
+	var p *int
+	var imap map[int]int
+	var fslice []float64
+	var c complex64
+	// Some good format/argtypes
+	fmt.Printf(<warning descr="Value used for formatting text does not appear to contain a placeholder">""</warning>)
+	fmt.Printf("%b %b %b", 3, i, x)
+	fmt.Printf("%c %c %c %c", 3, i, 'x', r)
+	fmt.Printf("%d %d %d", 3, i, imap)
+	fmt.Printf("%e %e %e %e", 3e9, x, fslice, c)
+	fmt.Printf("%E %E %E %E", 3e9, x, fslice, c)
+	fmt.Printf("%f %f %f %f", 3e9, x, fslice, c)
+	fmt.Printf("%F %F %F %F", 3e9, x, fslice, c)
+	fmt.Printf("%g %g %g %g", 3e9, x, fslice, c)
+	fmt.Printf("%G %G %G %G", 3e9, x, fslice, c)
+	fmt.Printf("%b %b %b %b", 3e9, x, fslice, c)
+	fmt.Printf("%o %o", 3, i)
+	fmt.Printf("%p %p", p, nil)
+	fmt.Printf("%q %q %q %q", 3, i, 'x', r)
+	fmt.Printf("%s %s %s", "hi", s, []byte{65})
+	fmt.Printf("%t %t", true, b)
+	fmt.Printf("%T %T", 3, i)
+	fmt.Printf("%U %U", 3, i)
+	fmt.Printf("%v %v", 3, i)
+	fmt.Printf("%x %x %x %x", 3, i, "hi", s)
+	fmt.Printf("%X %X %X %X", 3, i, "hi", s)
+	fmt.Printf("%.*s %d %g", 3, "hi", 23, 2.3)
+	fmt.Printf("%s", &stringerv)
+	fmt.Printf("%v", &stringerv)
+	fmt.Printf("%T", &stringerv)
+	fmt.Printf("%v", notstringerv)
+	fmt.Printf("%T", notstringerv)
+	fmt.Printf("%q", stringerarrayv)
+	fmt.Printf("%v", stringerarrayv)
+	fmt.Printf("%s", stringerarrayv)
+	fmt.Printf("%v", notstringerarrayv)
+	fmt.Printf("%T", notstringerarrayv)
+	fmt.Printf("%d", new(Formatter))
+	fmt.Printf("%*%", 2)               // Ridiculous but allowed.
+	fmt.Printf("%s", interface{}(nil)) // Nothing useful we can say.
+
+	fmt.Printf("%g", 1+2i)
+	// Some bad format/argTypes
+	fmt.Printf("%b", "hi")                     // ERROR "arg .hi. for printf verb %b of wrong type"
+	fmt.Printf("%t", c)                        // ERROR "arg c for printf verb %t of wrong type"
+	fmt.Printf("%t", 1+2i)                     // ERROR "arg 1 \+ 2i for printf verb %t of wrong type"
+	fmt.Printf("%c", 2.3)                      // ERROR "arg 2.3 for printf verb %c of wrong type"
+	fmt.Printf("%d", 2.3)                      // ERROR "arg 2.3 for printf verb %d of wrong type"
+	fmt.Printf("%e", "hi")                     // ERROR "arg .hi. for printf verb %e of wrong type"
+	fmt.Printf("%E", true)                     // ERROR "arg true for printf verb %E of wrong type"
+	fmt.Printf("%f", "hi")                     // ERROR "arg .hi. for printf verb %f of wrong type"
+	fmt.Printf("%F", 'x')                      // ERROR "arg 'x' for printf verb %F of wrong type"
+	fmt.Printf("%g", "hi")                     // ERROR "arg .hi. for printf verb %g of wrong type"
+	fmt.Printf("%g", imap)                     // ERROR "arg imap for printf verb %g of wrong type"
+	fmt.Printf("%G", i)                        // ERROR "arg i for printf verb %G of wrong type"
+	fmt.Printf("%o", x)                        // ERROR "arg x for printf verb %o of wrong type"
+	fmt.Printf("%p", 23)                       // ERROR "arg 23 for printf verb %p of wrong type"
+	fmt.Printf("%q", x)                        // ERROR "arg x for printf verb %q of wrong type"
+	fmt.Printf("%s", b)                        // ERROR "arg b for printf verb %s of wrong type"
+	fmt.Printf("%s", byte(65))                 // ERROR "arg byte\(65\) for printf verb %s of wrong type"
+	fmt.Printf("%t", 23)                       // ERROR "arg 23 for printf verb %t of wrong type"
+	fmt.Printf("%U", x)                        // ERROR "arg x for printf verb %U of wrong type"
+	fmt.Printf("%x", nil)                      // ERROR "arg nil for printf verb %x of wrong type"
+	fmt.Printf("%X", 2.3)                      // ERROR "arg 2.3 for printf verb %X of wrong type"
+	fmt.Printf("%s", stringerv)                // ERROR "arg stringerv for printf verb %s of wrong type"
+	fmt.Printf("%t", stringerv)                // ERROR "arg stringerv for printf verb %t of wrong type"
+	fmt.Printf("%q", notstringerv)             // ERROR "arg notstringerv for printf verb %q of wrong type"
+	fmt.Printf("%t", notstringerv)             // ERROR "arg notstringerv for printf verb %t of wrong type"
+	fmt.Printf("%t", stringerarrayv)           // ERROR "arg stringerarrayv for printf verb %t of wrong type"
+	fmt.Printf("%t", notstringerarrayv)        // ERROR "arg notstringerarrayv for printf verb %t of wrong type"
+	fmt.Printf("%q", notstringerarrayv)        // ERROR "arg notstringerarrayv for printf verb %q of wrong type"
+	fmt.Printf("%d", Formatter(true))          // correct (the type is responsible for formatting)
+	fmt.Printf("%s", nonemptyinterface)        // correct (the dynamic type of nonemptyinterface may be a stringer)
+	fmt.Printf("%.*s %d %g", 3, "hi", 23, 'x') // ERROR "arg 'x' for printf verb %g of wrong type"
+	fmt.Println()                              // not an error
+	fmt.Println(<warning descr="Possible formatting directive in '\"%s\"'">"%s"</warning>, "hi")                    // ERROR "possible formatting directive in Println call"
+	fmt.Printf(<warning descr="Got 1 placeholder(s) for 2 arguments(s)">"%s"</warning>, "hi", 3)                  // ERROR "wrong number of args for format in Printf call"
+	_ = fmt.Sprintf("%"+("s"), "hi", 3)        // ERROR "wrong number of args for format in Sprintf call"
+	fmt.Printf("%s%%%d", "hi", 3)              // correct
+	fmt.Printf("%08s", "woo")                  // correct
+	fmt.Printf("% 8s", "woo")                  // correct
+	fmt.Printf("%.*d", 3, 3)                   // correct
+	fmt.Printf(<warning descr="Got 2 placeholder(s) for 4 arguments(s)">"%.*d"</warning>, 3, 3, 3, 3)             // ERROR "wrong number of args for format in Printf call.*4 args"
+	fmt.Printf("%.*d", "hi", 3)                // ERROR "arg .hi. for \* in printf format not of type int"
+	fmt.Printf("%.*d", i, 3)                   // correct
+	fmt.Printf("%.*d", s, 3)                   // ERROR "arg s for \* in printf format not of type int"
+	fmt.Printf("%*%", 0.22)                    // ERROR "arg 0.22 for \* in printf format not of type int"
+	fmt.Printf("%q %q", multi()...)            // ok
+	fmt.Printf("%#q", `blah`)                  // ok
+	printf("now is the time", "buddy")         // ERROR "no formatting directive"
+	Printf("now is the time", "buddy")         // ERROR "no formatting directive"
+	Printf("hi")                               // ok
+	const format = "%s %s\n"
+	Printf(format, "hi", "there")
+	Printf(format, "hi")              // ERROR "missing argument for Printf..%s..: format reads arg 2, have only 1"
+	Printf("%s %d %.3v %q", "str", 4) // ERROR "missing argument for Printf..%.3v..: format reads arg 3, have only 2"
+	f := new(stringer)
+	f.Warn(0, "%s", "hello", 3)  // ERROR "possible formatting directive in Warn call"
+	f.Warnf(0, "%s", "hello", 3) // ERROR "wrong number of args for format in Warnf call"
+	f.Warnf(0, "%r", "hello")    // ERROR "unrecognized printf verb"
+	f.Warnf(0, "%#s", "hello")   // ERROR "unrecognized printf flag"
+	Printf("d%", 2)              // ERROR "missing verb at end of format string in Printf call"
+	Printf("%d", percentDV)
+	Printf("%d", &percentDV)
+	Printf("%d", notPercentDV)  // ERROR "arg notPercentDV for printf verb %d of wrong type"
+	Printf("%d", &notPercentDV) // ERROR "arg &notPercentDV for printf verb %d of wrong type"
+	Printf("%p", &notPercentDV) // Works regardless: we print it as a pointer.
+	Printf("%s", percentSV)
+	Printf("%s", &percentSV)
+	// Good argument reorderings.
+	Printf("%[1]d", 3)
+	Printf("%[1]*d", 3, 1)
+	Printf("%[2]*[1]d", 1, 3)
+	Printf("%[2]*.[1]*[3]d", 2, 3, 4)
+	fmt.Fprintf(os.Stderr, "%[2]*.[1]*[3]d", 2, 3, 4) // Use Fprintf to make sure we count arguments correctly.
+	// Bad argument reorderings.
+	Printf("%[xd", 3)                    // ERROR "illegal syntax for printf argument index"
+	Printf("%[x]d", 3)                   // ERROR "illegal syntax for printf argument index"
+	Printf("%[3]*s", "hi", 2)            // ERROR "missing argument for Printf.* reads arg 3, have only 2"
+	_ = fmt.Sprintf(<warning descr="Got 3 placeholder(s) for 1 arguments(s)">"%[3]d"</warning>, 2)          // ERROR "missing argument for Sprintf.* reads arg 3, have only 1"
+	Printf("%[2]*.[1]*[3]d", 2, "hi", 4) // ERROR "arg .hi. for \* in printf format not of type int"
+	Printf("%[0]s", "arg1")              // ERROR "index value \[0\] for Printf.*; indexes start at 1"
+	Printf("%[0]d", 1)                   // ERROR "index value \[0\] for Printf.*; indexes start at 1"
+	// Something that satisfies the error interface.
+	var e error
+	fmt.Println(e.Error()) // ok
+	// Something that looks like an error interface but isn't, such as the (*T).Error method
+	// in the testing package.
+	var et1 errorTest1
+	fmt.Println(et1.Error())        // ERROR "no args in Error call"
+	fmt.Println(et1.Error("hi"))    // ok
+	fmt.Println(et1.Error(<warning descr="Possible formatting directive in '\"%d\"'">"%d"</warning>, 3)) // ERROR "possible formatting directive in Error call"
+	var et2 errorTest2
+	et2.Error()        // ERROR "no args in Error call"
+	et2.Error("hi")    // ok, not an error method.
+	et2.Error(<warning descr="Possible formatting directive in '\"%d\"'">"%d"</warning>, 3) // ERROR "possible formatting directive in Error call"
+	var et3 errorTest3
+	et3.Error() // ok, not an error method.
+	var et4 errorTest4
+	et4.Error() // ok, not an error method.
+	var et5 errorTest5
+	et5.error() // ok, not an error method.
+	// Can't print a function.
+	Printf("%d", someFunction) // ERROR "arg someFunction in printf call is a function value, not a function call"
+	Printf("%v", someFunction) // ERROR "arg someFunction in printf call is a function value, not a function call"
+	Println(<warning descr="Argument 'someFunction' is not a function call">someFunction</warning>)      // ERROR "arg someFunction in Println call is a function value, not a function call"
+	Printf("%p", someFunction) // ok: maybe someone wants to see the pointer
+	Printf("%T", someFunction) // ok: maybe someone wants to see the type
+	// Bug: used to recur forever.
+	Printf("%p %x", recursiveStructV, recursiveStructV.next)
+	Printf("%p %x", recursiveStruct1V, recursiveStruct1V.next)
+	Printf("%p %x", recursiveSliceV, recursiveSliceV)
+	Printf("%p %x", recursiveMapV, recursiveMapV)
+	// Special handling for Log.
+	math.<error descr="Unresolved reference 'Log'">Log</error>(3)  // OK
+	<error descr="Unresolved reference 'Log'">Log</error>(3)       // OK
+	<error descr="Unresolved reference 'Log'">Log</error>("%d", 3) // ERROR "possible formatting directive in Log call"
+	<error descr="Unresolved reference 'Logf'">Logf</error>("%d", 3)
+	<error descr="Unresolved reference 'Logf'">Logf</error>("%d", "hi") // ERROR "arg .hi. for printf verb %d of wrong type: untyped string"
+
+}
+
+// A function we use as a function value; it has no other purpose.
+func someFunction() {
+}
+
+func Println(<warning descr="Unused parameter 'args'">args</warning> ...interface{}) {
+	panic("don't call - testing only")
+}
+
+// Printf is used by the test so we must declare it.
+func Printf(<warning descr="Unused parameter 'format'">format</warning> string, <warning descr="Unused parameter 'args'">args</warning> ...interface{}) {
+	panic("don't call - testing only")
+}
+
+// printf is used by the test so we must declare it.
+func printf(<warning descr="Unused parameter 'format'">format</warning> string, <warning descr="Unused parameter 'args'">args</warning> ...interface{}) {
+	panic("don't call - testing only")
+}
+
+// multi is used by the test.
+func multi() []interface{} {
+	panic("don't call - testing only")
+}
+
+type stringer float64
+
+var stringerv stringer
+
+func (*stringer) String() string {
+	return "string"
+}
+
+func (*stringer) Warn(int, ...interface{}) string {
+	return "warn"
+}
+
+func (*stringer) Warnf(int, string, ...interface{}) string {
+	return "warnf"
+}
+
+type notstringer struct {
+	f float64
+}
+
+var notstringerv notstringer
+
+type stringerarray [4]float64
+
+func (stringerarray) String() string {
+	return "string"
+}
+
+var stringerarrayv stringerarray
+
+type notstringerarray [4]float64
+
+var notstringerarrayv notstringerarray
+
+var nonemptyinterface = interface {
+	f()
+}(nil)
+
+// A data type we can print with "%d".
+type percentDStruct struct {
+	a int
+	b []byte
+	c *float64
+}
+
+var percentDV percentDStruct
+
+// A data type we cannot print correctly with "%d".
+type notPercentDStruct struct {
+	a int
+	b []byte
+	c bool
+}
+
+var notPercentDV notPercentDStruct
+
+// A data type we can print with "%s".
+type percentSStruct struct {
+	a string
+	b []byte
+	c stringerarray
+}
+
+var percentSV percentSStruct
+
+type recursiveStringer int
+
+func (s recursiveStringer) String() string {
+	_ = fmt.Sprintf("%d", s)
+	_ = fmt.Sprintf("%#v", s)
+	_ = fmt.Sprintf("%v", s)  // ERROR "arg s for printf causes recursive call to String method"
+	_ = fmt.Sprintf("%v", &s) // ERROR "arg &s for printf causes recursive call to String method"
+	_ = fmt.Sprintf("%T", s)  // ok; does not recursively call String
+	return fmt.Sprintln(s)    // ERROR "arg s in Sprintln call causes recursive call to String method"
+}
+
+type recursivePtrStringer int
+
+func (p *recursivePtrStringer) String() string {
+	_ = fmt.Sprintf("%v", *p)
+	return fmt.Sprintln(p) // ERROR "arg p in Sprintln call causes recursive call to String method"
+}
+
+type Formatter bool
+
+func (*Formatter) Format(fmt.State, rune) {
+}
+
+type RecursiveSlice []RecursiveSlice
+
+var recursiveSliceV = &RecursiveSlice{}
+
+type RecursiveMap map[int]RecursiveMap
+
+var recursiveMapV = make(RecursiveMap)
+
+type RecursiveStruct struct {
+	next *RecursiveStruct
+}
+
+var recursiveStructV = &RecursiveStruct{}
+
+type RecursiveStruct1 struct {
+	next *<error descr="Unresolved type 'Recursive2Struct'">Recursive2Struct</error>
+}
+
+type RecursiveStruct2 struct {
+	next *<error descr="Unresolved type 'Recursive1Struct'">Recursive1Struct</error>
+}
+
+var recursiveStruct1V = &RecursiveStruct1{}
+
+// Fix for issue 7149: Missing return type on String method caused fault.
+func (int) String() {
+	return ""
+}

--- a/testData/highlighting/struct.go
+++ b/testData/highlighting/struct.go
@@ -58,7 +58,6 @@ func main() {
 
     c := Car{4}
     Println("A Car has this many wheels:", c.wheelCount)
-    Println("A Car has this many wheels:", c.numberOfWheels)
     Println("A Car has this many wheels:", c.numberOfWheels())
 
     a := AstonMartin{Car{4}}

--- a/testData/highlighting/varBlocks.go
+++ b/testData/highlighting/varBlocks.go
@@ -3,8 +3,8 @@ package main
 import "fmt"
 
 func main() {
-    fmt.Println(test())
-    fmt.Println(test2())
+    fmt.Println(<warning descr="Final return type of 'test()' is a function not a function call">test()</warning>)
+    fmt.Println(<warning descr="Final return type of 'test2()' is a function not a function call">test2()</warning>)
     test3()
     test4()
     test5()

--- a/testData/highlighting/vars.go
+++ b/testData/highlighting/vars.go
@@ -72,8 +72,8 @@ var (
 
 func TestIdeaTimeApi() {
 	interval1.Nanoseconds()
-	fmt.Println("%T %T", interval1, interval2)
-	fmt.Println("%d %d", interval1.Nanoseconds(), interval2.Nanoseconds())
+	fmt.Printf("%T %T", interval1, interval2)
+	fmt.Printf("%d %d", interval1.Nanoseconds(), interval2.Nanoseconds())
 }
 
 func _() {

--- a/tests/com/goide/inspections/GoHighlightingTest.java
+++ b/tests/com/goide/inspections/GoHighlightingTest.java
@@ -144,6 +144,7 @@ public class GoHighlightingTest extends GoCodeInsightFixtureTestCase {
   public void testCyclicDefinition()          { doTest(); }
   public void testEmbeddedInterfacePointer()  { doTest(); }
   public void testPlaceholderCount()          { doTest(); }
+  public void testPlaceholderCountVet()       { doTest(); }
   public void testTypeConversion()            { doTest(); }
   public void testInit()                      { doTest(); }
   public void testMainWithWrongSignature()    { doTest(); }


### PR DESCRIPTION
This matches the inspection with what `go vet` does. The problem is that `go vet` currently doesn't match the language specs / what the Go compiler does, thus the failing tests.
I'll work into getting this back in working order without changing the tests as the error is in the inspection logic not the test code.