### PR TITLE
Don't load AST in toString

### DIFF
--- a/src/com/goide/psi/impl/GoStubbedElementImpl.java
+++ b/src/com/goide/psi/impl/GoStubbedElementImpl.java
@@ -45,7 +45,7 @@ public abstract class GoStubbedElementImpl<T extends StubBase<?>> extends StubBa
 
   @Override
   public String toString() {
-    return getNode().getElementType().toString();
+    return getElementType().toString();
   }
 
   @Nullable


### PR DESCRIPTION
Somehow this `toString` can end up being called by Swing when trying to do GoTo symbol: [stacktrace]

[stacktrace]: https://gist.github.com/matklad/95835f52a50e1e3b9bab0936e925a76e