### PR TITLE
Add receiver names inspection (don't use generics names: me, this, self) (fixes #2158)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -246,6 +246,9 @@
     <localInspection language="go" displayName="Struct initialization without field names" groupPath="Go"
                      groupName="Code style issues" enabledByDefault="false" level="WEAK WARNING"
                      implementationClass="com.goide.inspections.GoStructInitializationInspection"/>
+    <localInspection language="go" displayName="Receiver has generic name" groupPath="Go"
+                     groupName="Code style issues" enabledByDefault="true" level="WEAK WARNING"
+                     implementationClass="com.goide.inspections.GoReceiverNamesInspection"/>
     <!-- /code style issues -->
 
     <!-- probable bugs -->

--- a/resources/inspectionDescriptions/GoReceiverNames.html
+++ b/resources/inspectionDescriptions/GoReceiverNames.html
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+<body>
+Inspection checks that names like me, this, self don't used in receiver names.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/com/goide/inspections/GoReceiverNamesInspection.java
+++ b/src/com/goide/inspections/GoReceiverNamesInspection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.psi.GoReceiver;
+import com.goide.psi.GoVisitor;
+import com.goide.quickfix.GoRenameQuickFix;
+import com.intellij.codeInspection.LocalInspectionToolSession;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+
+public class GoReceiverNamesInspection extends GoInspectionBase {
+  private static String[] genericNames = {"me", "this", "self"};
+  private static HashSet<String> genericNamesSet = ContainerUtil.newHashSet(genericNames);
+
+  @NotNull
+  @Override
+  protected GoVisitor buildGoVisitor(@NotNull final ProblemsHolder holder, @NotNull LocalInspectionToolSession session) {
+    return new GoVisitor() {
+      @Override
+      public void visitReceiver(@NotNull GoReceiver o) {
+        if (genericNamesSet.contains(o.getName())) {
+          PsiElement identifier = o.getIdentifier();
+          if (identifier == null) return;
+          holder.registerProblem(identifier, "Receiver has generic name", new GoRenameQuickFix(o));
+        }
+      }
+    };
+  }
+}

--- a/tests/com/goide/inspections/GoReceiverNamesInspectionTest.java
+++ b/tests/com/goide/inspections/GoReceiverNamesInspectionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2016 Sergey Ignatov, Alexander Zolotov, Florin Patan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.goide.inspections;
+
+import com.goide.GoCodeInsightFixtureTestCase;
+
+public class GoReceiverNamesInspectionTest extends GoCodeInsightFixtureTestCase {
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    myFixture.enableInspections(GoReceiverNamesInspection.class);
+  }
+
+  public void testThis() {
+    doTest("func (<weak_warning descr=\"Receiver has generic name\">this<caret></weak_warning> MyType) asd() {}");
+  }
+
+
+  public void testNoFix() {
+    doTest("func (myType<caret> MyType) asd() {}");
+  }
+
+
+  private void doTest(String code) {
+    myFixture.configureByText("a.go", "package main; type MyType int; " + code);
+    myFixture.checkHighlighting();
+  }
+}


### PR DESCRIPTION
Fixes #2158