### PR TITLE
Update SDK in External Libraries tree

### DIFF
--- a/src/com/goide/GoModuleBuilder.java
+++ b/src/com/goide/GoModuleBuilder.java
@@ -21,11 +21,13 @@ import com.intellij.compiler.CompilerWorkspaceConfiguration;
 import com.intellij.ide.util.projectWizard.JavaModuleBuilder;
 import com.intellij.ide.util.projectWizard.ModuleBuilderListener;
 import com.intellij.ide.util.projectWizard.SourcePathsBuilder;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.projectRoots.SdkTypeId;
 import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
 import org.jetbrains.annotations.NotNull;
@@ -58,5 +60,8 @@ public class GoModuleBuilder extends JavaModuleBuilder implements SourcePathsBui
   @Override
   public void moduleCreated(@NotNull Module module) {
     CompilerWorkspaceConfiguration.getInstance(module.getProject()).CLEAR_OUTPUT_DIRECTORY = false;
+    ModifiableRootModel rootModel = ModuleRootManager.getInstance(module).getModifiableModel();
+    rootModel.inheritSdk();
+    ApplicationManager.getApplication().runWriteAction(rootModel::commit);
   }
 }


### PR DESCRIPTION
Fixes #2861.

When a Go project is created by the plugin, the project SDK is fixed in iml file e.g.
`<orderEntry type="jdk" jdkName="Go 1.3.3" jdkType="Go SDK" />`.

But if we can change this line to `<orderEntry type="inheritedJdk" />` in iml file, the SDK in `External Libraries` tree can be synchronized as we change project SDK in `Project Structure` panel. Got this trick from [intellij-erlang](https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/rebar/importWizard/RebarProjectImportBuilder.java#L235) 😄 

![screenshot](https://cloud.githubusercontent.com/assets/6234553/22007059/efa45ede-dcaa-11e6-828b-1bed26713e56.gif)

