### PR TITLE
Improve receiver assignment inspection (fixes #2719)

### DIFF
--- a/testData/highlighting/assignmentToReceiver.go
+++ b/testData/highlighting/assignmentToReceiver.go
@@ -36,3 +36,25 @@ func _() {
 	d.change3()
 	d.myVal()
 }
+
+type Flags chan string
+
+func (f Flags) Add(flag string) {
+	f <- flag
+}
+
+type Flagz []string
+
+func (f *Flagz) Add(flag string) {
+	*f = append(*f, flag)
+}
+
+func (f *Flagz) Clear() {
+	<weak_warning descr="Assignment to method receiver propagates only to callees but not to callers">f</weak_warning> = nil
+}
+
+type Flagm map[string]string
+
+func (f Flagm) Add(flag string) {
+	f = make(map[string]string)
+}


### PR DESCRIPTION
Currently the only annoyance this produces is when the receiver is not returned from the method.

For example:

``` go
type Flagz []string

func (f Flagz) Add(flag string) Flagz {
    f = append(f, flag) // still a warning, shouldn't be
    return f
}
```

Short from walking the PSI tree and checking if the receiver is returned, how could this be done? Or should we disable this by default?

I've also moved the inspection from ReferenceExpression to Assignment in hopes this will be faster to use.
