### PR TITLE
Fix underscore used as name inspections (#fixes 2716)

### DIFF
--- a/src/com/goide/inspections/GoImportUsedAsNameInspection.java
+++ b/src/com/goide/inspections/GoImportUsedAsNameInspection.java
@@ -60,7 +60,9 @@ public class GoImportUsedAsNameInspection extends GoInspectionBase {
 
   private static void check(@NotNull GoNamedElement element, @NotNull ProblemsHolder holder) {
     String name = element.getName();
-    if (name != null && element.getContainingFile().getImportMap().containsKey(name)) {
+    if (StringUtil.isNotEmpty(name) &&
+        !"_".equals(name) &&
+        element.getContainingFile().getImportMap().containsKey(name)) {
       registerProblem(holder, element);
     }
   }

--- a/src/com/goide/inspections/GoRedeclareImportAsFunctionInspection.java
+++ b/src/com/goide/inspections/GoRedeclareImportAsFunctionInspection.java
@@ -32,7 +32,9 @@ public class GoRedeclareImportAsFunctionInspection extends GoInspectionBase {
       @Override
       public void visitFunctionDeclaration(@NotNull GoFunctionDeclaration o) {
         String functionName = o.getName();
-        if (StringUtil.isNotEmpty(functionName) && o.getContainingFile().getImportMap().containsKey(functionName)) {
+        if (StringUtil.isNotEmpty(functionName) &&
+            !"_".equals(functionName) &&
+            o.getContainingFile().getImportMap().containsKey(functionName)) {
           holder.registerProblem(o.getIdentifier(), "import \"" + functionName + "\" redeclared in this block", new GoRenameQuickFix(o));
         }
       }

--- a/testData/highlighting/importUsedAsName.go
+++ b/testData/highlighting/importUsedAsName.go
@@ -1,6 +1,7 @@
 package demo
 
 import "fmt"
+import _ "fmt"
 import iio "io"
 
 func _() {
@@ -9,8 +10,14 @@ func _() {
 	 _, _ = iio.EOF, demo
 }
 
+func demo() (int, int) {
+	return 1, 2
+}
+
 func _() {
 	<warning descr="Variable 'fmt' collides with imported package name">fmt</warning> := "demo"
 	<warning descr="Variable 'iio' collides with imported package name">iio</warning> := 1
 	_, _ = iio, fmt
+	a, _ := demo()
+	_ = a
 }


### PR DESCRIPTION
The inspections should probably be unified? Or it's better to keep them separate so that they can be disabled independently?