### PR TITLE
Make resolve cache more efficient

### DIFF
--- a/src/com/goide/psi/impl/GoCachedReference.java
+++ b/src/com/goide/psi/impl/GoCachedReference.java
@@ -31,6 +31,19 @@ public abstract class GoCachedReference<T extends PsiElement> extends PsiReferen
     super(element, TextRange.from(0, element.getTextLength()));
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GoCachedReference)) return false;
+    GoCachedReference other = (GoCachedReference)o;
+    return getElement() == other.getElement();
+  }
+
+  @Override
+  public int hashCode() {
+    return getElement().hashCode();
+  }
+
   private static final ResolveCache.AbstractResolver<PsiReferenceBase, PsiElement> MY_RESOLVER =
     new ResolveCache.AbstractResolver<PsiReferenceBase, PsiElement>() {
       @Override

--- a/src/com/goide/psi/impl/GoReference.java
+++ b/src/com/goide/psi/impl/GoReference.java
@@ -60,6 +60,19 @@ public class GoReference extends PsiPolyVariantReferenceBase<GoReferenceExpressi
     super(o, TextRange.from(o.getIdentifier().getStartOffsetInParent(), o.getIdentifier().getTextLength()));
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GoReference)) return false;
+    GoReference other = (GoReference)o;
+    return getElement() == other.getElement();
+  }
+
+  @Override
+  public int hashCode() {
+    return getElement().hashCode();
+  }
+
   @Nullable
   static PsiFile getContextFile(@NotNull ResolveState state) {
     PsiElement element = getContextElement(state);


### PR DESCRIPTION
Hi! I've finally looked into equals/hashCode/ResolveCache issue. To recap:

* `ResoveCache` uses reference as a key in a hash map cache.
* `PsiElement.getReference()` always returns a fresh instance of the reference.
* `equals` / `hashCode` are **not** overridden in the base reference class.

All this together means that despite using `ResolveCache` sometimes the same resolve work is done several times, which potentially hurts performance. 

To fix this issue, I've overridden equality contract in base reference classes such that two references are considered equal if they share the same underlying element. The same [pattern] is used in IntelliJ IDEA.

I have not tested the performance thoroughly, but on my machine for [highlighting/simple.go] I've got highlighting time improvement from about **2500 ms** without equals to about **2000 ms** with equals, as measured by 

```Java
long elapsed = myFixture.testHighlighting(true, false, false, getTestName(true) + ".go");
System.out.println(elapsed);
```

There is a huge caveat though :) These [two tests] about import optimizer fail now. Looks like the problem is with [IMPORT_USERS], which is installed during resolve and is cleared during highlighting, so it naturally depends on the resolve not being cached. I don't know how this should be fixed, if it should be fixed at all.

Hope this analysis is helpful :)

[pattern]: https://github.com/JetBrains/intellij-community/blob/f06540e18d6a5c2eba6c15696795608db1ed260e/java/java-psi-impl/src/com/intellij/psi/impl/source/tree/java/PsiNewExpressionImpl.java#L200-L208

[highlighting/simple.go]: https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/master/testData/highlighting/simple.go

[two tests]: https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/23630962081c1bdeac4e0a7e6a08f3d935d0bf3c/tests/com/goide/codeInsight/imports/GoImportOptimizerTest.java#L35-L36

[IMPORT_USERS]: https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/23630962081c1bdeac4e0a7e6a08f3d935d0bf3c/src/com/goide/psi/impl/GoReference.java#L45